### PR TITLE
Self-activate the vaultkeeper watcher on first normal use

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,19 @@ The plugin includes a two-layer background maintenance system that keeps the vau
 
 `Librarian.md` is written exclusively by the keeper tick. Manual edits do not persist — the next tick overwrites it atomically. Read it as a live dashboard; don't edit it.
 
-### Install
+### Activation (automatic)
+
+The keeper activates itself. The first time the session-end hook (`session-save.sh`) runs on a host where the keeper isn't scheduled yet, it seeds the frontmatter schema, writes default keeper config, and installs the namespaced scheduler — no command to run. Once installed it's a cheap no-op on every later session end.
+
+Because Syncthing carries the vault but not a launchd plist / crontab line, each host self-activates the first time you work on it. Opt out with `keeper_autostart: false` in `obsidian.local.md`.
+
+To install manually (or on a host you never run a session on), the engine is still directly invokable:
 
 ```bash
 bash scripts/install-watcher.sh install "$(pwd)/scripts/vaultkeeper-tick.sh"
 ```
 
-This registers the keeper under the `com.nhangen.obsidian-vaultkeeper` namespace — visible in `crontab -l` (Linux) or `launchctl list | grep obsidian-vaultkeeper` (macOS) for audits.
+Either way the keeper registers under the `com.nhangen.obsidian-vaultkeeper` namespace — visible in `crontab -l` (Linux) or `launchctl list | grep obsidian-vaultkeeper` (macOS) for audits.
 
 ### No CEO writes
 

--- a/obsidian.local.md.example
+++ b/obsidian.local.md.example
@@ -13,6 +13,7 @@ moc_promotion_threshold: 3
 frontmatter_required: tags type
 keeper_host_priority: ml-1 mbp
 keeper_interval_secs: 900
+keeper_autostart: true
 intent_high_score: 0.70
 intent_margin: 0.15
 capture_high_score: 0.70
@@ -79,9 +80,13 @@ unfiled notes / open `[ask]`s / promotable clusters into the machine-owned
 `Librarian.md`, appends only genuinely-new items to `Pending.md`, and maintains
 `_vaultkeeper.base` (a write-only GUI view — never read to answer queries).
 
-- `frontmatter_required` — keys every note should carry (seed once via
-  `scripts/seed-frontmatter-schema.sh`). The tick only *surfaces* gaps; it never
-  auto-writes frontmatter.
+- `keeper_autostart` — when not `false`, the session-end hook self-installs the
+  keeper scheduler on this host the first time it runs (seeds the schema, writes
+  these defaults, installs the namespaced launchd/cron job). Set `false` to keep
+  activation fully manual.
+- `frontmatter_required` — keys every note should carry. Seeded automatically on
+  first activation (or manually via `scripts/seed-frontmatter-schema.sh`). The
+  tick only *surfaces* gaps; it never auto-writes frontmatter.
 - `keeper_host_priority` — host election order over Syncthing (highest-priority
   live host owns shared writes; others defer). `.sync-conflict-*` files on
   keeper-owned files are quarantined under `.vaultkeeper-quarantine/`, never

--- a/scripts/install-watcher.sh
+++ b/scripts/install-watcher.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 LABEL="com.nhangen.obsidian-vaultkeeper"
 
