### PR TITLE
Cross-domain routing tiebreaker for multi-match topics

### DIFF
--- a/obsidian.local.md.example
+++ b/obsidian.local.md.example
@@ -23,16 +23,18 @@ Run `/obsidian:setup` to generate this file interactively, or copy and edit manu
 
 ## Project Taxonomy
 
-| Domain | Vault path | Notes |
-|--------|-----------|-------|
-| Development | Projects/Development/ | Code, tools, debugging |
-| Work | Projects/Work/ | Client/employer work, meetings |
-| Personal | Projects/Personal/ | Personal notes, goals |
-| Learning | Projects/Learning/ | Books, courses, research |
-| Daily | Daily/ | Date-stamped daily notes |
-| Inbox | Inbox/ | Fallback for ambiguous notes |
+| Domain | Vault path | Precedence | Notes |
+|--------|-----------|------------|-------|
+| Development | Projects/Development/ | 10 | Code, tools, debugging |
+| Work | Projects/Work/ | 20 | Client/employer work, meetings |
+| Personal | Projects/Personal/ | 30 | Personal notes, goals |
+| Learning | Projects/Learning/ | 40 | Books, courses, research |
+| Daily | Daily/ | 50 | Date-stamped daily notes |
+| Inbox | Inbox/ | 99 | Fallback for ambiguous notes |
 
 The `Vault path` column above is the **canonical allow-list**. Skills validate every save target against this list and refuse to create folders outside it. To add a new top-level folder, add a row here (or rerun `/obsidian:setup`) — never let routine saves create new top-level folders.
+
+The `Precedence` column ranks routes when more than one keyword matches (lower wins; absent → 100). Optional — leave blank to fall back to a "matched multiple — pick one" prompt.
 
 ## Routing Rules
 

--- a/skills/obsidian/save-conversation/SKILL.md
+++ b/skills/obsidian/save-conversation/SKILL.md
@@ -102,7 +102,7 @@ source: claude-code
 
 1. **Check vault conventions** — if `VAULT.md` exists at the vault root, read it for vault-specific conventions (e.g., session template, domain folders, linking rules)
 2. **Detect topic and collect candidates** — scan conversation context for domain keywords; collect **every** matching candidate, not just the first
-3. **Resolve target folder** — if exactly one candidate matched, use it. If two or more matched, run the **Cross-Domain Tiebreaker** below to pick one. The result is the resolved target folder.
+3. **Resolve target folder** — if exactly one candidate matched, use it. If two or more matched, run the **Cross-Domain Tiebreaker** (see section above) to pick one. The result is the resolved target folder.
 4. **Generate title** — create descriptive kebab-case title from topic, e.g. `2026-02-19-obsidian-vault-consolidation`
 5. **Build content** — format conversation as structured markdown per template above (or use `Templates/session.md` from vault if it exists)
 6. **Determine full path** — `<vault_path>/<target-folder>/<YYYY-MM-DD-title>.md`

--- a/skills/obsidian/save-conversation/SKILL.md
+++ b/skills/obsidian/save-conversation/SKILL.md
@@ -19,9 +19,9 @@ Vault path: read `vault_path` field from `${CLAUDE_PLUGIN_ROOT}/obsidian.local.m
 Read routing rules from `${CLAUDE_PLUGIN_ROOT}/obsidian.local.md`:
 
 1. Extract the `## Routing Rules` section from the config file
-2. Extract the `## Project Taxonomy` section for folder paths — the `Vault path` column is the **canonical allow-list** of top-level folders
-3. Match the conversation's dominant topics against the keywords in those sections
-4. Use the matching target folder from the taxonomy
+2. Extract the `## Project Taxonomy` section for folder paths — the `Vault path` column is the **canonical allow-list** of top-level folders. The optional `precedence` column ranks routes when more than one matches (lower number wins; absent → 100).
+3. Match the conversation's dominant topics against the keywords in those sections — collect **every** matching candidate, not just the first.
+4. If exactly one candidate matches above threshold, use it. If two or more match, run the **Cross-Domain Tiebreaker** below.
 
 If `obsidian.local.md` does not exist, tell the user to run `/obsidian:setup` first and stop.
 
