### PR TITLE
Fix skill discovery: flatten skills/ layout, bare skill names, bump 1.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "obsidian",
       "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, query past work with /recall, export conversations, create/retrieve notes, and auto-organize content.",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "author": {
         "name": "nhangen"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Per-repo commit-capture overrides go in the same file under a `## Commit Capture
 ```
 .claude-plugin/plugin.json    Plugin manifest
 commands/*.md                 Slash command entry points
-skills/obsidian/*/SKILL.md    Skill logic (save, find, recall, setup, …)
+skills/*/SKILL.md             Skill logic (save, find, recall, setup, …)
 hooks/hooks.json              Stop + PostToolUse hook registration
 scripts/                      Hook executables (commit-capture, session-save, …)
 scripts/lib/resolve-config.sh Version-independent config-path resolver

--- a/commands/daily.md
+++ b/commands/daily.md
@@ -5,4 +5,4 @@ description: Open or append to today's Obsidian daily note. Usage: /obsidian:dai
 
 Open today's daily note in Obsidian. If content is provided, append it to the note.
 
-Invoke the obsidian-daily-note skill to execute.
+Invoke the obsidian:daily-note skill to execute.

--- a/commands/find.md
+++ b/commands/find.md
@@ -5,4 +5,4 @@ description: Search the Obsidian vault. Usage: /obsidian:find <query>
 
 Search the Obsidian vault for notes matching the provided query.
 
-Invoke the obsidian-find-notes skill to execute.
+Invoke the obsidian:find-notes skill to execute.

--- a/commands/new.md
+++ b/commands/new.md
@@ -5,4 +5,4 @@ description: Create a new note or project in Obsidian. Usage: /obsidian:new <tit
 
 Create a new note or project in the Obsidian vault with the given title.
 
-Invoke the obsidian-create-note skill to execute.
+Invoke the obsidian:create-note skill to execute.

--- a/commands/recall.md
+++ b/commands/recall.md
@@ -5,7 +5,7 @@ description: Recall context about past work. Searches vault, git history, GitHub
 
 Recall and synthesize context about past work from multiple data sources.
 
-Pass the full user query to the obsidian-recall skill at `${CLAUDE_PLUGIN_ROOT}/skills/obsidian/recall/SKILL.md` to execute.
+Pass the full user query to the obsidian:recall skill at `${CLAUDE_PLUGIN_ROOT}/skills/recall/SKILL.md` to execute.
 
 Examples:
 - `/obsidian:recall what did I do on ticket #188 last week`

--- a/commands/save.md
+++ b/commands/save.md
@@ -8,4 +8,4 @@ Save the current conversation to the Obsidian vault.
 If a topic argument was provided, use it as a routing/title hint.
 Otherwise, auto-detect the domain from conversation context.
 
-Invoke the obsidian-save-conversation skill to execute.
+Invoke the obsidian:save-conversation skill to execute.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -5,4 +5,4 @@ description: First-time setup wizard for the Obsidian plugin. Configures vault p
 
 Run the first-time setup wizard for the Obsidian plugin.
 
-Invoke the obsidian-setup skill to execute.
+Invoke the obsidian:setup skill to execute.

--- a/scripts/commit-capture.sh
+++ b/scripts/commit-capture.sh
@@ -137,7 +137,7 @@ if [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_FILE" ]; then
   done < "$CONFIG_FILE"
 fi
 
-# --- Output metadata inline for the obsidian-commit-capture skill ---
+# --- Output metadata inline for the obsidian:commit-capture skill ---
 
 printf 'obsidian-commit-capture: hash=%s | msg=%s | branch=%s | files=%s | org_repo=%s | repo_name=%s | ticket=%s | date=%s | time=%s | vault_path=%s\n' \
   "$HASH" "$MSG" "$BRANCH" "$FILES" "$ORG_REPO" "$REPO_NAME" "$TICKET" "$TODAY" "$NOW" "$VAULT_PATH"

--- a/skills/commit-capture/SKILL.md
+++ b/skills/commit-capture/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: obsidian-commit-capture
+name: commit-capture
 description: Captures conversation context around git commits to Obsidian vault. Fires automatically via PostToolUse hook.
 version: 2.1.0
 ---

--- a/skills/create-note/SKILL.md
+++ b/skills/create-note/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: obsidian-create-note
+name: create-note
 description: Creates a new note, project folder, or page in the Obsidian vault. Triggers on phrases like "create a note about X", "start a new project for Y", "add a page for Z", "new obsidian note", "create project folder", "set up a new project in obsidian".
 version: 1.0.0
 ---
@@ -22,7 +22,7 @@ If the resolver prints nothing (no config at `$OBSIDIAN_LOCAL_MD`, `${XDG_CONFIG
 
 1. **Check for vault conventions** — if `VAULT.md` exists at the vault root, read it. Follow any structure conventions it defines (e.g., custom note types, templates folder, naming conventions). If no `VAULT.md` exists, use the defaults below.
 2. **Determine type** — single note, project folder (with README + subfolders), or page in existing project
-3. **Route to correct domain** — use routing logic from `obsidian-save-conversation` skill
+3. **Route to correct domain** — use routing logic from `obsidian:save-conversation` skill
 4. **Generate content** — create appropriate starter template:
    - Single note: title + frontmatter + H1 + empty sections
    - Project: `README.md` + subfolders (Plans, Notes, Meetings as appropriate)

--- a/skills/daily-note/SKILL.md
+++ b/skills/daily-note/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: obsidian-daily-note
+name: daily-note
 description: Reads, creates, or appends to the Obsidian daily note. Triggers on phrases like "add to my daily note", "update today's note", "what's in my daily note", "open today's note", "daily note", "log this to today".
 version: 1.0.0
 ---

--- a/skills/find-notes/SKILL.md
+++ b/skills/find-notes/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: obsidian-find-notes
+name: find-notes
 description: Searches the Obsidian vault and returns matching notes. Triggers on phrases like "find my notes on X", "what did I write about Y", "search obsidian for Z", "do I have any notes about", "find in vault", "look up in obsidian".
 version: 1.0.0
 ---

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: obsidian-recall
+name: recall
 description: Multi-source context recall. Searches Obsidian vault, git history, GitHub PRs, and claude-mem, then synthesizes a timeline report.
 version: 1.1.0
 ---

--- a/skills/reorganize/SKILL.md
+++ b/skills/reorganize/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: obsidian-reorganize
+name: reorganize
 description: Reorganizes the Obsidian vault or a specific project. Triggers on phrases like "reorganize my vault", "clean up obsidian", "move X to Y in obsidian", "reorganize my notes", "restructure my projects", "organize the vault". Launches the vault-organizer subagent for deep analysis and execution.
 version: 1.0.0
 ---

--- a/skills/save-conversation/SKILL.md
+++ b/skills/save-conversation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: obsidian-save-conversation
+name: save-conversation
 description: Exports the current Claude conversation to the Obsidian vault. Triggers on phrases like "save this to Obsidian", "export to obsidian", "document this session", "save our conversation", "write this up", "put this in obsidian". Formats the conversation as structured markdown, determines the correct project folder from context, and saves with a timestamped filename. Optionally opens the note in the Obsidian GUI.
 version: 1.0.0
 ---
@@ -118,7 +118,7 @@ When the keyword scan in step 2 produces **2+ candidate domains** (common for cr
 
 This prevents the parallel-tree problem (e.g. `Career/`, `Awesome Motive/career/`, `Personal/Job Search/` all accumulating notes about the same job-search thread because each save resolved to a different route).
 
-Mirror the precedence column in the example file's `## Project Taxonomy`. The setup wizard offers an optional precedence prompt — see `obsidian-setup`.
+Mirror the precedence column in the example file's `## Project Taxonomy`. The setup wizard offers an optional precedence prompt — see `obsidian:setup`.
 
 ## Allow-list Validation (strict_domains)
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: obsidian-setup
+name: setup
 description: First-time setup wizard for the Obsidian plugin. Guides the user through configuring vault path, domain taxonomy, and routing rules, then writes obsidian.local.md. Triggers on "/obsidian:setup", "set up obsidian", "configure obsidian plugin", "obsidian first run".
 version: 1.0.0
 ---


### PR DESCRIPTION
## Description

All 8 plugin skills were silently unregistered: they lived at `skills/obsidian/<name>/SKILL.md`, one level deeper than the `skills/<name>/SKILL.md` layout the plugin loader scans. Commands registered fine, so `/obsidian:save` etc. ran — but their handoff line ("Invoke the obsidian-save-conversation skill") referenced a skill name that never existed in the session, failing on every invocation. Verified against working plugins (claude-mem, superpowers, figma): all use the flat layout.

- Move `skills/obsidian/<name>/` → `skills/<name>/` (8 skills)
- Bare frontmatter names (`save-conversation`, not `obsidian-save-conversation`) — the loader namespaces from the manifest
- Commands now reference fully-qualified `obsidian:<name>`; `recall.md` hardcoded path fixed
- `obsidian-commit-capture:` hook output marker kept as-is (textual protocol string, consistent on both sides)
- Version 1.6.1 → 1.7.0 in `plugin.json` + in-repo `marketplace.json`

## Testing
1. `bash tests/commit-capture-vault-path.sh` → 9/9 passed (local mock fixtures)
2. `bash tests/resolve-config.sh` → 6/6 passed
3. `bash tests/session-summarize-intent.sh` → passed
4. After merge + `/plugin update`: new session should list `obsidian:save-conversation` etc. in available skills; `/obsidian:save` handoff resolves