-usage() { echo "usage: install-watcher.sh {render-launchd|render-cron|install} <tick_abs_path> [interval_secs]" >&2; exit 2; }
+usage() { echo "usage: install-watcher.sh {label|render-launchd|render-cron|install} <tick_abs_path> [interval_secs]" >&2; exit 2; }
 
 render_launchd() {
   local tick="$1" interval="$2"
@@ -50,6 +50,7 @@ install_watcher() {
 }
 
 case "${1:-}" in
+  label)          printf '%s\n' "$LABEL" ;;
   render-launchd) [ $# -ge 3 ] || usage; render_launchd "$2" "$3" ;;
   render-cron)    [ $# -ge 3 ] || usage; render_cron "$2" "$3" ;;
   install)        [ $# -ge 2 ] || usage; install_watcher "$2" "${3:-900}" ;;

--- a/scripts/install-watcher.sh
+++ b/scripts/install-watcher.sh
@@ -40,7 +40,11 @@ install_watcher() {
       local plist="$HOME/Library/LaunchAgents/${LABEL}.plist"
       render_launchd "$tick" "$interval" > "$plist"
       launchctl unload "$plist" 2>/dev/null || true
-      launchctl load "$plist"
+      if ! launchctl load "$plist"; then
+        rm -f "$plist"
+        echo "install-watcher: launchctl load failed; removed $plist (no unloaded artifact left behind)" >&2
+        exit 1
+      fi
       echo "installed launchd agent: $plist" ;;
     *)
       local line; line="$(render_cron "$tick" "$interval")"

--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# keeper-bootstrap.sh — self-activation for the vaultkeeper watcher.
+#
+# Sourced by the Stop hook (session-save.sh), which fires at the end of every
+# session on whichever host you are working on. When that host has no
+# vaultkeeper scheduler yet, keeper_ensure_active seeds the frontmatter schema,
+# writes default keeper config, and installs the namespaced scheduler — once.
+# Once the scheduler exists it runs the keeper autonomously, so every later
+# call here is a cheap no-op. Non-interactive and never aborts its caller: a
+# Stop hook cannot prompt, and activation must never break session-save.
+#
+# Per-host by necessity: Syncthing carries the vault, not a launchd plist or
+# crontab line, so each host installs its own scheduler the first time normal
+# workflow runs on it. Opt out with `keeper_autostart: false` in the config.
+
+_kb_scripts() { cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd; }
+
+# Single source of truth for the namespace label: install-watcher.sh owns it.
+keeper_label() { bash "$(_kb_scripts)/install-watcher.sh" label 2>/dev/null; }
+
+keeper_scheduler_installed() {
+  local os="${KEEPER_OS:-$(uname -s)}" label
+  label="$(keeper_label)"
+  [ -n "$label" ] || return 1
+  case "$os" in
+    Darwin) [ -f "$HOME/Library/LaunchAgents/${label}.plist" ] ;;
+    *)      crontab -l 2>/dev/null | grep -qF "# ${label}" ;;
+  esac
+}
+
+# Append "key: value" after the opening --- if the key is absent. bash 3.2 safe.
+_kb_cfg_ensure() {
+  local key="$1" val="$2" cfg="$3" tmp
+  grep -q "^${key}:" "$cfg" && return 0
+  tmp="$(mktemp "${TMPDIR:-/tmp}/kbcfg-XXXXXX")" || return 1
+  awk -v line="${key}: ${val}" '
+    NR==1 && $0=="---" { print; print line; inserted=1; next }
+    { print }
+    END { if (!inserted) print line }
+  ' "$cfg" > "$tmp" && mv "$tmp" "$cfg"
+}
+
+# keeper_ensure_active <plugin_root> <config_file> <vault_path> [interval_secs]
+keeper_ensure_active() {
+  local plugin_root="$1" cfg="$2" vault="$3" interval="${4:-900}"
+  [ -f "$cfg" ] && [ -d "$vault" ] || return 0
+
+  local autostart
+  autostart="$(grep '^keeper_autostart:' "$cfg" | head -1 | sed 's/^keeper_autostart:[[:space:]]*//')"
+  [ "$autostart" = "false" ] && return 0
+
+  keeper_scheduler_installed && return 0
+
+  local scripts; scripts="$(_kb_scripts)"
+  local tick="$scripts/vaultkeeper-tick.sh"
+  bash "$scripts/seed-frontmatter-schema.sh" "$vault" "$cfg" >/dev/null 2>&1 || true
+  _kb_cfg_ensure keeper_autostart true "$cfg" || true
+  _kb_cfg_ensure keeper_interval_secs "$interval" "$cfg" || true
+
+  if [ -n "${VAULTKEEPER_INSTALL:-}" ]; then
+    "$VAULTKEEPER_INSTALL" "$tick" "$interval" \
+      && printf 'vaultkeeper: activated watcher on this host (interval %ss)\n' "$interval" >&2
+  else
+    bash "$scripts/install-watcher.sh" install "$tick" "$interval" \
+      && printf 'vaultkeeper: activated watcher on this host (interval %ss)\n' "$interval" >&2
+  fi
+  return 0
+}