@@ -30,6 +30,22 @@ If the user provides a topic hint (e.g. "/obsidian:save WSL setup"), use it to o
 > Topic hint `<hint>` did not match any allow-listed domain. Allow-listed domains: `<list>`. Either correct the hint or add a row to `## Project Taxonomy` via `/obsidian:setup`.
 
 Never let a fuzzy hint create a new top-level folder.
+
+## Cross-Domain Tiebreaker
+
+When the keyword scan in step 2 produces **2+ candidate domains** (common for cross-cutting topics: career notes that touch a specific employer; finance notes that touch personal goals; dev notes that touch a specific repo), apply this tiebreaker before writing:
+
+0. **Check the session cache first.** Maintain a mental map of `<topic-stem> → <chosen-domain>` for the current Claude Code session (use a code block in working memory or a dedicated section of your scratchpad). If the current note's topic-stem already appears in the cache, use the cached domain and skip steps 1–5. The cache is in-memory only; it resets between sessions.
+1. **Sort candidates by `precedence`** (the optional column in `## Project Taxonomy`). Lower number wins; absent treated as 100.
+2. **Pick the highest-precedence candidate** as the proposed target.
+3. **Scan sibling candidates** for existing notes with overlapping slugs (use the same token Jaccard from "Same-Day Dedup Check" but across the whole sibling folder, not just same-day). If any sibling has matches scoring ≥ `dedup_jaccard_threshold`, surface them:
+   > Topic also matched `<sibling-domain>` (precedence `<n>`); existing notes there: `<list>`. Routing to `<chosen>` (precedence `<m>`). Override?
+4. **Remember the choice for the session** — once the user confirms or overrides, write `<topic-stem> → <chosen-domain>` into the in-memory cache from step 0. Do not re-prompt for the same topic-stem this session.
+5. **No precedence column at all** in the taxonomy → fall back to: warn the user about the multi-match, list candidates, and ask once. Their reply seeds the in-memory cache (step 4).
+
+This prevents the parallel-tree problem (e.g. `Career/`, `Awesome Motive/career/`, `Personal/Job Search/` all accumulating notes about the same job-search thread because each save resolved to a different route).
+
+Mirror the precedence column in the example file's `## Project Taxonomy`. The setup wizard offers an optional precedence prompt — see `obsidian-setup`.
 
 ## Allow-list Validation (strict_domains)
 
@@ -85,16 +101,17 @@ source: claude-code
 ## Steps
 
 1. **Check vault conventions** — if `VAULT.md` exists at the vault root, read it for vault-specific conventions (e.g., session template, domain folders, linking rules)
