### PR TITLE
Bump plugin version to 1.9.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

PR #20 (vaultkeeper self-activation) merged under the same `1.9.0` as PR #19, so the marketplace had no version delta to surface as an update — a host already on 1.9.0 would see nothing new and never pull the autostart code. Bumps `plugin.json` to `1.9.1` so the feature is installable. No code change.

## Testing Procedure

1. Check out this branch.
2. `python3 -c "import json; print(json.load(open('.claude-plugin/plugin.json'))['version'])"` → `1.9.1`.
3. `bash tests/run-all.sh` → `ALL PASS` (version string is inert to tests; run to honor test-before-commit).

## Additional Notes / HelpScout Tickets

Companion change required outside this repo: the personal marketplace manifest (`~/ML-AI/claude/plugins/.claude-plugin/marketplace.json`) pins the obsidian entry at a stale `1.7.1` with a pre-librarian description — that is the actual update gate and must move to `1.9.1` in lockstep.