--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -26,9 +26,12 @@ keeper_scheduler_installed() {
   # before `launchctl load`, so a failed load can leave a plist that was never
   # loaded. Reading `launchctl list` (mirroring the Linux `crontab -l` branch)
   # means a not-running agent is correctly seen as absent and retried.
+  # Match the label as a whole field, not a substring: `launchctl list` puts
+  # the label in the last column, and the cron marker ends the line. Anchoring
+  # avoids a longer label that merely contains this one (anchored-identifier).
   case "$os" in
-    Darwin) launchctl list 2>/dev/null | grep -qF "$label" ;;
-    *)      crontab -l 2>/dev/null | grep -qF "# ${label}" ;;
+    Darwin) launchctl list 2>/dev/null | awk -v l="$label" '$NF==l{f=1} END{exit !f}' ;;
+    *)      crontab -l 2>/dev/null | grep -q -- "# ${label}\$" ;;
   esac
 }
 

--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -22,8 +22,12 @@ keeper_scheduler_installed() {
   local os="${KEEPER_OS:-$(uname -s)}" label
   label="$(keeper_label)"
   [ -n "$label" ] || return 1
+  # Check LIVE state, not an on-disk artifact: install-watcher writes the plist
+  # before `launchctl load`, so a failed load can leave a plist that was never
+  # loaded. Reading `launchctl list` (mirroring the Linux `crontab -l` branch)
+  # means a not-running agent is correctly seen as absent and retried.
   case "$os" in
-    Darwin) [ -f "$HOME/Library/LaunchAgents/${label}.plist" ] ;;
+    Darwin) launchctl list 2>/dev/null | grep -qF "$label" ;;
     *)      crontab -l 2>/dev/null | grep -qF "# ${label}" ;;
   esac
 }
@@ -40,29 +44,43 @@ _kb_cfg_ensure() {
   ' "$cfg" > "$tmp" && mv "$tmp" "$cfg"
 }
 
-# keeper_ensure_active <plugin_root> <config_file> <vault_path> [interval_secs]
+# keeper_ensure_active <config_file> <vault_path> [interval_secs]
 keeper_ensure_active() {
-  local plugin_root="$1" cfg="$2" vault="$3" interval="${4:-900}"
+  local cfg="$1" vault="$2" interval="${3:-900}"
   [ -f "$cfg" ] && [ -d "$vault" ] || return 0
 
   local autostart
   autostart="$(grep '^keeper_autostart:' "$cfg" | head -1 | sed 's/^keeper_autostart:[[:space:]]*//')"
   [ "$autostart" = "false" ] && return 0
 
+  # A missing/empty label means the installer is broken — that's an error to
+  # report, not a "not installed" signal to barrel past into a doomed install.
+  local label; label="$(keeper_label)"
+  if [ -z "$label" ]; then
+    printf 'vaultkeeper: cannot resolve scheduler label (install-watcher.sh broken?); skipping activation\n' >&2
+    return 0
+  fi
+
   keeper_scheduler_installed && return 0
 
   local scripts; scripts="$(_kb_scripts)"
   local tick="$scripts/vaultkeeper-tick.sh"
-  bash "$scripts/seed-frontmatter-schema.sh" "$vault" "$cfg" >/dev/null 2>&1 || true
+  if ! bash "$scripts/seed-frontmatter-schema.sh" "$vault" "$cfg" >/dev/null 2>&1; then
+    printf 'vaultkeeper: frontmatter-schema seed failed; using default (tags type)\n' >&2
+  fi
   _kb_cfg_ensure keeper_autostart true "$cfg" || true
   _kb_cfg_ensure keeper_interval_secs "$interval" "$cfg" || true
 
+  local ok=""
   if [ -n "${VAULTKEEPER_INSTALL:-}" ]; then
-    "$VAULTKEEPER_INSTALL" "$tick" "$interval" \
-      && printf 'vaultkeeper: activated watcher on this host (interval %ss)\n' "$interval" >&2
+    "$VAULTKEEPER_INSTALL" "$tick" "$interval" && ok=1
   else
-    bash "$scripts/install-watcher.sh" install "$tick" "$interval" \
-      && printf 'vaultkeeper: activated watcher on this host (interval %ss)\n' "$interval" >&2
+    bash "$scripts/install-watcher.sh" install "$tick" "$interval" && ok=1
+  fi
+  if [ -n "$ok" ]; then
+    printf 'vaultkeeper: activated watcher on this host (interval %ss)\n' "$interval" >&2
+  else
+    printf 'vaultkeeper: watcher install FAILED on this host (will retry next session); run manually: bash %s/install-watcher.sh install %s %s\n' "$scripts" "$tick" "$interval" >&2
   fi
   return 0
 }