-2. **Detect topic and routing** — scan conversation context for domain keywords, determine target folder
-3. **Generate title** — create descriptive kebab-case title from topic, e.g. `2026-02-19-obsidian-vault-consolidation`
-4. **Build content** — format conversation as structured markdown per template above (or use `Templates/session.md` from vault if it exists)
-5. **Determine full path** — `<vault_path>/<target-folder>/<YYYY-MM-DD-title>.md`
-6. **Validate allow-list** — `strict_domains` defaults to `true` when absent; only an explicit `false` skips validation. See "Allow-list Validation (strict_domains)" above. If the top-level folder is not allow-listed, refuse and surface the closest match. Do not create the folder. If routing landed in `Inbox/` because no clear domain matched, prompt for confirmation ("No clear domain match — routing to `Inbox/`. Confirm or supply a topic hint") rather than writing silently.
-7. **Same-day dedup check** — see "Same-Day Dedup Check" below. Before writing, scan the **confirmed** target folder (after any Inbox redirect or topic-hint correction from step 6) for same-day notes and offer append vs new-file when an existing match scores above the threshold.
-8. **Create parent dirs if needed** — `mkdir -p <vault_path>/<target-folder>` (only after validation passes)
-9. **Write or append** — use Write tool for new files; use Edit tool to append a timestamped section when the user chose append mode in step 7.
-10. **Confirm** — tell user where the file was saved (and whether it was a new file or an append)
-11. **Open in GUI** — call `bash ${CLAUDE_PLUGIN_ROOT}/scripts/open-in-obsidian.sh <relative-path>`
+2. **Detect topic and collect candidates** — scan conversation context for domain keywords; collect **every** matching candidate, not just the first
+3. **Resolve target folder** — if exactly one candidate matched, use it. If two or more matched, run the **Cross-Domain Tiebreaker** below to pick one. The result is the resolved target folder.
+4. **Generate title** — create descriptive kebab-case title from topic, e.g. `2026-02-19-obsidian-vault-consolidation`
+5. **Build content** — format conversation as structured markdown per template above (or use `Templates/session.md` from vault if it exists)
+6. **Determine full path** — `<vault_path>/<target-folder>/<YYYY-MM-DD-title>.md`
+7. **Validate allow-list** — `strict_domains` defaults to `true` when absent; only an explicit `false` skips validation. See "Allow-list Validation (strict_domains)" above. If the top-level folder is not allow-listed, refuse and surface the closest match. Do not create the folder. If routing landed in `Inbox/` because no clear domain matched, prompt for confirmation ("No clear domain match — routing to `Inbox/`. Confirm or supply a topic hint") rather than writing silently.
+8. **Same-day dedup check** — see "Same-Day Dedup Check" below. Before writing, scan the **confirmed** target folder (after any Inbox redirect or topic-hint correction from step 7) for same-day notes and offer append vs new-file when an existing match scores above the threshold.
+9. **Create parent dirs if needed** — `mkdir -p <vault_path>/<target-folder>` (only after validation passes)
+10. **Write or append** — use Write tool for new files; use Edit tool to append a timestamped section when the user chose append mode in step 8.
+11. **Confirm** — tell user where the file was saved (and whether it was a new file or an append)
+12. **Open in GUI** — call `bash ${CLAUDE_PLUGIN_ROOT}/scripts/open-in-obsidian.sh <relative-path>`
 
 ## Same-Day Dedup Check
 

--- a/skills/obsidian/setup/SKILL.md
+++ b/skills/obsidian/setup/SKILL.md
@@ -65,6 +65,20 @@ For each domain, ask in a single message listing all domains at once:
 
 Collect the keyword list for each domain from the user's reply.
 
+### 4b. Ask for Precedence (optional)
+
+Ask:
+
+> If multiple domains' keywords could match the same note, which wins?
+> Provide a precedence integer per domain (lower number wins). Skip with Enter to leave precedence blank — the plugin will prompt at save-time on multi-matches.
+>
+> **Domain1:** (number, e.g. 10)
+> **Domain2:** (number, e.g. 20)
+>
+> Example: Development=10, Work=20, Personal=30 means a note matching both Development and Work routes to Development.
+
+Collect optional precedence per domain. If the user skips all, omit the `Precedence` column from the generated taxonomy table.
+
 ### 5. Ask for Daily Notes Path
 
 Ask:
@@ -91,7 +105,10 @@ Replace:
 - `VAULT_ABSOLUTE_PATH` → expanded absolute path from Step 2
 - `VAULT_FOLDER_NAME` → last path component of the vault path (e.g. `Obsidian`)
 - `DOMAIN_LIST` → one `  - DomainName` line per domain
