### PR TITLE
Soft MOC-promotion prompt after writing into a loose folder

### DIFF
--- a/obsidian.local.md.example
+++ b/obsidian.local.md.example
@@ -8,6 +8,8 @@ time_gap_minutes: 30
 smart_detect: true
 strict_domains: true
 dedup_jaccard_threshold: 0.4
+moc_promotion: true
+moc_promotion_threshold: 3
 domains:
   - Development
   - Work

--- a/skills/obsidian/save-conversation/SKILL.md
+++ b/skills/obsidian/save-conversation/SKILL.md
@@ -158,7 +158,7 @@ After a successful new-file write, check whether the parent folder has grown a c
    - The parent folder is already inside a per-idea subfolder (e.g. `Projects/Physics-AI-ML/DeCoN/notes/`) — promotion only fires at the *parent of loose notes*, not nested.
    - `moc_promotion: false` is set in `obsidian.local.md` frontmatter.
 
-2. **Cluster detection** — In the parent folder (non-recursive), find all `.md` files whose slug shares ≥ 2 tokens after applying the same token filter from "Same-Day Dedup Check" (drop purely-numeric and single-character tokens). Use the longest shared token-prefix as the candidate **topic stem**.
+2. **Cluster detection** — In the parent folder (non-recursive), find all `.md` files whose slug shares ≥ 2 tokens after applying the same token filter from "Same-Day Dedup Check" (drop purely-numeric and single-character tokens). Identify the candidate **topic stem** using the precise rule in the "Tokenization for stem detection" section below — do not pick stem by length alone here.
    - Minimum cluster size: 3 (configurable via `moc_promotion_threshold` in config; default 3).
    - The new file just written counts toward the cluster.
 

--- a/skills/obsidian/save-conversation/SKILL.md
+++ b/skills/obsidian/save-conversation/SKILL.md
@@ -112,6 +112,7 @@ source: claude-code
 10. **Write or append** — use Write tool for new files; use Edit tool to append a timestamped section when the user chose append mode in step 8.
 11. **Confirm** — tell user where the file was saved (and whether it was a new file or an append)
 12. **Open in GUI** — call `bash ${CLAUDE_PLUGIN_ROOT}/scripts/open-in-obsidian.sh <relative-path>`
+13. **MOC-promotion prompt (post-save, soft)** — see "MOC-Promotion Prompt" below. After a successful new-file write, check whether the parent folder has accumulated 3+ notes sharing a topic stem. If so, prompt once to promote into a dedicated subfolder with a `README.md` index. Skip on append. Skip if the user previously declined promotion for this stem.
 
 ## Same-Day Dedup Check
 
@@ -144,6 +145,81 @@ Before writing a new note in the resolved target folder, check whether a same-da
 ### Why
 
 Recent vault reorg surfaced same-day twin notes that had to be manually merged. The skill writes a new file even when an existing same-day note covers the same ground because it never checks before writing. Globbing the target folder costs ~1 ms; the merge cost (manual or via the vault-organizer agent) is much higher.
