### PR TITLE
Inline vault_path in commit-capture hook output

### DIFF
--- a/scripts/commit-capture.sh
+++ b/scripts/commit-capture.sh
@@ -110,7 +110,17 @@ if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "$CONFIG_FILE" ]; then
     case "$line" in
       vault_path:*)
         VAULT_PATH="${line#vault_path:}"
+        # Strip trailing CR from CRLF-edited configs before any other parsing.
+        VAULT_PATH="${VAULT_PATH%$'\r'}"
+        # Strip an inline "# comment" tail before quote/whitespace handling.
+        case "$VAULT_PATH" in
+          *' #'*) VAULT_PATH="${VAULT_PATH%% #*}" ;;
+          *$'\t#'*) VAULT_PATH="${VAULT_PATH%%	#*}" ;;
+        esac
         VAULT_PATH="${VAULT_PATH# }"
+        VAULT_PATH="${VAULT_PATH#	}"
+        VAULT_PATH="${VAULT_PATH% }"
+        VAULT_PATH="${VAULT_PATH%	}"
         VAULT_PATH="${VAULT_PATH#\"}"
         VAULT_PATH="${VAULT_PATH%\"}"
         VAULT_PATH="${VAULT_PATH#\'}"

--- a/scripts/commit-capture.sh
+++ b/scripts/commit-capture.sh
@@ -98,7 +98,34 @@ while [ -n "$REMAINING" ]; do
   esac
 done
 
+# --- Resolve vault_path from obsidian.local.md ---
+# Inline this in the hook output so the skill doesn't have to Read the config
+# file on every commit. The config rarely changes; if it does, the next commit
+# picks up the new value.
+
+VAULT_PATH=""
+CONFIG_FILE="${CLAUDE_PLUGIN_ROOT:-}/obsidian.local.md"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "$CONFIG_FILE" ]; then
+  while IFS= read -r line; do
+    case "$line" in
+      vault_path:*)
+        VAULT_PATH="${line#vault_path:}"
+        VAULT_PATH="${VAULT_PATH# }"
+        VAULT_PATH="${VAULT_PATH#\"}"
+        VAULT_PATH="${VAULT_PATH%\"}"
+        VAULT_PATH="${VAULT_PATH#\'}"
+        VAULT_PATH="${VAULT_PATH%\'}"
+        case "$VAULT_PATH" in
+          '~/'*) VAULT_PATH="${HOME}/${VAULT_PATH#\~/}" ;;
+          '~') VAULT_PATH="${HOME}" ;;
+        esac
+        break
+        ;;
+    esac
+  done < "$CONFIG_FILE"
+fi
+
 # --- Output metadata inline for the obsidian-commit-capture skill ---
 
-printf 'obsidian-commit-capture: hash=%s | msg=%s | branch=%s | files=%s | org_repo=%s | repo_name=%s | ticket=%s | date=%s | time=%s\n' \
-  "$HASH" "$MSG" "$BRANCH" "$FILES" "$ORG_REPO" "$REPO_NAME" "$TICKET" "$TODAY" "$NOW"
+printf 'obsidian-commit-capture: hash=%s | msg=%s | branch=%s | files=%s | org_repo=%s | repo_name=%s | ticket=%s | date=%s | time=%s | vault_path=%s\n' \
+  "$HASH" "$MSG" "$BRANCH" "$FILES" "$ORG_REPO" "$REPO_NAME" "$TICKET" "$TODAY" "$NOW" "$VAULT_PATH"