--- a/scripts/session-save.sh
+++ b/scripts/session-save.sh
@@ -25,6 +25,12 @@ if [ -z "$VAULT_PATH" ] || [ ! -d "$VAULT_PATH" ]; then
   exit 0
 fi
 
+# Self-activate the vaultkeeper watcher on this host if it isn't scheduled yet.
+# Cheap no-op once installed; never blocks autosave (opt out: keeper_autostart: false).
+. "${SCRIPT_DIR}/lib/keeper-bootstrap.sh"
+KEEPER_INTERVAL=$(grep '^keeper_interval_secs:' "$CONFIG_FILE" | head -1 | sed 's/^keeper_interval_secs:[[:space:]]*//')
+keeper_ensure_active "$PLUGIN_ROOT" "$CONFIG_FILE" "$VAULT_PATH" "${KEEPER_INTERVAL:-900}" || true
+
 if ! command -v python3 >/dev/null 2>&1; then
   echo "session-save.sh: python3 not found; autosave requires python3 to parse hook JSON" >&2
   exit 0

--- a/scripts/session-save.sh
+++ b/scripts/session-save.sh
@@ -29,7 +29,7 @@ fi
 # Cheap no-op once installed; never blocks autosave (opt out: keeper_autostart: false).
 . "${SCRIPT_DIR}/lib/keeper-bootstrap.sh"
 KEEPER_INTERVAL=$(grep '^keeper_interval_secs:' "$CONFIG_FILE" | head -1 | sed 's/^keeper_interval_secs:[[:space:]]*//')
-keeper_ensure_active "$PLUGIN_ROOT" "$CONFIG_FILE" "$VAULT_PATH" "${KEEPER_INTERVAL:-900}" || true
+keeper_ensure_active "$CONFIG_FILE" "$VAULT_PATH" "${KEEPER_INTERVAL:-900}" || true
 
 if ! command -v python3 >/dev/null 2>&1; then
   echo "session-save.sh: python3 not found; autosave requires python3 to parse hook JSON" >&2

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -3,33 +3,50 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 . "${ROOT_DIR}/scripts/lib/keeper-bootstrap.sh"
+INSTALLER="${ROOT_DIR}/scripts/install-watcher.sh"
 
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/kb-XXXXXX")"
 trap 'rm -rf "$WORK"' EXIT
 
 # install-watcher.sh exposes the namespace label, and the bootstrap lib reads
 # from it — one source of truth, no drift between the two files.
-LABEL_FROM_INSTALLER="$(bash "${ROOT_DIR}/scripts/install-watcher.sh" label)"
-[ "$LABEL_FROM_INSTALLER" = "com.nhangen.obsidian-vaultkeeper" ] \
-  || fail "installer label drifted: '$LABEL_FROM_INSTALLER'"
-[ "$(keeper_label)" = "$LABEL_FROM_INSTALLER" ] \
-  || fail "bootstrap label '$(keeper_label)' != installer label '$LABEL_FROM_INSTALLER'"
+LABEL="$(bash "$INSTALLER" label)"
+[ "$LABEL" = "com.nhangen.obsidian-vaultkeeper" ] || fail "installer label drifted: '$LABEL'"
+[ "$(keeper_label)" = "$LABEL" ] || fail "bootstrap label '$(keeper_label)' != installer label '$LABEL'"
 
