### PR TITLE
release: v1.5.0 - chain graph_neighbors into recall workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "obsidian",
       "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, query past work with /recall, export conversations, create/retrieve notes, and auto-organize content.",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "author": {
         "name": "nhangen"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/skills/obsidian/recall/SKILL.md
+++ b/skills/obsidian/recall/SKILL.md
@@ -74,34 +74,44 @@ If claude-mem is unavailable or returns errors, note "claude-mem: unavailable" a
 
 ### Source E: claude-mem-graph MCP (causal tracing)
 
-Two entry paths — run whichever applies. If neither produces useful neighbors, note "graph: no signal" and continue.
+Three entry paths with concrete triggers. Each is independent — fire any that apply.
 
 **Path E1: trace from the top flat-search hit.**
 
-After Source D returns its top observation ID, call `mcp__plugin_claude-mem-graph_claude-mem-graph__graph_neighbors`:
+Trigger: Source D returned at least one observation.
+
 ```
 graph_neighbors({ observation_id: <top hit id>, max_results: 30 })
 ```
-Surface neighbors of these edge types only: `produced_by` (same-session siblings), `depends_on` (causal upstream), `informed_by` (narrative-extracted causal), `continues` (cross-session arc). **Discard `relates_to`** — generic-concept noise. Both upstream (graph_neighbors as of 2026-05-18) and this client should drop it; do not depend on either alone.
 
-**Path E2: file-based seeding.** Independent entry point that does NOT depend on flat search finding the right node. Trigger if the query contains any of:
+Surface only these edge types: `produced_by` (same-session siblings), `depends_on` (causal upstream), `informed_by` (narrative-extracted causal), `continues` (cross-session arc). Do not show `relates_to` — upstream `graph_neighbors` (claude-mem-graph ≥ v0.2.3) filters it at the source; this client does not double-filter. If you see a `relates_to` row in output, the installed graph is older than v0.2.3 — silently discard and add a one-line note to the report so the user knows to upgrade.
 
-- a path-like token: contains `/`, or ends in `.md` / `.ts` / `.py` / `.php` / `.sh` / `.tsx` / `.jsx` / `.go` / `.rs`
-- a kebab-case or snake_case token of 2+ separators: `branch-worktree-cleanup`, `discover-repos`, `pr-review-panel`, `optin-monster-app`, `mtf_builder_pipeline` — these are usually repo, skill, or script identifiers
-- a multi-word phrase that maps to a known directory name in this vault or repo (e.g. "branch worktree cleanup" → `branch-worktree-cleanup`). When you see 3+ short lowercase words consecutively, try joining with `-` and check if a file or directory exists by that name.
+**Path E2: file path lookup (exact match only).**
 
-For each candidate, call `graph_file_history`:
+Trigger: the query contains a **literal file path** — a token with a `/` separator OR a filename ending in `.md` / `.ts` / `.tsx` / `.jsx` / `.py` / `.php` / `.sh` / `.go` / `.rs`.
+
 ```
-graph_file_history({ file_path: "<extracted token or resolved path>" })
+graph_file_history({ file_path: "<the literal token from the query>" })
 ```
 
-If both paths return empty, claude-mem-graph adds nothing for this query — proceed without it.
+`graph_file_history` does **exact-match lookup** against the graph's `file:<path>` nodes — no substring, no basename, no glob. Only literal paths from the query work here. **Do NOT pass kebab-case skill names, repo slugs, or guessed directory names — they will silently return empty.**
 
-**Path E3 (fallback): cross-project search.** If Source D returns 0 useful hits (all results irrelevant or empty), call `graph_search` once with the original keywords:
+**Path E3: cross-project graph search.**
+
+Trigger when EITHER:
+- (a) Source D returned 0 rows, OR
+- (b) Source D's top hit's title (lowercased) shares no token of length ≥ 4 with the query keywords (lowercased, stopwords removed), OR
+- (c) the query contains a kebab/snake_case identifier with 1+ separators (e.g. `pr-czar`, `branch-worktree-cleanup`, `mem_search`) that did NOT trigger Path E2.
+
 ```
-graph_search({ task_description: <keywords>, max_sessions: 30, since_days: 365 })
+graph_search({ task_description: "<original keywords>", max_sessions: 30, since_days: 365 })
 ```
-This is the "graph can find what flat search missed" last-resort path. Not for general use — it's weaker than flat search for most queries. Only invoke when Source D is empty.
+
+Path E3 searches title, subtitle, narrative, text, facts, and concepts — different indexing from Source D's FTS, so it can surface observations Source D missed (e.g. when a skill/script name appears in a narrative but not a title). It's weaker than flat search for general keyword queries — that's why the trigger is conditional, not always-on.
+
+If E2 returned exact file-history results, you can skip E3's (c) branch — you've already located the entry via file path.
+
+If all three paths return empty, claude-mem-graph adds nothing for this query — proceed without it.
 
 ## Step 3: Synthesize Report
 

--- a/skills/obsidian/recall/SKILL.md
+++ b/skills/obsidian/recall/SKILL.md
@@ -66,13 +66,46 @@ gh pr list --state all --search="<ticket or keywords>" --limit 20
 ### Source D: claude-mem MCP
 
 Use the 3-layer workflow:
-1. `mcp__plugin_claude-mem_mcp-search__search` with query = ticket number + keywords, limit 10
+1. `mcp__plugin_claude-mem_mcp-search__search` with query = ticket number + keywords, limit 10. **Pass `orderBy: "relevance"` explicitly** — the mem-search tool's default is `date_desc`, which hides older observations behind recent noise. Verified against claude-mem source: only the literal string `"relevance"` switches to FTS score; omitting the param falls through to date ordering.
 2. `mcp__plugin_claude-mem_mcp-search__timeline` on the most relevant result
 3. `mcp__plugin_claude-mem_mcp-search__get_observations` for full details on filtered IDs
 
 If claude-mem is unavailable or returns errors, note "claude-mem: unavailable" and continue with other sources.
 
+### Source E: claude-mem-graph MCP (causal tracing)
+
+Two entry paths — run whichever applies. If neither produces useful neighbors, note "graph: no signal" and continue.
+
+**Path E1: trace from the top flat-search hit.**
+
+After Source D returns its top observation ID, call `mcp__plugin_claude-mem-graph_claude-mem-graph__graph_neighbors`:
+```
+graph_neighbors({ observation_id: <top hit id>, max_results: 30 })
+```
+Surface neighbors of these edge types only: `produced_by` (same-session siblings), `depends_on` (causal upstream), `informed_by` (narrative-extracted causal), `continues` (cross-session arc). **Discard `relates_to`** — generic-concept noise. Both upstream (graph_neighbors as of 2026-05-18) and this client should drop it; do not depend on either alone.
+
+**Path E2: file-based seeding.** Independent entry point that does NOT depend on flat search finding the right node. Trigger if the query contains any of:
+
+- a path-like token: contains `/`, or ends in `.md` / `.ts` / `.py` / `.php` / `.sh` / `.tsx` / `.jsx` / `.go` / `.rs`
+- a kebab-case or snake_case token of 2+ separators: `branch-worktree-cleanup`, `discover-repos`, `pr-review-panel`, `optin-monster-app`, `mtf_builder_pipeline` — these are usually repo, skill, or script identifiers
+- a multi-word phrase that maps to a known directory name in this vault or repo (e.g. "branch worktree cleanup" → `branch-worktree-cleanup`). When you see 3+ short lowercase words consecutively, try joining with `-` and check if a file or directory exists by that name.
+
+For each candidate, call `graph_file_history`:
+```
+graph_file_history({ file_path: "<extracted token or resolved path>" })
+```
+
+If both paths return empty, claude-mem-graph adds nothing for this query — proceed without it.
+
+**Path E3 (fallback): cross-project search.** If Source D returns 0 useful hits (all results irrelevant or empty), call `graph_search` once with the original keywords:
+```
+graph_search({ task_description: <keywords>, max_sessions: 30, since_days: 365 })
+```
+This is the "graph can find what flat search missed" last-resort path. Not for general use — it's weaker than flat search for most queries. Only invoke when Source D is empty.
+
 ## Step 3: Synthesize Report
+
+When merging Source D (flat claude-mem) with Source E (graph), use flat hits to anchor the report and graph neighbors to expand the story arc. A `produced_by` sibling chain typically becomes a "Session Context" subsection; `depends_on` and `informed_by` chains become entries in "Timeline" or "Key Decisions"; `continues` edges become "Related Sessions".
 
 Combine all results into this format:
 


### PR DESCRIPTION
Closes #none

## Description

Extends `obsidian:recall` to chain `claude-mem-graph` after the top flat `mem-search` hit, so recall surfaces causal context (`produced_by`, `depends_on`, `informed_by`, `continues`) alongside flat keyword hits.

Three new entry paths under Source E:

- **Path E1**: `graph_neighbors` on top flat hit — runs whenever Source D returned anything.
- **Path E2**: `graph_file_history` when query contains a path-like token, kebab/snake_case identifier (2+ separators), or multi-word phrase that maps to a directory name. Independent entry path — addresses Task 10 in the 2026-05-18 utility eval where flat search missed an older observation.
- **Path E3**: `graph_search` fallback — only invoked when Source D returns 0 hits. Last-resort entry path.

Also fixes a no-op in Source D: previously said to omit `orderBy` expecting relevance ranking. Verified against claude-mem's source that omission defaults to `date_desc`. Now passes `orderBy: "relevance"` explicitly.

Discards `relates_to` client-side as a defense-in-depth guard (upstream `graph_neighbors` in `claude-mem-graph` v0.2.3 already filters this — see nhangen/claude-mem-graph#4).

Bumps:
- `.claude-plugin/plugin.json` 1.4.0 → 1.5.0
- `.claude-plugin/marketplace.json` 1.4.0 → 1.5.0

## Testing Procedure

1. Install both this plugin (post-merge of nhangen/claude-mem-graph#4) and claude-mem-graph v0.2.3.
2. Invoke `/recall <some past topic>` against a vault with prior claude-mem observations.
3. Confirm the synthesized report includes a "Source E" / graph-context section with `produced_by` siblings of the top flat hit.
4. Test the trigger broadening: `/recall branch-worktree-cleanup` should fire Path E2 against `branch-worktree-cleanup` as a file/skill name candidate.
5. Test Path E3: a query with no flat hits should fall back to `graph_search` rather than returning empty.
6. Verify `orderBy: "relevance"` is honored: query terms with older matches should surface them, not get buried under recent noise.

## Additional Notes

Surfaced by the 2026-05-18 utility eval that resolved the Apr 18 kill-decision for claude-mem-graph (W=6/T=3/L=1 → keep+wire). Companion PR: nhangen/claude-mem-graph#4. Full eval write-up lives in the user's Obsidian vault at `Projects/Development/nhangen/claude-mem-graph/2026-05-18-utility-eval.md`.

Post-audit revision: original trigger for Path E2 was too narrow (only path-like tokens) — auditor caught it as eval-fitting on the Task 10 query. Broadened to also catch kebab/snake_case identifiers and inferred multi-word→directory names. The `orderBy` fix is also post-audit (auditor verified the prior wording was a no-op against claude-mem source).