### PR TITLE
Replace Stop prompt hook with background command + claude CLI summarizer

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/session-save.sh\"",
-            "timeout": 10
+            "timeout": 60
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,15 +1,15 @@
 {
   "hooks": {
     "Stop": [
-    {
-      "hooks": [
-        {
-          "type": "prompt",
-          "prompt": "You are the Obsidian auto-save hook. A Claude Code session has just ended.\n\nRead the session config from: ${CLAUDE_PLUGIN_ROOT}/obsidian.local.md\nUse the vault_path from that config file (do NOT hardcode a path).\n\nAuto-save logic:\n1. Scan the conversation for significance: was code written? Were decisions made? Was debugging resolved? Were long explanations given? Were commands run?\n2. If the conversation was trivial (e.g. just a few messages, no meaningful output), skip saving.\n3. Check for #bookmark markers in the conversation — each becomes a separate note.\n4. Check for time gaps >30 min between messages — each segment becomes a separate note.\n5. For each segment/chapter to save:\n   a. Detect domain from keywords (see routing rules in config)\n   b. Generate title: YYYY-MM-DD-topic-slug\n   c. Format as structured markdown with frontmatter, summary, key findings, details\n   d. Write to correct vault folder using Write tool\n   e. Append a link to today's daily note: ## Session Links section\n6. Do NOT open notes in GUI (session is ending — user may have closed window).\n7. If nothing worth saving: skip silently.\n\nRouting rules are defined in obsidian.local.md. Read them from there.",
-          "timeout": 120
-        }
-      ]
-    }
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/session-save.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
     ],
     "PostToolUse": [
       {

--- a/scripts/session-save.sh
+++ b/scripts/session-save.sh
@@ -18,8 +18,7 @@ if [ -z "$VAULT_PATH" ] || [ ! -d "$VAULT_PATH" ]; then
   exit 0
 fi
 
-TIMESTAMP=$(date '+%s')
-TMPFILE="${TMPDIR:-/tmp}/obsidian-session-${TIMESTAMP}-$$.json"
+TMPFILE="$(mktemp "${TMPDIR:-/tmp}/obsidian-session-XXXXXX.json")"
 
 cat > "$TMPFILE"
 

--- a/scripts/session-save.sh
+++ b/scripts/session-save.sh
@@ -19,7 +19,7 @@ if [ -z "$VAULT_PATH" ] || [ ! -d "$VAULT_PATH" ]; then
 fi
 
 TIMESTAMP=$(date '+%s')
-TMPFILE="${TMPDIR:-/tmp}/obsidian-session-${TIMESTAMP}.json"
+TMPFILE="${TMPDIR:-/tmp}/obsidian-session-${TIMESTAMP}-$$.json"
 
 cat > "$TMPFILE"
 

--- a/scripts/session-save.sh
+++ b/scripts/session-save.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# session-save.sh
+# Stop command hook. Saves the conversation transcript to a temp file
+# and spawns session-summarize.sh in the background. Exits immediately.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+CONFIG_FILE="${PLUGIN_ROOT}/obsidian.local.md"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  exit 0
+fi
+
+VAULT_PATH=$(grep '^vault_path:' "$CONFIG_FILE" | head -1 | sed 's/^vault_path:[[:space:]]*//')
+if [ -z "$VAULT_PATH" ] || [ ! -d "$VAULT_PATH" ]; then
+  exit 0
+fi
+
+TIMESTAMP=$(date '+%s')
+TMPFILE="${TMPDIR:-/tmp}/obsidian-session-${TIMESTAMP}.json"
+
+cat > "$TMPFILE"
+
+FILE_SIZE=$(wc -c < "$TMPFILE" | tr -d ' ')
+if [ "$FILE_SIZE" -lt 200 ]; then
+  rm -f "$TMPFILE"
+  exit 0
+fi
+
+nohup bash "${SCRIPT_DIR}/session-summarize.sh" "$TMPFILE" "$CONFIG_FILE" "$VAULT_PATH" &>/dev/null &
+
+exit 0

--- a/scripts/session-summarize.sh
+++ b/scripts/session-summarize.sh
@@ -26,8 +26,8 @@ fi
 TODAY=$(date '+%Y-%m-%d')
 DAILY_NOTE="${VAULT_PATH}/Daily/${TODAY}.md"
 
-ROUTING_RULES=$(sed -n '/^## Routing Rules/,/^##/p' "$CONFIG_FILE" | head -20)
-TAXONOMY=$(sed -n '/^## Project Taxonomy/,/^##/p' "$CONFIG_FILE" | head -20)
+ROUTING_RULES=$(awk '/^## Routing Rules/ { in_section=1; next } /^## / && in_section { exit } in_section { print }' "$CONFIG_FILE" | head -20)
+TAXONOMY=$(awk '/^## Project Taxonomy/ { in_section=1; next } /^## / && in_section { exit } in_section { print }' "$CONFIG_FILE" | head -20)
 
 PROMPT=$(cat <<'PROMPT_EOF'
 You are a session-to-Obsidian note converter. You receive a Claude Code conversation transcript (JSON).
@@ -119,6 +119,8 @@ TITLE=$(printf '%s\n' "$RESULT" | grep '^# ' | head -1 | sed 's/^# //')
 : "${TITLE:=$SLUG}"
 
 LINK_LINE="- [[${RELATIVE_NOTE_PATH}|${TITLE}]]"
+
+mkdir -p "$(dirname "$DAILY_NOTE")"
 
 if [ ! -f "$DAILY_NOTE" ]; then
   cat > "$DAILY_NOTE" <<DAILY_EOF

--- a/scripts/session-summarize.sh
+++ b/scripts/session-summarize.sh
@@ -75,28 +75,47 @@ PROMPT="${PROMPT/TAXONOMY_PLACEHOLDER/$TAXONOMY}"
 
 RESULT=$(claude --print --bare --system-prompt "$PROMPT" --max-budget-usd 0.10 < "$TMPFILE" 2>/dev/null) || exit 1
 
-if [ -z "$RESULT" ] || [ "$RESULT" = "SKIP" ]; then
+TRIMMED=$(printf '%s' "$RESULT" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+if [ -z "$TRIMMED" ] || [ "$TRIMMED" = "SKIP" ]; then
   exit 0
 fi
 
-VAULT_FOLDER=$(echo "$RESULT" | grep '^vault_folder:' | head -1 | sed 's/^vault_folder:[[:space:]]*//')
-SLUG=$(echo "$RESULT" | grep '^slug:' | head -1 | sed 's/^slug:[[:space:]]*//')
+VAULT_FOLDER=$(printf '%s\n' "$RESULT" | grep '^vault_folder:' | head -1 | sed 's/^vault_folder:[[:space:]]*//')
+SLUG=$(printf '%s\n' "$RESULT" | grep '^slug:' | head -1 | sed 's/^slug:[[:space:]]*//')
 
 : "${VAULT_FOLDER:=Inbox/}"
 : "${SLUG:=session-note}"
 
+# Sanitize: strip path traversal, restrict slug to safe characters
+VAULT_FOLDER=$(printf '%s' "$VAULT_FOLDER" | sed 's|\.\./||g; s|^\./||; s|^/||')
+SLUG=$(printf '%s' "$SLUG" | sed 's/[^a-z0-9-]//g')
+: "${SLUG:=session-note}"
+
+# Ensure trailing slash on vault_folder
+case "$VAULT_FOLDER" in
+  */) ;;
+  *)  VAULT_FOLDER="${VAULT_FOLDER}/" ;;
+esac
+
 NOTE_DIR="${VAULT_PATH}/${VAULT_FOLDER}"
+
+# Resolve and verify the target stays inside the vault
+RESOLVED_VAULT=$(cd "$VAULT_PATH" && pwd -P)
 mkdir -p "$NOTE_DIR"
+RESOLVED_DIR=$(cd "$NOTE_DIR" && pwd -P)
+case "$RESOLVED_DIR" in
+  "${RESOLVED_VAULT}"*) ;;
+  *) exit 1 ;;
+esac
 
 NOTE_FILENAME="${TODAY}-${SLUG}.md"
 NOTE_PATH="${NOTE_DIR}/${NOTE_FILENAME}"
 
-# Strip the frontmatter vault_folder and slug lines (internal-only metadata)
-CLEAN_RESULT=$(echo "$RESULT" | sed '/^vault_folder:/d; /^slug:/d')
+CLEAN_RESULT=$(printf '%s\n' "$RESULT" | sed '/^vault_folder:/d; /^slug:/d')
 printf '%s\n' "$CLEAN_RESULT" > "$NOTE_PATH"
 
 RELATIVE_NOTE_PATH="${VAULT_FOLDER}${NOTE_FILENAME%.md}"
-TITLE=$(echo "$RESULT" | grep '^# ' | head -1 | sed 's/^# //')
+TITLE=$(printf '%s\n' "$RESULT" | grep '^# ' | head -1 | sed 's/^# //')
 : "${TITLE:=$SLUG}"
 
 LINK_LINE="- [[${RELATIVE_NOTE_PATH}|${TITLE}]]"

--- a/scripts/session-summarize.sh
+++ b/scripts/session-summarize.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# session-summarize.sh
+# Background process spawned by session-save.sh.
+# Pipes the conversation transcript through `claude --print` for summarization,
+# then writes the result to the Obsidian vault and updates the daily note.
+
+set -uo pipefail
+
+TMPFILE="$1"
+CONFIG_FILE="$2"
+VAULT_PATH="$3"
+
+if [ ! -f "$TMPFILE" ]; then
+  exit 1
+fi
+
+cleanup() {
+  rm -f "$TMPFILE"
+}
+trap cleanup EXIT
+
+if ! command -v claude &>/dev/null; then
+  exit 1
+fi
+
+TODAY=$(date '+%Y-%m-%d')
+DAILY_NOTE="${VAULT_PATH}/Daily/${TODAY}.md"
+
+ROUTING_RULES=$(sed -n '/^## Routing Rules/,/^##/p' "$CONFIG_FILE" | head -20)
+TAXONOMY=$(sed -n '/^## Project Taxonomy/,/^##/p' "$CONFIG_FILE" | head -20)
+
+PROMPT=$(cat <<'PROMPT_EOF'
+You are a session-to-Obsidian note converter. You receive a Claude Code conversation transcript (JSON).
+
+Your ONLY output must be valid markdown for a single Obsidian session note. No preamble, no explanation, no code fences — just the raw markdown content starting with the YAML frontmatter.
+
+Rules:
+1. If the conversation is trivial (< 5 substantive messages, no code/decisions/debugging), output exactly: SKIP
+2. Determine the domain from the routing rules below and pick the correct vault subfolder.
+3. Generate a slug from the main topics (lowercase, dashes, no dates).
+
+Output format (when not SKIP):
+---
+date: YYYY-MM-DD
+domain: <domain>
+vault_folder: <relative path from vault root, e.g. Awesome Motive/sessions/>
+slug: <topic-slug>
+tags: [<relevant tags>]
+---
+
+# <Descriptive Title>
+
+## Summary
+- <2-4 bullet points of what was accomplished>
+
+## Key Decisions
+- <decisions made, if any>
+
+## Files Changed
+- <list of files modified, if any>
+
+## Commits
+- <commit hashes and messages, if any>
+
+## Notes
+<any other important context>
+
+ROUTING_RULES_PLACEHOLDER
+TAXONOMY_PLACEHOLDER
+PROMPT_EOF
+)
+
+PROMPT="${PROMPT/ROUTING_RULES_PLACEHOLDER/$ROUTING_RULES}"
+PROMPT="${PROMPT/TAXONOMY_PLACEHOLDER/$TAXONOMY}"
+
+RESULT=$(claude --print --bare --system-prompt "$PROMPT" --max-budget-usd 0.10 < "$TMPFILE" 2>/dev/null) || exit 1
+
+if [ -z "$RESULT" ] || [ "$RESULT" = "SKIP" ]; then
+  exit 0
+fi
+
+VAULT_FOLDER=$(echo "$RESULT" | grep '^vault_folder:' | head -1 | sed 's/^vault_folder:[[:space:]]*//')
+SLUG=$(echo "$RESULT" | grep '^slug:' | head -1 | sed 's/^slug:[[:space:]]*//')
+
+: "${VAULT_FOLDER:=Inbox/}"
+: "${SLUG:=session-note}"
+
+NOTE_DIR="${VAULT_PATH}/${VAULT_FOLDER}"
+mkdir -p "$NOTE_DIR"
+
+NOTE_FILENAME="${TODAY}-${SLUG}.md"
+NOTE_PATH="${NOTE_DIR}/${NOTE_FILENAME}"
+
+# Strip the frontmatter vault_folder and slug lines (internal-only metadata)
+CLEAN_RESULT=$(echo "$RESULT" | sed '/^vault_folder:/d; /^slug:/d')
+printf '%s\n' "$CLEAN_RESULT" > "$NOTE_PATH"
+
+RELATIVE_NOTE_PATH="${VAULT_FOLDER}${NOTE_FILENAME%.md}"
+TITLE=$(echo "$RESULT" | grep '^# ' | head -1 | sed 's/^# //')
+: "${TITLE:=$SLUG}"
+
+LINK_LINE="- [[${RELATIVE_NOTE_PATH}|${TITLE}]]"
+
+if [ ! -f "$DAILY_NOTE" ]; then
+  cat > "$DAILY_NOTE" <<DAILY_EOF
+# ${TODAY}
+
+## Top 3
+1.
+2.
+3.
+
+## Schedule / Time blocks
+-
+
+## Tasks
+- [ ]
+
+## Notes
+-
+
+## Carryover
+-
+
+## Session Links
+${LINK_LINE}
+DAILY_EOF
+elif grep -qF "## Session Links" "$DAILY_NOTE"; then
+  printf '%s\n' "$LINK_LINE" >> "$DAILY_NOTE"
+else
+  printf '\n## Session Links\n%s\n' "$LINK_LINE" >> "$DAILY_NOTE"
+fi


### PR DESCRIPTION
## Summary
- Replaces the `Stop` prompt hook (120s timeout, unreliable for long sessions) with a `command` hook that exits in <1s
- `session-save.sh` captures the transcript to a temp file and spawns `session-summarize.sh` in the background
- `session-summarize.sh` pipes the transcript through `claude --print --bare` for LLM summarization with no timeout pressure
- Writes structured session notes to the Obsidian vault and updates the daily note

## How it works
1. **Stop hook fires** -> `session-save.sh` reads stdin (transcript), writes to temp file, spawns background process, exits 0
2. **Background** -> `session-summarize.sh` reads the temp file, builds a prompt with routing rules from `obsidian.local.md`, pipes through `claude --print --bare`, parses output, writes note to vault, appends link to daily note
3. **Cleanup** -> temp file removed after summarization

## Files synced
- Plugin cache (~/.claude/plugins/cache/nhangen/obsidian/)
- Codex skills (~/.codex/skills/obsidian-vault/scripts/)