+
+## MOC-Promotion Prompt
+
+After a successful new-file write, check whether the parent folder has grown a coherent cluster that deserves its own subfolder + index. **Soft prompt only — never auto-create.**
+
+### Steps
+
+1. **Skip conditions** — Skip immediately if any of:
+   - The save was an append (not a new file).
+   - The user has previously declined promotion for this topic-stem in the current session (track in the same in-memory cache as the Cross-Domain Tiebreaker, with a separate key prefix like `moc-declined:<stem>`).
+   - The parent folder is already inside a per-idea subfolder (e.g. `Projects/Physics-AI-ML/DeCoN/notes/`) — promotion only fires at the *parent of loose notes*, not nested.
+   - `moc_promotion: false` is set in `obsidian.local.md` frontmatter.
+
+2. **Cluster detection** — In the parent folder (non-recursive), find all `.md` files whose slug shares ≥ 2 tokens after applying the same token filter from "Same-Day Dedup Check" (drop purely-numeric and single-character tokens). Use the longest shared token-prefix as the candidate **topic stem**.
+   - Minimum cluster size: 3 (configurable via `moc_promotion_threshold` in config; default 3).
+   - The new file just written counts toward the cluster.
+
+3. **Prompt once** — if a cluster ≥ 3 is found, surface:
+   > Folder `<parent>/` has accumulated 3+ notes sharing the topic stem `<stem>`:
+   > - `<file-1>`
+   > - `<file-2>`
+   > - `<file-3>` (just written)
+   >
+   > Promote `<stem>` to its own subfolder with a `README.md` index?
+   > - **yes** → move matching files into `<parent>/<Stem>/notes/` and create `<parent>/<Stem>/README.md` with a stub MOC linking each note
+   > - **no** → leave files where they are, remember the decline so we don't ask again this session
+
+4. **On accept**:
+   - **Pre-move wikilink scan** — before any `mv`, grep the vault for each candidate file's wikilink form: `grep -rl "\[\[<filename-without-ext>\]\]" "<vault_path>" --include="*.md"` per file. If any references exist, surface them:
+     > Promoting will break the following wikilinks (Obsidian will not auto-update them via shell `mv`):
+     > - `<note-with-link>` → `[[<broken-target>]]`
+     >
+     > Continue anyway? (yes/no — recommend running Obsidian's "Update links on rename" manually after if you proceed)
+
+     If the user declines on the link-warning prompt, treat as an MOC decline (cache it) and stop.
+   - `mkdir -p "<parent>/<Stem>/notes"` — these writes operate under the already-validated parent folder and bypass the Step 7 allow-list check by design.
+   - Move matching files: `mv "<parent>/<file-N>" "<parent>/<Stem>/notes/"` (preserves frontmatter — no content edits).
+   - Write a stub `<parent>/<Stem>/README.md`:
+     ```markdown
+     ---
+     date: <YYYY-MM-DD>
+     type: moc
+     tags: [moc, <stem>]
+     ---
+
+     # <Stem-title-cased>
+
+     ## Notes
+
+     - [[notes/<file-1>]]
+     - [[notes/<file-2>]]
+     - [[notes/<file-3>]]
+
+     ## Related
+
+     -
+     ```
+   - Confirm to user with the new paths.
+
+5. **On decline**: write `moc-declined:<stem>` to the session cache and move on. Do not ask again this session.
+
+### Tokenization for stem detection
+
+Same filter as dedup: split slug on `-`, lowercase, drop tokens that are purely numeric (`2026`, `04`) or exactly one character (`a`, `v`, `x`). Keep 2-char tokens (`pr`, `om`, `wp`, `ai`).
+
+**Stem selection (precise rule):**
+1. For each filtered token, count the **number of distinct file-slugs in the candidate cluster that contain it** (not total occurrences across all files).
+2. Pick the token with the highest distinct-file count. That token must appear in **every** file in the candidate cluster — otherwise the cluster isn't coherent enough to promote, abort the prompt.
+3. **Tie-break:** if multiple tokens are tied on distinct-file count, pick the longest token (by character count). If still tied, pick alphabetically first. Always pick a single token, never a contiguous sequence — false-positive risk on overlapping tokens that happen to appear in different slug positions.
+
+### Why
+
+Idea folders accumulate loose notes without an index. By the time the user notices, the cluster is hard to navigate and links are missing — the 2026-05-09 vault reorg found 9 loose notes at `Projects/Physics-AI-ML/` that had grown around 3-4 latent ideas. A soft prompt at the right moment promotes the cluster before drift sets in.
+
+This is **strictly opt-in per cluster**. Never move files without explicit confirmation. Never re-prompt for the same stem in the same session.
 
 ## Chapter Segmentation
 

--- a/skills/obsidian/setup/SKILL.md
+++ b/skills/obsidian/setup/SKILL.md
@@ -124,6 +124,8 @@ time_gap_minutes: 30
 smart_detect: true
 strict_domains: true
 dedup_jaccard_threshold: 0.4
+moc_promotion: true
+moc_promotion_threshold: 3
 domains:
 DOMAIN_LIST
 ---


### PR DESCRIPTION
Closes #6

## Description

Idea folders accumulate loose notes without an index until the user manually consolidates. The 2026-05-09 vault reorg found 9 loose notes at `Projects/Physics-AI-ML/` clustered around 3-4 latent ideas that should each have their own subfolder + MOC.

This PR adds a soft post-save prompt: after a successful new-file write, check whether the parent folder has 3+ notes sharing a common token. If so, offer to promote into `<Stem>/notes/` with a `<Stem>/README.md` MOC stub.

**Soft, opt-in per cluster — never auto-creates.** Skip conditions:
- Append (not new file)
- Previously-declined stem (session cache, prefix `moc-declined:<stem>`)
- Already inside a per-idea subfolder
- `moc_promotion: false` in config

## Files

- `skills/obsidian/save-conversation/SKILL.md` — Step 13 added; new "MOC-Promotion Prompt" section
- `obsidian.local.md.example`, `skills/obsidian/setup/SKILL.md` — `moc_promotion: true` and `moc_promotion_threshold: 3`

## Implementation details

- **Cluster detection**: token must appear in every file in the candidate cluster; distinct-file count wins; ties broken by longest token, then alphabetical. Reuses the dedup token filter (drops numeric and single-char tokens).
- **Pre-move wikilink scan**: before any `mv`, grep the vault for `[[<filename>]]` references. If any exist, warn the user that links will break (Obsidian's "Update links on rename" only fires through the GUI, not shell `mv`). User can abort.
- **Allow-list interaction**: MOC writes operate under the already-validated parent and bypass Step 7 by design — explicitly noted in the spec to prevent future confusion.
- **Frontmatter preservation**: `mv` only, no content edits.

## Testing Procedure

1. Read save-conversation Step 13 — runs after Open in GUI, soft prompt only.
2. Read MOC-Promotion Prompt section — skip conditions, cluster detection, prompt body, on-accept and on-decline branches.
3. Read Tokenization for stem detection — distinct-file count rule, must-appear-in-every-file rule, tie-break order.
4. Walk against the historical case: `Projects/Physics-AI-ML/` with 9 loose notes including `*-decon-*`, `*-memory-dynamics-*`, `*-psychohistory-*`. After saving a 4th `decon` note, prompt fires for stem `decon`; user accepts, files move to `Projects/Physics-AI-ML/DeCon/notes/` with stub `README.md`.
5. Walk wikilink-warning path: any vault note containing `[[<moved-file>]]` is surfaced before the move; user aborts → cluster left intact, decline cached.

## Additional Notes

Final piece in the routing-quality work surfaced by the 2026-05-09 vault reorg. Builds on PRs #7 (allow-list), #8 (same-day dedup), #9 (cross-domain tiebreaker).