--- a/skills/obsidian/commit-capture/SKILL.md
+++ b/skills/obsidian/commit-capture/SKILL.md
@@ -14,15 +14,15 @@ Detection and metadata extraction are handled by `scripts/commit-capture.sh` (sh
 
 ## Config
 
-Read vault path from: `${CLAUDE_PLUGIN_ROOT}/obsidian.local.md`
+Vault path is passed inline by the hook (parsed once from `${CLAUDE_PLUGIN_ROOT}/obsidian.local.md`). Do **not** Read the config file from this skill — every read costs ~1-2K tokens per commit. If `vault_path` is empty in the hook output, skip silently (the config is missing or malformed).
 
 ## Steps
 
 1. **Parse inline metadata** from the hook output line:
-   `obsidian-commit-capture: hash=<h> | msg=<m> | branch=<b> | files=<f> | org_repo=<o> | repo_name=<r> | ticket=<t> | date=<d> | time=<ti>`
-   Extract: `hash`, `msg`, `branch`, `files`, `org_repo`, `repo_name`, `ticket`, `date`, `time`.
+   `obsidian-commit-capture: hash=<h> | msg=<m> | branch=<b> | files=<f> | org_repo=<o> | repo_name=<r> | ticket=<t> | date=<d> | time=<ti> | vault_path=<v>`
+   Extract: `hash`, `msg`, `branch`, `files`, `org_repo`, `repo_name`, `ticket`, `date`, `time`, `vault_path`.
 
-2. **Determine target path** (relative to vault_path from config):
+2. **Determine target path** (relative to `vault_path` from the hook output):
    `Projects/Development/<org_repo>/<date>.md`
 
 3. **Read existing file** at the target path. If it doesn't exist, create it.

--- a/tests/commit-capture-vault-path.sh
+++ b/tests/commit-capture-vault-path.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Exercises scripts/commit-capture.sh's vault_path YAML parse block.
+# Regression coverage for inline-vault_path inlining (issue #12) — reverting
+# the parse block must fail this suite.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/commit-capture.sh"
+GIT_BIN_DIR=""
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# Stub git so commit-capture treats us as inside a real commit and we can
+# control hash/msg/branch/files without touching a real repo.
+make_git_stub() {
+  GIT_BIN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-git-XXXXXX")"
+  cat > "${GIT_BIN_DIR}/git" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  "rev-parse --short HEAD") echo abc1234 ;;
+  "log -1 --pretty=format:%s") echo "test commit" ;;
+  "rev-parse --abbrev-ref HEAD") echo nh/feat/test ;;
+  "diff --name-only HEAD~1..HEAD") echo foo.txt ;;
+  "remote get-url origin") echo "git@github.com:nhangen/test.git" ;;
+  "rev-parse --show-toplevel") echo "/tmp/test-repo" ;;
+  *) echo "" ;;
+esac
+exit 0
+STUB
+  chmod +x "${GIT_BIN_DIR}/git"
+}
+
+cleanup_git_stub() {
+  [ -n "$GIT_BIN_DIR" ] && rm -rf "$GIT_BIN_DIR"
+  GIT_BIN_DIR=""
+}
+
+# Run the script with a given config file and capture the printf output.
+# Returns the captured vault_path field value via stdout. Empty string if the
+# field is empty or the script took the silent-skip path.
+run_case() {
+  local config_file="$1"
+  local plugin_root="${2:-}"
+  local input='{"tool_input":{"command":"git commit -m foo"},"tool_response":{"stdout":"[main abc1234] foo\n"}}'
+  local out
+  if [ -n "$plugin_root" ]; then
+    out=$(CLAUDE_PLUGIN_ROOT="$plugin_root" PATH="${GIT_BIN_DIR}:$PATH" bash "$SCRIPT" <<< "$input")
+  else
+    out=$(env -u CLAUDE_PLUGIN_ROOT PATH="${GIT_BIN_DIR}:$PATH" bash "$SCRIPT" <<< "$input")
+  fi
+  # Extract vault_path=<value> field.
+  printf '%s' "$out" | sed -n 's/.* | vault_path=\(.*\)$/\1/p'
+}
+
+# Run and capture the raw output line (for asserting fields beyond vault_path).
+run_case_raw() {
+  local config_file="$1"
+  local plugin_root="${2:-}"
+  local input='{"tool_input":{"command":"git commit -m foo"},"tool_response":{"stdout":"[main abc1234] foo\n"}}'
+  if [ -n "$plugin_root" ]; then
+    CLAUDE_PLUGIN_ROOT="$plugin_root" PATH="${GIT_BIN_DIR}:$PATH" bash "$SCRIPT" <<< "$input"
+  else
+    env -u CLAUDE_PLUGIN_ROOT PATH="${GIT_BIN_DIR}:$PATH" bash "$SCRIPT" <<< "$input"
+  fi
+}
+
+make_git_stub
+trap cleanup_git_stub EXIT
+
+PASS_COUNT=0
+
+# ----- Case 1: happy path with tilde expansion -----
+CASE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-XXXXXX")"
+printf -- '---\nvault_path: ~/Documents/Obsidian\n---\n' > "${CASE_DIR}/obsidian.local.md"
+GOT=$(run_case "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
+EXPECTED="${HOME}/Documents/Obsidian"
+[ "$GOT" = "$EXPECTED" ] || fail "case1 (tilde): got '$GOT' want '$EXPECTED'"
+PASS_COUNT=$((PASS_COUNT + 1))
+
+# ----- Case 2: unset CLAUDE_PLUGIN_ROOT -> empty vault_path, no error -----
+GOT=$(run_case "" "")
+[ -z "$GOT" ] || fail "case2 (unset root): got '$GOT' want empty"
+PASS_COUNT=$((PASS_COUNT + 1))
+
+# ----- Case 3: missing config file -> empty vault_path, no error -----
+EMPTY_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-empty-XXXXXX")"
+GOT=$(run_case "" "$EMPTY_DIR")
+[ -z "$GOT" ] || fail "case3 (missing file): got '$GOT' want empty"
+PASS_COUNT=$((PASS_COUNT + 1))
+
+# ----- Case 4: empty vault_path: value -> empty -----
+CASE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-XXXXXX")"
+printf -- '---\nvault_path:\n---\n' > "${CASE_DIR}/obsidian.local.md"
+GOT=$(run_case "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
+[ -z "$GOT" ] || fail "case4 (empty value): got '$GOT' want empty"
+PASS_COUNT=$((PASS_COUNT + 1))
+
+# ----- Case 5: CRLF line endings stripped -----
+CASE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-XXXXXX")"
+printf -- '---\r\nvault_path: /Users/test/vault\r\n---\r\n' > "${CASE_DIR}/obsidian.local.md"
+GOT=$(run_case "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
+[ "$GOT" = "/Users/test/vault" ] || fail "case5 (CRLF): got '$GOT' want '/Users/test/vault'"
+PASS_COUNT=$((PASS_COUNT + 1))
+
+# ----- Case 6: inline comment stripped -----
+CASE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-XXXXXX")"
+printf -- '---\nvault_path: /Users/test/vault  # main vault\n---\n' > "${CASE_DIR}/obsidian.local.md"
+GOT=$(run_case "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
+[ "$GOT" = "/Users/test/vault" ] || fail "case6 (inline comment): got '$GOT' want '/Users/test/vault'"
+PASS_COUNT=$((PASS_COUNT + 1))
+
+# ----- Case 7: double-quoted value -----
+CASE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-XXXXXX")"
+printf -- '---\nvault_path: "/Users/test/My Vault"\n---\n' > "${CASE_DIR}/obsidian.local.md"
+GOT=$(run_case "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
+[ "$GOT" = "/Users/test/My Vault" ] || fail "case7 (double-quoted): got '$GOT' want '/Users/test/My Vault'"
+PASS_COUNT=$((PASS_COUNT + 1))
+
+# ----- Case 8: single-quoted value -----
+CASE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-XXXXXX")"
+printf -- "---\nvault_path: '/Users/test/Vault'\n---\n" > "${CASE_DIR}/obsidian.local.md"
+GOT=$(run_case "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
+[ "$GOT" = "/Users/test/Vault" ] || fail "case8 (single-quoted): got '$GOT' want '/Users/test/Vault'"
+PASS_COUNT=$((PASS_COUNT + 1))
+
+# ----- Case 9: output preserves all metadata fields with vault_path appended -----
+CASE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-XXXXXX")"
+printf -- '---\nvault_path: /Users/test/v\n---\n' > "${CASE_DIR}/obsidian.local.md"
+OUT=$(run_case_raw "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
+case "$OUT" in
+  'obsidian-commit-capture: hash='*' | msg='*' | branch='*' | files='*' | org_repo='*' | repo_name='*' | ticket='*' | date='*' | time='*' | vault_path=/Users/test/v') ;;
+  *) fail "case9 (schema): got '$OUT'" ;;
+esac
+PASS_COUNT=$((PASS_COUNT + 1))
+
+printf '%d/9 cases passed\n' "$PASS_COUNT"


### PR DESCRIPTION
Closes #12

## Description

The `obsidian-commit-capture` skill previously had the agent `Read` `${CLAUDE_PLUGIN_ROOT}/obsidian.local.md` on every successful git commit to resolve the vault path. Across an active day this is ~1–2K tokens per commit of redundant config reads.

`scripts/commit-capture.sh` now parses `vault_path` from the YAML frontmatter once per commit (shell parse, zero token cost) and appends it to the inline metadata line. `SKILL.md` is updated to consume `vault_path` from the hook output and explicitly forbid reading the config file from the skill.

If the config is missing or unparseable, `vault_path` is emitted empty and the skill skips silently — same behavior as before.

## Testing Procedure

1. `git checkout nh/perf/12-cache-config`
2. Mock the config:
   ```bash
   mkdir -p /tmp/obs-test && printf -- '---\nvault_path: ~/Documents/Obsidian\n---\n' > /tmp/obs-test/obsidian.local.md
   INPUT='{"tool_input":{"command":"git commit -m foo"},"tool_response":{"stdout":"[main abc1234] foo\n"}}'
   CLAUDE_PLUGIN_ROOT=/tmp/obs-test bash scripts/commit-capture.sh <<< "$INPUT"
   ```
3. Confirm the output line includes `| vault_path=/Users/<you>/Documents/Obsidian`.
4. Run again with `CLAUDE_PLUGIN_ROOT=/tmp/does-not-exist` and confirm `vault_path=` (empty) is emitted — the skill will skip silently.

## Additional Notes

Followups left out of scope: cache-by-mtime if the YAML parse ever becomes the bottleneck. Currently the parse is a single while-read pass over a small file, negligible compared to the per-commit git commands the hook already runs.