-- `TAXONOMY_ROWS` → one table row per domain: `| DomainName | Projects/DomainName/ | |`
+- `TAXONOMY_HEADER` → `| Domain | Vault path | Precedence | Notes |` if any precedence values were provided in Step 4b; otherwise `| Domain | Vault path | Notes |`.
+- `TAXONOMY_SEPARATOR` → matching separator row: `|--------|-----------|------------|-------|` (4-col) or `|--------|-----------|-------|` (3-col).
+- `TAXONOMY_ROWS` → one row per domain in the same shape as the header. **Substitute the actual domain name in both columns.** With precedence: `| <DomainName> | Projects/<DomainName>/ | <prec-or-blank> | |`. Without: `| <DomainName> | Projects/<DomainName>/ | |`. Replace each `<DomainName>` with the user's domain (e.g. `Development`, producing `| Development | Projects/Development/ | 10 | |`). Pick one shape for the whole table — do not mix.
+- `DAILY_AND_INBOX_ROWS` → emit `| Daily | DAILY_PATH | 50 | |` and `| Inbox | INBOX_PATH | 99 | Fallback for ambiguous notes |` if precedence column is included; otherwise `| Daily | DAILY_PATH | |` and `| Inbox | INBOX_PATH | Fallback for ambiguous notes |`. Substitute `DAILY_PATH` and `INBOX_PATH` with the values collected in Steps 5 and 6.
 - `ROUTING_RULE_LINES` → one routing line per domain: `- Keywords "kw1, kw2" → Projects/DomainName/`
 - `DAILY_PATH` → value from Step 5
 - `INBOX_PATH` → value from Step 6
@@ -117,13 +134,14 @@ Vault is at `VAULT_ABSOLUTE_PATH`.
 
 ## Project Taxonomy
 
-| Domain | Vault path | Notes |
-|--------|-----------|-------|
+TAXONOMY_HEADER
+TAXONOMY_SEPARATOR
 TAXONOMY_ROWS
-| Daily | DAILY_PATH | |
-| Inbox | INBOX_PATH | Fallback for ambiguous notes |
+DAILY_AND_INBOX_ROWS
 
 The `Vault path` column above is the canonical allow-list of top-level folders. Skills refuse to write outside this list while `strict_domains: true`.
+
+If a `Precedence` column is present, lower number wins when keywords from multiple domains match the same note. If it is absent, the skill prompts the user to pick on multi-match.
 
 ## Routing Rules
 


### PR DESCRIPTION
Closes #4

## Description

Multiple parallel trees accumulated for the same theme (e.g. `Career/`, `Awesome Motive/career/`, `Personal/Job Search/`) because the routing logic resolved differently per save without surfacing siblings.

This PR adds an optional `Precedence` column to `## Project Taxonomy` (lower wins; absent = 100) and a Cross-Domain Tiebreaker that fires when keywords from 2+ domains match the same note:

1. Sort candidates by precedence; pick the highest.
2. Scan sibling candidates' folders for overlapping slugs (token Jaccard, reused from #3) and surface them with an override option.
3. Cache the user's choice as `<topic-stem> → <domain>` in-memory for the session — second save of same topic skips the prompt.
4. No precedence column at all → fall back to "ask once, cache the answer."

Steps 2-3 now collect all candidates and explicitly invoke the tiebreaker (the prior shape kept the tiebreaker as prose outside the Steps execution path, which was unreachable).

## Files

- `skills/obsidian/save-conversation/SKILL.md` — Steps 2-3 multi-candidate collection + explicit tiebreaker invocation; new "Cross-Domain Tiebreaker" section with session-cache check at step 0
- `obsidian.local.md.example` — Precedence column added to taxonomy with example values
- `skills/obsidian/setup/SKILL.md` — new Step 4b for optional per-domain precedence collection; emits 3-col or 4-col table accordingly; templated `TAXONOMY_HEADER`/`TAXONOMY_SEPARATOR`/`DAILY_AND_INBOX_ROWS`

## Testing Procedure

1. Read save-conversation SKILL Steps section: step 2 collects all candidates, step 3 explicitly invokes the tiebreaker on multi-match.
2. Read Cross-Domain Tiebreaker section: step 0 checks session cache before tiebreaker; steps 1-5 cover precedence sort, sibling scan, cache write, and no-precedence fallback.
3. Read setup SKILL Step 4b: optional precedence collection; Step 7 templates render either 3-col or 4-col table.
4. Walk against the historical case: a save matching both "career" (precedence 30 in user vault) and "awesome motive" (precedence 50) routes to Career/, surfaces existing notes in `Awesome Motive/career/` for sibling override, caches the result.

## Additional Notes

Builds on PR #7 (allow-list validation) and PR #8 (same-day dedup). Together these three PRs close the routing-quality gaps surfaced by the 2026-05-09 vault reorg.