-# --- keeper_scheduler_installed: macOS file-based check ---
-FAKE_HOME="$WORK/home"; mkdir -p "$FAKE_HOME/Library/LaunchAgents"
-if HOME="$FAKE_HOME" KEEPER_OS="Darwin" keeper_scheduler_installed; then
-  fail "scheduler reported installed with no plist present"
+# Stub launchctl so the macOS detection branch reads LIVE state from a file we
+# control (a not-running agent must read as absent, not from a stale plist).
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/launchctl" <<'EOF'
+#!/usr/bin/env bash
+[ "$1" = "list" ] || exit 0
+cat "${LAUNCHCTL_STATE:-/dev/null}" 2>/dev/null || true
+EOF
+chmod +x "$WORK/bin/launchctl"
+export PATH="$WORK/bin:$PATH"
+STATE="$WORK/lc-state"; : > "$STATE"; export LAUNCHCTL_STATE="$STATE"
+
+# --- keeper_scheduler_installed reads live launchctl state, not a plist file ---
+if KEEPER_OS="Darwin" keeper_scheduler_installed; then
+  fail "scheduler reported installed when launchctl lists nothing"
 fi
-touch "$FAKE_HOME/Library/LaunchAgents/$(keeper_label).plist"
-if ! HOME="$FAKE_HOME" KEEPER_OS="Darwin" keeper_scheduler_installed; then
-  fail "scheduler reported absent when plist exists"
+printf '%s\n' "$LABEL" > "$STATE"
+if ! KEEPER_OS="Darwin" keeper_scheduler_installed; then
+  fail "scheduler reported absent when launchctl lists the label"
 fi
+: > "$STATE"   # back to not-installed for the ensure tests
+
+# --- install-contract: render output must satisfy the detection grep patterns
+# (locks the production install dispatch the ensure tests stub out, F5/F6) ---
+PLIST="$(bash "$INSTALLER" render-launchd "/x/tick.sh" 900)"
+grep -qF "$LABEL" <<<"$PLIST"            || fail "render-launchd missing label"
+grep -qF "/x/tick.sh" <<<"$PLIST"        || fail "render-launchd missing tick path"
+grep -q '<integer>900</integer>' <<<"$PLIST" || fail "render-launchd missing interval"
+CRON="$(bash "$INSTALLER" render-cron "/x/tick.sh" 900)"
+# the cron detection branch greps "# ${label}" — assert render-cron emits exactly that
+grep -qF "# ${LABEL}" <<<"$CRON" || fail "render-cron marker != cron-detection grep pattern '# ${LABEL}'"
 
 # --- keeper_ensure_active: clean state seeds + installs exactly once ---
