### PR TITLE
Same-day dedup check before writing session notes

### DIFF
--- a/obsidian.local.md.example
+++ b/obsidian.local.md.example
@@ -7,6 +7,7 @@ auto_open: true
 time_gap_minutes: 30
 smart_detect: true
 strict_domains: true
+dedup_jaccard_threshold: 0.4
 domains:
   - Development
   - Work

--- a/skills/obsidian/save-conversation/SKILL.md
+++ b/skills/obsidian/save-conversation/SKILL.md
@@ -106,7 +106,7 @@ Before writing a new note in the resolved target folder, check whether a same-da
    ```bash
    find "<vault_path>/<target-folder>" -maxdepth 1 -type f -name "$(date +%Y-%m-%d)-*.md" 2>/dev/null
    ```
-2. **Score topic similarity** between the proposed kebab-case slug (the part after the date prefix in the new filename) and each existing same-day file's slug. Use **token Jaccard similarity**: split each slug on `-`, lowercase, **drop tokens that are purely numeric (e.g. `2026`, `04`) or a single character**. Keep 2-char tokens like `pr`, `om`, `wp`, `ai` — these carry signal in dev/work slugs. Then compute `|A ∩ B| / |A ∪ B|`.
+2. **Score topic similarity** between the proposed kebab-case slug (the part after the date prefix in the new filename) and each existing same-day file's slug. Use **token Jaccard similarity**: split each slug on `-`, lowercase, **drop tokens that are purely numeric (e.g. `2026`, `04`, `1234`) or exactly one character (e.g. `a`, `v`, `x`)**. Keep 2-char tokens like `pr`, `om`, `wp`, `ai` — these carry signal in dev/work slugs. Then compute `|A ∩ B| / |A ∪ B|`.
 3. **If the highest score is ≥ 0.4**, treat as a likely match and prompt the user:
    > Same-day note already exists: `<existing-path>` (similarity: `<score>`).
    > - **append** → add `## HH:MM — <new-topic>` section to the existing file

--- a/skills/obsidian/save-conversation/SKILL.md
+++ b/skills/obsidian/save-conversation/SKILL.md
@@ -90,12 +90,47 @@ source: claude-code
 4. **Build content** — format conversation as structured markdown per template above (or use `Templates/session.md` from vault if it exists)
 5. **Determine full path** — `<vault_path>/<target-folder>/<YYYY-MM-DD-title>.md`
 6. **Validate allow-list** — `strict_domains` defaults to `true` when absent; only an explicit `false` skips validation. See "Allow-list Validation (strict_domains)" above. If the top-level folder is not allow-listed, refuse and surface the closest match. Do not create the folder. If routing landed in `Inbox/` because no clear domain matched, prompt for confirmation ("No clear domain match — routing to `Inbox/`. Confirm or supply a topic hint") rather than writing silently.
