### PR TITLE
Validate save targets against canonical allow-list

### DIFF
--- a/obsidian.local.md.example
+++ b/obsidian.local.md.example
@@ -6,6 +6,7 @@ auto_save: true
 auto_open: true
 time_gap_minutes: 30
 smart_detect: true
+strict_domains: true
 domains:
   - Development
   - Work
@@ -27,6 +28,10 @@ Run `/obsidian:setup` to generate this file interactively, or copy and edit manu
 | Work | Projects/Work/ | Client/employer work, meetings |
 | Personal | Projects/Personal/ | Personal notes, goals |
 | Learning | Projects/Learning/ | Books, courses, research |
+| Daily | Daily/ | Date-stamped daily notes |
+| Inbox | Inbox/ | Fallback for ambiguous notes |
+
+The `Vault path` column above is the **canonical allow-list**. Skills validate every save target against this list and refuse to create folders outside it. To add a new top-level folder, add a row here (or rerun `/obsidian:setup`) — never let routine saves create new top-level folders.
 
 ## Routing Rules
 
@@ -36,3 +41,15 @@ Run `/obsidian:setup` to generate this file interactively, or copy and edit manu
 - Keywords "book, course, paper, research, study, learn" → Projects/Learning/
 - Keywords "daily, journal, today" → Daily/
 - Ambiguous → Inbox/ (with #needs-filing tag)
+
+## Strict Domain Validation
+
+When `strict_domains: true` (default), the save/create skills:
+
+1. Parse the `## Project Taxonomy` table and treat the `Vault path` column as the canonical allow-list of top-level folders.
+2. Before writing, verify the resolved target's top-level folder is in the allow-list. Dated subfolders and per-repo namespacing *under* an allow-listed root are fine.
+3. On miss: refuse to write, surface the closest matching allow-listed folder, and tell the user to either correct the topic hint or add the folder to `## Project Taxonomy` via `/obsidian:setup`.
+
+This prevents silent alias folders (`AM/` alongside `Awesome Motive/`, `Obsidian Daily/` alongside `Daily/`). Failure-mode reference: the `enum-config-typo-fallback` pattern — string fields selecting a code path must reject unknown values, not coerce to a default.
+
+To opt out (not recommended), set `strict_domains: false`.

--- a/skills/obsidian/create-note/SKILL.md
+++ b/skills/obsidian/create-note/SKILL.md
@@ -27,8 +27,9 @@ If `obsidian.local.md` does not exist, tell the user to run `/obsidian:setup` fi
    - Project: `README.md` + subfolders (Plans, Notes, Meetings as appropriate)
 5. **Validate allow-list** — `strict_domains` defaults to `true` when absent from the config frontmatter; only an explicit `false` skips validation. When on:
    - Parse the `## Project Taxonomy` table from `${CLAUDE_PLUGIN_ROOT}/obsidian.local.md`; the `Vault path` column is the canonical allow-list of top-level folders.
+   - Normalize both the allow-list entries and the resolved target before comparison: strip any trailing `/`, and lowercase both sides (macOS HFS+/default APFS is case-insensitive).
    - Compute the resolved target's top-level prefix (path up to and including the first allow-listed root match). Dated subfolders and per-repo namespacing *under* an allow-listed root are valid.
-   - If no allow-list entry is a prefix of the target, **refuse to write**. Surface the closest match (Levenshtein on the top-level component) and tell the user:
+   - If no normalized allow-list entry is a prefix of the normalized target, **refuse to write**. Surface the closest match (Levenshtein on the top-level component, original casing from the taxonomy) and tell the user:
      > Refusing to write to `<target>` — top-level folder is not in the allow-list. Closest match: `<closest>`. Either correct the topic hint, or add `<target-toplevel>` to `## Project Taxonomy` in `obsidian.local.md` (or rerun `/obsidian:setup`).
    - Do not create unrecognized top-level folders. Topic hints that fuzzy-match must themselves resolve to an existing taxonomy row.
 6. **Create dirs if needed** — `mkdir -p <path>` (only after validation passes)

--- a/skills/obsidian/create-note/SKILL.md
+++ b/skills/obsidian/create-note/SKILL.md
@@ -25,10 +25,16 @@ If `obsidian.local.md` does not exist, tell the user to run `/obsidian:setup` fi
 4. **Generate content** — create appropriate starter template:
    - Single note: title + frontmatter + H1 + empty sections
    - Project: `README.md` + subfolders (Plans, Notes, Meetings as appropriate)
-5. **Create dirs if needed** — `mkdir -p <path>`
-6. **Write file(s)** — use Write tool
-7. **Confirm path** — tell user exactly where it was created
-8. **Open in GUI** — `bash ${CLAUDE_PLUGIN_ROOT}/scripts/open-in-obsidian.sh <path>`
+5. **Validate allow-list** — `strict_domains` defaults to `true` when absent from the config frontmatter; only an explicit `false` skips validation. When on:
+   - Parse the `## Project Taxonomy` table from `${CLAUDE_PLUGIN_ROOT}/obsidian.local.md`; the `Vault path` column is the canonical allow-list of top-level folders.
+   - Compute the resolved target's top-level prefix (path up to and including the first allow-listed root match). Dated subfolders and per-repo namespacing *under* an allow-listed root are valid.
+   - If no allow-list entry is a prefix of the target, **refuse to write**. Surface the closest match (Levenshtein on the top-level component) and tell the user:
+     > Refusing to write to `<target>` — top-level folder is not in the allow-list. Closest match: `<closest>`. Either correct the topic hint, or add `<target-toplevel>` to `## Project Taxonomy` in `obsidian.local.md` (or rerun `/obsidian:setup`).
+   - Do not create unrecognized top-level folders. Topic hints that fuzzy-match must themselves resolve to an existing taxonomy row.
+6. **Create dirs if needed** — `mkdir -p <path>` (only after validation passes)
+7. **Write file(s)** — use Write tool
+8. **Confirm path** — tell user exactly where it was created
+9. **Open in GUI** — `bash ${CLAUDE_PLUGIN_ROOT}/scripts/open-in-obsidian.sh <path>`
 
 ## Note Template
 

--- a/skills/obsidian/save-conversation/SKILL.md
+++ b/skills/obsidian/save-conversation/SKILL.md
@@ -19,13 +19,35 @@ Vault path: read `vault_path` field from `${CLAUDE_PLUGIN_ROOT}/obsidian.local.m
 Read routing rules from `${CLAUDE_PLUGIN_ROOT}/obsidian.local.md`:
 
 1. Extract the `## Routing Rules` section from the config file
-2. Extract the `## Project Taxonomy` section for folder paths
+2. Extract the `## Project Taxonomy` section for folder paths — the `Vault path` column is the **canonical allow-list** of top-level folders
 3. Match the conversation's dominant topics against the keywords in those sections
 4. Use the matching target folder from the taxonomy
 
 If `obsidian.local.md` does not exist, tell the user to run `/obsidian:setup` first and stop.
 
-If the user provides a topic hint (e.g. "/obsidian:save WSL setup"), use it to override the keyword-based routing — look for the closest matching domain in the taxonomy.
+If the user provides a topic hint (e.g. "/obsidian:save WSL setup"), use it to override the keyword-based routing — look for the closest matching domain **that exists in the taxonomy**. The hint must resolve to a row already in `## Project Taxonomy`. If it does not, stop and tell the user:
+
+> Topic hint `<hint>` did not match any allow-listed domain. Allow-listed domains: `<list>`. Either correct the hint or add a row to `## Project Taxonomy` via `/obsidian:setup`.
+
+Never let a fuzzy hint create a new top-level folder.
+
+## Allow-list Validation (strict_domains)
+
+`strict_domains` defaults to **`true`** when the field is absent from the config frontmatter. Treat the field as opt-out, not opt-in. Only `strict_domains: false` (explicit) skips validation.
+
+When strict mode is on, validate the resolved target before any write:
+
+1. Parse the `## Project Taxonomy` table; collect every value in the `Vault path` column as the canonical allow-list (e.g. `Projects/Development/`, `Daily/`, `Inbox/`).
+2. Compute the resolved target's **top-level prefix** — i.e. the path up to and including the first allow-listed root match. Dated subfolders and per-repo namespacing *under* an allow-listed root are valid (e.g. `Projects/Development/nhangen/foo/2026-05-09.md` is fine because `Projects/Development/` is allow-listed).
+3. If no allow-list entry is a prefix of the resolved target, **refuse to write**. Surface the closest match (Levenshtein on the top-level component) and tell the user:
+
+   > Refusing to write to `<target>` — top-level folder is not in the allow-list. Closest match: `<closest>`. Either correct the topic hint, or add `<target-toplevel>` to `## Project Taxonomy` in `obsidian.local.md` (or rerun `/obsidian:setup`).
+
+4. Do **not** create the unrecognized folder. The taxonomy is the only place new top-level folders get added.
+
+If `strict_domains: false`, skip this validation.
+
+Why this matters: without strict validation, a typo'd hint silently creates an alias folder (e.g. `AM/` alongside `Awesome Motive/`) that fragments the vault over time. Failure-mode reference: `enum-config-typo-fallback`.
 
 ## Output Format
 
@@ -66,10 +88,11 @@ source: claude-code
 3. **Generate title** — create descriptive kebab-case title from topic, e.g. `2026-02-19-obsidian-vault-consolidation`
 4. **Build content** — format conversation as structured markdown per template above (or use `Templates/session.md` from vault if it exists)
 5. **Determine full path** — `<vault_path>/<target-folder>/<YYYY-MM-DD-title>.md`
-6. **Create parent dirs if needed** — `mkdir -p <vault_path>/<target-folder>`
-7. **Write file** — use Write tool to save
-8. **Confirm** — tell user where the file was saved
-9. **Open in GUI** — call `bash ${CLAUDE_PLUGIN_ROOT}/scripts/open-in-obsidian.sh <relative-path>`
+6. **Validate allow-list** — `strict_domains` defaults to `true` when absent; only an explicit `false` skips validation. See "Allow-list Validation (strict_domains)" above. If the top-level folder is not allow-listed, refuse and surface the closest match. Do not create the folder. If routing landed in `Inbox/` because no clear domain matched, prompt for confirmation ("No clear domain match — routing to `Inbox/`. Confirm or supply a topic hint") rather than writing silently.
+7. **Create parent dirs if needed** — `mkdir -p <vault_path>/<target-folder>` (only after validation passes)
+8. **Write file** — use Write tool to save
+9. **Confirm** — tell user where the file was saved
+10. **Open in GUI** — call `bash ${CLAUDE_PLUGIN_ROOT}/scripts/open-in-obsidian.sh <relative-path>`
 
 ## Chapter Segmentation
 

--- a/skills/obsidian/save-conversation/SKILL.md
+++ b/skills/obsidian/save-conversation/SKILL.md
@@ -38,12 +38,13 @@ Never let a fuzzy hint create a new top-level folder.
 When strict mode is on, validate the resolved target before any write:
 
 1. Parse the `## Project Taxonomy` table; collect every value in the `Vault path` column as the canonical allow-list (e.g. `Projects/Development/`, `Daily/`, `Inbox/`).
-2. Compute the resolved target's **top-level prefix** — i.e. the path up to and including the first allow-listed root match. Dated subfolders and per-repo namespacing *under* an allow-listed root are valid (e.g. `Projects/Development/nhangen/foo/2026-05-09.md` is fine because `Projects/Development/` is allow-listed).
-3. If no allow-list entry is a prefix of the resolved target, **refuse to write**. Surface the closest match (Levenshtein on the top-level component) and tell the user:
+2. Normalize both the allow-list entries and the resolved target before comparison: strip any trailing `/`, and lowercase both sides. The on-disk filesystem is often case-insensitive (macOS HFS+, default APFS); the prompt comparison must match.
+3. Compute the resolved target's **top-level prefix** — i.e. the path up to and including the first allow-listed root match. Dated subfolders and per-repo namespacing *under* an allow-listed root are valid (e.g. `Projects/Development/nhangen/foo/2026-05-09.md` is fine because `Projects/Development/` is allow-listed).
+4. If no normalized allow-list entry is a prefix of the normalized target, **refuse to write**. Surface the closest match (Levenshtein on the top-level component, in the original casing from the taxonomy) and tell the user:
 
    > Refusing to write to `<target>` — top-level folder is not in the allow-list. Closest match: `<closest>`. Either correct the topic hint, or add `<target-toplevel>` to `## Project Taxonomy` in `obsidian.local.md` (or rerun `/obsidian:setup`).
 
-4. Do **not** create the unrecognized folder. The taxonomy is the only place new top-level folders get added.
+5. Do **not** create the unrecognized folder. The taxonomy is the only place new top-level folders get added.
 
 If `strict_domains: false`, skip this validation.
 

--- a/skills/obsidian/setup/SKILL.md
+++ b/skills/obsidian/setup/SKILL.md
@@ -105,6 +105,7 @@ auto_save: true
 auto_open: true
 time_gap_minutes: 30
 smart_detect: true
+strict_domains: true
 domains:
 DOMAIN_LIST
 ---
@@ -119,6 +120,9 @@ Vault is at `VAULT_ABSOLUTE_PATH`.
 |--------|-----------|-------|
 TAXONOMY_ROWS
 | Daily | DAILY_PATH | |
+| Inbox | INBOX_PATH | Fallback for ambiguous notes |
+
+The `Vault path` column above is the canonical allow-list of top-level folders. Skills refuse to write outside this list while `strict_domains: true`.
 
 ## Routing Rules
 
@@ -149,3 +153,4 @@ Tell the user:
 - `vault_name` is read by `open-in-obsidian.sh` to construct the Obsidian URI — it must match the vault name shown in the Obsidian app's vault switcher
 - Routing Rules section is read verbatim by `session-summarize.sh` and passed to Claude — plain English descriptions work best
 - The `domains` YAML list is metadata only; routing is driven by the `## Routing Rules` section
+- `strict_domains: true` (default) makes `## Project Taxonomy`'s `Vault path` column the canonical allow-list. Skills refuse to write to top-level folders that are not on the list, preventing silent alias folders. To add a new top-level folder, add a Project Taxonomy row (or rerun `/obsidian:setup`) — never let routine saves create new folders.


### PR DESCRIPTION
Closes #5

## Description (Issue Fixed & New Behavior)

The `obsidian:save` and `obsidian:create-note` skills previously created folders silently when the resolved target didn't match a canonical taxonomy entry. This produced alias folders (`AM/`, `Obsidian Daily/`, `VR&E/`, `Writing/`) in the user's vault during routine saves — the same shape as the documented `enum-config-typo-fallback` failure mode.

This PR makes the `## Project Taxonomy` table's `Vault path` column the **canonical allow-list** of top-level folders. With `strict_domains: true` (default), skills:

1. Parse the taxonomy table at write time and treat the `Vault path` column as the allow-list.
2. Compute the resolved target's top-level prefix; dated subfolders and per-repo namespacing under an allow-listed root remain valid.
3. On miss, refuse to write. Surface the closest allow-listed folder and instruct the user to either correct the topic hint or add a row via `/obsidian:setup`.

Topic hints must themselves resolve to an existing taxonomy row — fuzzy matches that don't land on an allow-listed entry are rejected. Inbox routing now prompts for confirmation rather than writing silently.

## Files

- `obsidian.local.md.example` — documents allow-list semantics, adds `strict_domains: true` and Daily/Inbox rows.
- `skills/obsidian/save-conversation/SKILL.md` — adds the validation section, opt-out semantics, hint validation, Inbox confirmation.
- `skills/obsidian/create-note/SKILL.md` — inlines the full validation block (no cross-skill reference).
- `skills/obsidian/setup/SKILL.md` — emits `strict_domains: true` and an Inbox row in generated configs; documents the rule in Notes.

## Testing Procedure

Manual prompt-walk per skill (no test runner — this is a prompt-engineered plugin):

1. Read `skills/obsidian/save-conversation/SKILL.md` end-to-end and confirm Step 6 references the validation section, Steps 7+ run only after validation passes, and the routing override paragraph requires hint to match an existing row.
2. Read `skills/obsidian/create-note/SKILL.md` Step 5 — validation logic should be inlined (not a cross-skill reference).
3. Read `skills/obsidian/setup/SKILL.md` Step 7 — generated frontmatter must contain `strict_domains: true` and the Inbox taxonomy row.
4. Read `obsidian.local.md.example` — frontmatter has `strict_domains: true`, Daily and Inbox rows present in taxonomy, "Strict Domain Validation" section present.

## Additional Notes

Failure-mode reference: `~/.claude/rules/enum-config-typo-fallback.md` — string fields that select a code path must reject unknown values, not coerce to a default.

Surfaced by the 2026-05-09 vault reorganization.