-mk_config() {
-  local cfg="$1"
-  printf -- '---\nvault_path: %s\nauto_save: true\n---\n' "$2" > "$cfg"
-}
 mk_vault() {
   local v="$1"; mkdir -p "$v"
   printf -- '---\ntags: [a]\ntype: note\n---\nbody\n' > "$v/one.md"
@@ -37,7 +54,8 @@ mk_vault() {
 }
 
 CFG="$WORK/obsidian.local.md"; VAULT="$WORK/vault"
-mk_config "$CFG" "$VAULT"; mk_vault "$VAULT"
+printf -- '---\nvault_path: %s\nauto_save: true\n---\n' "$VAULT" > "$CFG"
+mk_vault "$VAULT"
 CALLS="$WORK/install-calls.log"; : > "$CALLS"
 export VAULTKEEPER_INSTALL="$WORK/stub-install.sh"
 cat > "$VAULTKEEPER_INSTALL" <<EOF
@@ -46,11 +64,7 @@ printf '%s\n' "\$*" >> "$CALLS"
 EOF
 chmod +x "$VAULTKEEPER_INSTALL"
 
-FAKE_HOME2="$WORK/home2"; mkdir -p "$FAKE_HOME2/Library/LaunchAgents"
-run_ensure() {
-  HOME="$FAKE_HOME2" KEEPER_OS="Darwin" \
-    keeper_ensure_active "$ROOT_DIR" "$CFG" "$VAULT" 900
-}
+run_ensure() { KEEPER_OS="Darwin" keeper_ensure_active "$CFG" "$VAULT" 900; }
 
 run_ensure || fail "ensure_active returned non-zero on clean state"
 grep -q '^frontmatter_required:' "$CFG" || fail "schema not seeded into config"
@@ -58,27 +72,42 @@ grep -q '^keeper_autostart:' "$CFG" || fail "keeper_autostart default not writte
 [ "$(wc -l < "$CALLS" | tr -d ' ')" = "1" ] || fail "expected exactly one install call, got $(cat "$CALLS")"
 grep -q 'vaultkeeper-tick.sh' "$CALLS" || fail "install call missing tick path"
 
-# Simulate the install having landed the plist, then re-run: must be a no-op.
-touch "$FAKE_HOME2/Library/LaunchAgents/$(keeper_label).plist"
+# Simulate the agent now being loaded, then re-run: must be a no-op.
+printf '%s\n' "$LABEL" > "$STATE"
 run_ensure || fail "ensure_active returned non-zero when already installed"
 [ "$(wc -l < "$CALLS" | tr -d ' ')" = "1" ] \
   || fail "ensure_active re-installed when already active (not idempotent): $(cat "$CALLS")"
+: > "$STATE"
+
+# --- failed install is surfaced (not silent) and not recorded as success ---
+FAILCALLS="$WORK/fail-calls.log"; : > "$FAILCALLS"
+export VAULTKEEPER_INSTALL="$WORK/stub-fail.sh"
+cat > "$VAULTKEEPER_INSTALL" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$FAILCALLS"
+exit 1
+EOF
+chmod +x "$VAULTKEEPER_INSTALL"
+CFGF="$WORK/fail.local.md"; VAULTF="$WORK/vaultf"
+printf -- '---\nvault_path: %s\n---\n' "$VAULTF" > "$CFGF"
+mk_vault "$VAULTF"
+ERR="$(KEEPER_OS="Darwin" keeper_ensure_active "$CFGF" "$VAULTF" 900 2>&1 >/dev/null)" \
+  || fail "ensure_active must return 0 even when install fails (never abort the hook)"
+[ -s "$FAILCALLS" ] || fail "failing install was never attempted"
+grep -qi 'FAILED' <<<"$ERR" || fail "failed install was silent — no diagnostic emitted: '$ERR'"
 
 # --- opt-out: keeper_autostart: false skips install entirely ---
 CFG2="$WORK/optout.local.md"; VAULT2="$WORK/vault2"
 printf -- '---\nvault_path: %s\nkeeper_autostart: false\n---\n' "$VAULT2" > "$CFG2"
 mk_vault "$VAULT2"
 CALLS2="$WORK/install-calls2.log"; : > "$CALLS2"
-FAKE_HOME3="$WORK/home3"; mkdir -p "$FAKE_HOME3/Library/LaunchAgents"
-VAULTKEEPER_INSTALL_BAK="$VAULTKEEPER_INSTALL"
 export VAULTKEEPER_INSTALL="$WORK/stub-install2.sh"
 cat > "$VAULTKEEPER_INSTALL" <<EOF
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "$CALLS2"
 EOF
 chmod +x "$VAULTKEEPER_INSTALL"
-HOME="$FAKE_HOME3" KEEPER_OS="Darwin" \
-  keeper_ensure_active "$ROOT_DIR" "$CFG2" "$VAULT2" 900 \
+KEEPER_OS="Darwin" keeper_ensure_active "$CFG2" "$VAULT2" 900 \
   || fail "ensure_active returned non-zero on opt-out config"
 [ ! -s "$CALLS2" ] || fail "keeper_autostart:false still installed: $(cat "$CALLS2")"
 

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+. "${ROOT_DIR}/scripts/lib/keeper-bootstrap.sh"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/kb-XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# install-watcher.sh exposes the namespace label, and the bootstrap lib reads
+# from it — one source of truth, no drift between the two files.
+LABEL_FROM_INSTALLER="$(bash "${ROOT_DIR}/scripts/install-watcher.sh" label)"
+[ "$LABEL_FROM_INSTALLER" = "com.nhangen.obsidian-vaultkeeper" ] \
+  || fail "installer label drifted: '$LABEL_FROM_INSTALLER'"
+[ "$(keeper_label)" = "$LABEL_FROM_INSTALLER" ] \
+  || fail "bootstrap label '$(keeper_label)' != installer label '$LABEL_FROM_INSTALLER'"
+
+# --- keeper_scheduler_installed: macOS file-based check ---
+FAKE_HOME="$WORK/home"; mkdir -p "$FAKE_HOME/Library/LaunchAgents"
+if HOME="$FAKE_HOME" KEEPER_OS="Darwin" keeper_scheduler_installed; then
+  fail "scheduler reported installed with no plist present"
+fi
+touch "$FAKE_HOME/Library/LaunchAgents/$(keeper_label).plist"
+if ! HOME="$FAKE_HOME" KEEPER_OS="Darwin" keeper_scheduler_installed; then
+  fail "scheduler reported absent when plist exists"
+fi
+
+# --- keeper_ensure_active: clean state seeds + installs exactly once ---
+mk_config() {
+  local cfg="$1"
+  printf -- '---\nvault_path: %s\nauto_save: true\n---\n' "$2" > "$cfg"
+}
+mk_vault() {
+  local v="$1"; mkdir -p "$v"
+  printf -- '---\ntags: [a]\ntype: note\n---\nbody\n' > "$v/one.md"
+  printf -- '---\ntags: [b]\ntype: note\n---\nbody\n' > "$v/two.md"
+}
+
+CFG="$WORK/obsidian.local.md"; VAULT="$WORK/vault"
+mk_config "$CFG" "$VAULT"; mk_vault "$VAULT"
+CALLS="$WORK/install-calls.log"; : > "$CALLS"
+export VAULTKEEPER_INSTALL="$WORK/stub-install.sh"
+cat > "$VAULTKEEPER_INSTALL" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$CALLS"
+EOF
+chmod +x "$VAULTKEEPER_INSTALL"
+
+FAKE_HOME2="$WORK/home2"; mkdir -p "$FAKE_HOME2/Library/LaunchAgents"
+run_ensure() {
+  HOME="$FAKE_HOME2" KEEPER_OS="Darwin" \
+    keeper_ensure_active "$ROOT_DIR" "$CFG" "$VAULT" 900
+}
+
+run_ensure || fail "ensure_active returned non-zero on clean state"
+grep -q '^frontmatter_required:' "$CFG" || fail "schema not seeded into config"
+grep -q '^keeper_autostart:' "$CFG" || fail "keeper_autostart default not written"
+[ "$(wc -l < "$CALLS" | tr -d ' ')" = "1" ] || fail "expected exactly one install call, got $(cat "$CALLS")"
+grep -q 'vaultkeeper-tick.sh' "$CALLS" || fail "install call missing tick path"
+
+# Simulate the install having landed the plist, then re-run: must be a no-op.
+touch "$FAKE_HOME2/Library/LaunchAgents/$(keeper_label).plist"
+run_ensure || fail "ensure_active returned non-zero when already installed"
+[ "$(wc -l < "$CALLS" | tr -d ' ')" = "1" ] \
+  || fail "ensure_active re-installed when already active (not idempotent): $(cat "$CALLS")"
+
+# --- opt-out: keeper_autostart: false skips install entirely ---
+CFG2="$WORK/optout.local.md"; VAULT2="$WORK/vault2"
+printf -- '---\nvault_path: %s\nkeeper_autostart: false\n---\n' "$VAULT2" > "$CFG2"
+mk_vault "$VAULT2"
+CALLS2="$WORK/install-calls2.log"; : > "$CALLS2"
+FAKE_HOME3="$WORK/home3"; mkdir -p "$FAKE_HOME3/Library/LaunchAgents"
+VAULTKEEPER_INSTALL_BAK="$VAULTKEEPER_INSTALL"
+export VAULTKEEPER_INSTALL="$WORK/stub-install2.sh"
+cat > "$VAULTKEEPER_INSTALL" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$CALLS2"
+EOF
+chmod +x "$VAULTKEEPER_INSTALL"
+HOME="$FAKE_HOME3" KEEPER_OS="Darwin" \
+  keeper_ensure_active "$ROOT_DIR" "$CFG2" "$VAULT2" 900 \
+  || fail "ensure_active returned non-zero on opt-out config"
+[ ! -s "$CALLS2" ] || fail "keeper_autostart:false still installed: $(cat "$CALLS2")"
+
+# --- wiring: the Stop hook actually invokes the bootstrap ---
+SAVE="${ROOT_DIR}/scripts/session-save.sh"
+grep -q 'keeper-bootstrap.sh' "$SAVE" || fail "session-save.sh does not source keeper-bootstrap.sh"
+grep -q 'keeper_ensure_active' "$SAVE" || fail "session-save.sh never calls keeper_ensure_active"
+
+echo "PASS: keeper-bootstrap"


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

The merged vaultkeeper substrate (PR #19) shipped with a **manual ignition**: the engine did nothing until a human ran `install-watcher.sh` by hand. This wires activation into the session-end hook so the keeper turns itself on during normal workflow — matching the design intent that the plugin should notice it isn't set up and take care of the bulk of the work itself.

**New behavior:**
- **`scripts/lib/keeper-bootstrap.sh`** — `keeper_ensure_active()` is idempotent. On a host with no scheduler yet, it seeds the frontmatter schema, writes default keeper config, and installs the namespaced launchd/cron job. Once the scheduler exists, every later call is a cheap no-op (one label lookup + one file-existence check).
- **`scripts/session-save.sh`** (the Stop hook, fires every session end) calls `keeper_ensure_active` after the vault check. First session-end on a dormant host activates the keeper; later runs no-op. The call is non-interactive (a Stop hook can't prompt) and never aborts autosave.
- **`scripts/install-watcher.sh`** gains a `label` subcommand so the `com.nhangen.obsidian-vaultkeeper` namespace string has one source of truth, shared with the bootstrap lib (no drift).
- **`keeper_autostart`** config key (default `true`) opts out of self-activation.

**Per-host by necessity:** Syncthing carries the vault, not a launchd plist / crontab line, so each host self-activates the first time normal workflow runs on it. Documented in README + example config.

Also updates README (manual "Install" → automatic "Activation") and `obsidian.local.md.example` (documents `keeper_autostart`).

## Testing Procedure

1. Check out this branch.
2. Run the full suite: `bash tests/run-all.sh` — expect `ALL PASS` (19 suites).
3. Run the new suite under the bash-3.2 floor: `/bin/bash tests/keeper-bootstrap.sh` — expect `PASS: keeper-bootstrap`. Covers: label parity between installer and bootstrap lib, the installed/absent scheduler check, clean-state seed+install (exactly one install call, schema seeded, defaults written), idempotent re-run (no second install once the plist exists), `keeper_autostart: false` opt-out (no install), and the Stop-hook wiring.
4. Mutation check: delete the `keeper_ensure_active` line from `scripts/session-save.sh` and re-run `tests/keeper-bootstrap.sh` — it must FAIL (the wiring assertion bites). Restore it.
5. `bash -n` parses clean on all changed shell files.

## Additional Notes / HelpScout Tickets

- The bootstrap rides on the Stop hook only; it's gated behind the same `auto_save` check, so a user who disabled autosave stays in manual mode (the manual `install-watcher.sh install` path is retained and documented). A second trigger on the commit-capture hook was considered and deferred (YAGNI — one normal-workflow trigger is sufficient).
- No CEO writes; keeper remains plugin-owned. Installing a launchd agent on the MacBook is expected here (not subject to `ceo-scan-only-on-ml1`) — the keeper runs on every host that writes the vault, by design.