-7. **Create parent dirs if needed** — `mkdir -p <vault_path>/<target-folder>` (only after validation passes)
-8. **Write file** — use Write tool to save
-9. **Confirm** — tell user where the file was saved
-10. **Open in GUI** — call `bash ${CLAUDE_PLUGIN_ROOT}/scripts/open-in-obsidian.sh <relative-path>`
+7. **Same-day dedup check** — see "Same-Day Dedup Check" below. Before writing, scan the **confirmed** target folder (after any Inbox redirect or topic-hint correction from step 6) for same-day notes and offer append vs new-file when an existing match scores above the threshold.
+8. **Create parent dirs if needed** — `mkdir -p <vault_path>/<target-folder>` (only after validation passes)
+9. **Write or append** — use Write tool for new files; use Edit tool to append a timestamped section when the user chose append mode in step 7.
+10. **Confirm** — tell user where the file was saved (and whether it was a new file or an append)
+11. **Open in GUI** — call `bash ${CLAUDE_PLUGIN_ROOT}/scripts/open-in-obsidian.sh <relative-path>`
+
+## Same-Day Dedup Check
+
+Before writing a new note in the resolved target folder, check whether a same-day note covering the same topic already exists. This prevents same-day twin files like `2026-04-22-candid-vault-self-assessment.md` and `2026-04-22-vault-self-analysis.md`.
+
+### Steps
+
+1. **Glob the target folder** for `<YYYY-MM-DD>-*.md` where `<YYYY-MM-DD>` is today's date. Bash example:
+   ```bash
+   find "<vault_path>/<target-folder>" -maxdepth 1 -type f -name "$(date +%Y-%m-%d)-*.md" 2>/dev/null
+   ```
+2. **Score topic similarity** between the proposed kebab-case slug (the part after the date prefix in the new filename) and each existing same-day file's slug. Use **token Jaccard similarity**: split each slug on `-`, lowercase, **drop tokens that are purely numeric (e.g. `2026`, `04`) or a single character**. Keep 2-char tokens like `pr`, `om`, `wp`, `ai` — these carry signal in dev/work slugs. Then compute `|A ∩ B| / |A ∪ B|`.
+3. **If the highest score is ≥ 0.4**, treat as a likely match and prompt the user:
+   > Same-day note already exists: `<existing-path>` (similarity: `<score>`).
+   > - **append** → add `## HH:MM — <new-topic>` section to the existing file
+   > - **new** → write the proposed new file anyway
+   > Choose: append / new
+4. **Append mode**:
+   - Read the existing file with the Read tool.
+   - Use the Edit tool to insert a new section at the end (after the existing content, before any trailing whitespace). The new section starts with an h2 header: `## HH:MM — <Title>` (24h local time). The h2 header itself stays at h2 — do **not** demote it to h3.
+   - Preserve frontmatter exactly as-is — do not edit the `---` fenced block.
+   - Inside the new `## HH:MM — <Title>` section, the sub-blocks (`Summary`, `Key Findings / Decisions`, `Details`, `Related Notes`) are written as **`###` (h3) headings**, since they are children of the h2 timestamp section. Do not nest deeper than h3.
+5. **New mode**: proceed with the original Write to a new file. Check for filename collision with `test -f "<full-path>"` before writing; if true, append `-2`, `-3`, etc. and recheck until the path is free. (Collisions only happen when two saves run within the same minute against the same slug.)
+6. **No match (highest < 0.4)**: skip the prompt and proceed with Write.
+
+### Threshold
+
+`0.4` is the default. Override per-vault by setting `dedup_jaccard_threshold: 0.5` (or any float 0.0–1.0) in `obsidian.local.md` frontmatter. Set to `0.0` to always prompt; set to `1.0` to disable the check.
+
+### Why
+
+Recent vault reorg surfaced same-day twin notes that had to be manually merged. The skill writes a new file even when an existing same-day note covers the same ground because it never checks before writing. Globbing the target folder costs ~1 ms; the merge cost (manual or via the vault-organizer agent) is much higher.
 
 ## Chapter Segmentation
 
 If the conversation contains `#bookmark` markers, split into multiple notes — one per chapter.
 If there are time gaps >30 min (visible from message timestamps), treat each segment as a separate note.
+
+When segmentation produces multiple candidate files, run the Same-Day Dedup Check **per chapter** — each candidate file independently globs the target folder and prompts append vs new on a hit. Do not skip the dedup check for chapters 2..N.

--- a/skills/obsidian/setup/SKILL.md
+++ b/skills/obsidian/setup/SKILL.md
@@ -106,6 +106,7 @@ auto_open: true
 time_gap_minutes: 30
 smart_detect: true
 strict_domains: true
+dedup_jaccard_threshold: 0.4
 domains:
 DOMAIN_LIST
 ---


### PR DESCRIPTION
Closes #3

## Description

The `obsidian:save` skill previously wrote a new file even when a same-day note for the same topic already existed. This produced same-day twins (e.g. `2026-04-22-candid-vault-self-assessment.md` + `2026-04-22-vault-self-analysis.md`) that had to be manually merged during the 2026-05-09 vault reorg.

This PR adds a pre-write dedup check:

1. After allow-list validation (step 6 from PR #7), glob the confirmed target folder for `<YYYY-MM-DD>-*.md`.
2. Score token Jaccard similarity between the proposed slug and each existing same-day file.
3. If the highest score is ≥ `dedup_jaccard_threshold` (default 0.4), prompt append vs new.
4. Append: insert `## HH:MM — <Title>` h2 section, sub-blocks at h3. Frontmatter preserved verbatim.
5. New: collision-check with `test -f` and increment `-2`/`-3` suffix until free.

Token filter drops purely-numeric and single-char tokens; keeps 2-char tokens like `pr`, `om`, `wp`, `ai`.

Chapter segmentation runs dedup per chapter, not just the first.

## Files

- `skills/obsidian/save-conversation/SKILL.md` — Same-Day Dedup Check section, renumbered Steps 7+
- `obsidian.local.md.example`, `skills/obsidian/setup/SKILL.md` — `dedup_jaccard_threshold: 0.4`

## Testing Procedure

1. Read save-conversation SKILL Steps section: dedup is step 7, runs against confirmed target.
2. Read Same-Day Dedup Check section: token filter rule, threshold default, append mechanics, collision check.
3. Read Chapter Segmentation: per-chapter dedup is explicit.
4. Walk dedup against `2026-04-22-candid-vault-self-assessment.md` vs `2026-04-22-vault-self-analysis.md`. Filtered tokens: `{candid, vault, self, assessment}` and `{vault, self, analysis}`. Jaccard = 2/5 = 0.4 — at threshold, would prompt.

## Additional Notes

Default 0.4 is conservative; tune via `dedup_jaccard_threshold` in `obsidian.local.md`. 0.0 = always prompt, 1.0 = disabled.

Surfaced by 2026-05-09 vault reorg.