### PR TITLE
Surface missing config via a SessionStart advisory (config-doctor)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The keeper writes only to the Obsidian vault (`vault_path` from `obsidian.local.
 
 | Event | Script | Behavior |
 |---|---|---|
+| `SessionStart` | `scripts/config-doctor.sh` | If the plugin is installed but unconfigured on this host (no `obsidian.local.md`) while a synced vault is detectable, surfaces an advisory so the agent can offer `/obsidian:setup`. Silent once configured, and silent on hosts with no vault. Advisory only — a hook can't prompt. |
 | `Stop` | `scripts/session-save.sh` | Auto-saves significant sessions via background `claude --print` summarizer. Skips trivial sessions. |
 | `PostToolUse` (Bash) | `scripts/commit-capture.sh` | After a successful `git commit`, appends a context block to `<vault>/Projects/Development/<org>_<repo>/<YYYY-MM-DD>.md`. Per-repo overrides supported (e.g. `altamira2/mtf-builder` → flat `<vault>/Altamira/<date>-mtf-builder-commits.md`). |
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/config-doctor.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/scripts/config-doctor.sh
+++ b/scripts/config-doctor.sh
@@ -2,12 +2,12 @@
 # config-doctor.sh — SessionStart hook.
 #
 # Turns the silent "plugin installed but unconfigured" state into a visible
-# advisory. When no obsidian.local.md resolves on this host but a synced vault
-# is detectable, emit a SessionStart additionalContext message so the agent
-# surfaces it and can offer /obsidian:setup. Without config the Stop hook
-# (autosave) and the vaultkeeper watcher silently no-op, so the missing config
-# is otherwise invisible — that gap is exactly what cost a long investigation
-# on ML-1.
+# advisory. When the plugin is not usefully configured on this host but a synced
+# vault is detectable, emit a SessionStart additionalContext message so the
+# agent surfaces it and can offer /obsidian:setup. Without usable config the
+# Stop hook (autosave) and the vaultkeeper watcher silently no-op, so the
+# missing config is otherwise invisible — that gap cost a long investigation on
+# ML-1 (vault synced, plugin never set up there).
 #
 # Advisory only: a hook cannot prompt for input (additionalContext is injected
 # context, not an interactive dialog — see ~/.claude/rules/claude-code-hook-output-semantics).
@@ -18,14 +18,30 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
 . "${SCRIPT_DIR}/lib/resolve-config.sh"
 
-# Config already present -> nothing to advise.
-if resolve_obsidian_config "$PLUGIN_ROOT" >/dev/null 2>&1; then
-  exit 0
+# Opt-out, for a host that has a vault but is deliberately not wired to the
+# plugin. Lives OUTSIDE obsidian.local.md (which by definition is absent on the
+# advisory path), so an env var or a sentinel file in the config dir.
+SILENCE_FILE="$(dirname "$(obsidian_config_stable_path)")/.doctor-silence"
+[ -n "${OBSIDIAN_DOCTOR_SILENCE:-}" ] && exit 0
+[ -f "$SILENCE_FILE" ] && exit 0
+
+# A resolved file that is empty or has no vault_path is NOT usable config — the
+# autosave + keeper hooks also no-op on it, so treating it as healthy would
+# recreate the invisible misconfig this hook exists to surface.
+STATE="missing"   # missing | incomplete | ok
+CFG="$(resolve_obsidian_config "$PLUGIN_ROOT" 2>/dev/null || true)"
+if [ -n "$CFG" ] && [ -f "$CFG" ]; then
+  if grep -q '^vault_path:[[:space:]]*[^[:space:]]' "$CFG"; then
+    STATE="ok"
+  else
+    STATE="incomplete"
+  fi
 fi
+[ "$STATE" = "ok" ] && exit 0
 
 # Only advise where there is plausibly something to configure: a synced vault
-# is present but unconfigured. Hosts with no vault aren't meant to run the
-# plugin, so stay silent there rather than nag every session.
+# present but unconfigured. The list is the known-locations allowlist; a vault
+# at a custom path stays silent rather than triggering a $HOME-wide scan.
 HINT=""
 for d in "$HOME/Documents/Obsidian" "$HOME/Obsidian" "$HOME/sync/Obsidian" "$HOME/vault"; do
   if [ -d "$d" ]; then HINT="$d"; break; fi
@@ -35,9 +51,22 @@ done
 HOST="$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo 'this host')"
 STABLE="$(obsidian_config_stable_path)"
 
-json_escape() { local s="$1"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '"%s"' "$s"; }
+# Escape for a JSON string: backslash, quote, and the control chars that can
+# legally appear in a path/hostname. JSON forbids raw control chars, so an
+# unescaped newline/tab would make the whole object invalid and drop the advisory.
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"; s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"; s="${s//$'\r'/\\r}"; s="${s//$'\t'/\\t}"
+  printf '"%s"' "$s"
+}
 
-MSG="Obsidian plugin is installed on ${HOST} but not configured (no obsidian.local.md at ${STABLE}). A synced vault appears to be at ${HINT}, but autosave, commit-capture, and the vaultkeeper watcher are all dormant until configured. Offer to run /obsidian:setup to enable them."
+if [ "$STATE" = "incomplete" ]; then
+  WHAT="present but incomplete (no vault_path in ${CFG})"
+else
+  WHAT="missing (no obsidian.local.md at ${STABLE})"
+fi
+MSG="Obsidian plugin is installed on ${HOST} but its config is ${WHAT}. A synced vault appears to be at ${HINT}, while autosave, commit-capture, and the vaultkeeper watcher stay dormant until it is configured. Offer to run /obsidian:setup to enable them, or 'touch ${SILENCE_FILE}' to dismiss this notice."
 
 printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' \
   "$(json_escape "$MSG")"

--- a/scripts/config-doctor.sh
+++ b/scripts/config-doctor.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# config-doctor.sh — SessionStart hook.
+#
+# Turns the silent "plugin installed but unconfigured" state into a visible
+# advisory. When no obsidian.local.md resolves on this host but a synced vault
+# is detectable, emit a SessionStart additionalContext message so the agent
+# surfaces it and can offer /obsidian:setup. Without config the Stop hook
+# (autosave) and the vaultkeeper watcher silently no-op, so the missing config
+# is otherwise invisible — that gap is exactly what cost a long investigation
+# on ML-1.
+#
+# Advisory only: a hook cannot prompt for input (additionalContext is injected
+# context, not an interactive dialog — see ~/.claude/rules/claude-code-hook-output-semantics).
+# It makes the state discoverable; the agent relays it and the human runs setup.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+. "${SCRIPT_DIR}/lib/resolve-config.sh"
+
+# Config already present -> nothing to advise.
+if resolve_obsidian_config "$PLUGIN_ROOT" >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Only advise where there is plausibly something to configure: a synced vault
+# is present but unconfigured. Hosts with no vault aren't meant to run the
+# plugin, so stay silent there rather than nag every session.
+HINT=""
+for d in "$HOME/Documents/Obsidian" "$HOME/Obsidian" "$HOME/sync/Obsidian" "$HOME/vault"; do
+  if [ -d "$d" ]; then HINT="$d"; break; fi
+done
+[ -n "$HINT" ] || exit 0
+
+HOST="$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo 'this host')"
+STABLE="$(obsidian_config_stable_path)"
+
+json_escape() { local s="$1"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '"%s"' "$s"; }
+
+MSG="Obsidian plugin is installed on ${HOST} but not configured (no obsidian.local.md at ${STABLE}). A synced vault appears to be at ${HINT}, but autosave, commit-capture, and the vaultkeeper watcher are all dormant until configured. Offer to run /obsidian:setup to enable them."
+
+printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' \
+  "$(json_escape "$MSG")"
+exit 0

--- a/tests/config-doctor.sh
+++ b/tests/config-doctor.sh
@@ -7,32 +7,60 @@ DOCTOR="${ROOT_DIR}/scripts/config-doctor.sh"
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/cd-XXXXXX")"
 trap 'rm -rf "$WORK"' EXIT
 
-# Run the hook with a controlled HOME/XDG so config resolution is deterministic
-# and not affected by the developer's real machine.
+# Run the hook with a controlled HOME/XDG so config resolution is deterministic.
 run_doctor() {
   HOME="$1" XDG_CONFIG_HOME="$1/.config" OBSIDIAN_LOCAL_MD="" bash "$DOCTOR"
 }
 
-# --- config present -> silent (nothing to advise) ---
+# --- config present + usable -> silent ---
 H1="$WORK/h1"; mkdir -p "$H1/.config/claude-obsidian" "$H1/Documents/Obsidian"
 printf -- '---\nvault_path: %s\n---\n' "$H1/Documents/Obsidian" \
   > "$H1/.config/claude-obsidian/obsidian.local.md"
 OUT="$(run_doctor "$H1")"
-[ -z "$OUT" ] || fail "config present must emit nothing, got: $OUT"
+[ -z "$OUT" ] || fail "usable config must emit nothing, got: $OUT"
 
-# --- config absent + a synced vault is detectable -> advisory ---
+# --- config absent + a synced vault is detectable -> advisory (valid JSON) ---
 H2="$WORK/h2"; mkdir -p "$H2/.config" "$H2/Documents/Obsidian"
 OUT="$(run_doctor "$H2")"
-[ -n "$OUT" ] || fail "config absent + vault present must emit an advisory"
+[ -n "$OUT" ] || fail "config absent + vault present must advise"
 python3 -c "
 import json,sys
 d=json.loads('''$OUT''')
 o=d['hookSpecificOutput']
+assert set(o.keys())=={'hookEventName','additionalContext'}, o   # exact shape, not just substring
 assert o['hookEventName']=='SessionStart', o
 ctx=o['additionalContext']
-assert 'obsidian:setup' in ctx, ctx
-assert 'Documents/Obsidian' in ctx, ctx
-" || fail "advisory JSON malformed or missing setup/vault reference: $OUT"
+assert 'obsidian:setup' in ctx and 'Documents/Obsidian' in ctx, ctx
+" || fail "advisory JSON malformed / wrong shape: $OUT"
+
+# --- config present but INCOMPLETE (no vault_path) -> advisory ---
+H4="$WORK/h4"; mkdir -p "$H4/.config/claude-obsidian" "$H4/Documents/Obsidian"
+printf -- '---\nauto_save: true\n---\n' > "$H4/.config/claude-obsidian/obsidian.local.md"
+OUT="$(run_doctor "$H4")"
+[ -n "$OUT" ] || fail "incomplete config (no vault_path) must advise"
+echo "$OUT" | python3 -c "import json,sys;c=json.load(sys.stdin)['hookSpecificOutput']['additionalContext'];assert 'incomplete' in c, c" \
+  || fail "incomplete-config advisory should say 'incomplete': $OUT"
+
+# --- control chars in the interpolated path -> still valid JSON (F1 regression) ---
+HW="$WORK/we\"ird"$'\n'"path"; mkdir -p "$HW/.config" "$HW/Documents/Obsidian"
+OUT="$(run_doctor "$HW")"
+[ -n "$OUT" ] || fail "weird-path host should still advise"
+printf '%s' "$OUT" | python3 -c "
+import json,sys
+d=json.loads(sys.stdin.read())   # fails if newline/quote/backslash left unescaped
+assert 'obsidian:setup' in d['hookSpecificOutput']['additionalContext']
+" || fail "control-char/quote path produced invalid JSON: $OUT"
+
+# --- opt-out: env var silences ---
+H5="$WORK/h5"; mkdir -p "$H5/.config" "$H5/Documents/Obsidian"
+OUT="$(HOME="$H5" XDG_CONFIG_HOME="$H5/.config" OBSIDIAN_LOCAL_MD="" OBSIDIAN_DOCTOR_SILENCE=1 bash "$DOCTOR")"
+[ -z "$OUT" ] || fail "OBSIDIAN_DOCTOR_SILENCE=1 must silence the advisory, got: $OUT"
+
+# --- opt-out: sentinel file silences ---
+H6="$WORK/h6"; mkdir -p "$H6/.config/claude-obsidian" "$H6/Documents/Obsidian"
+touch "$H6/.config/claude-obsidian/.doctor-silence"
+OUT="$(run_doctor "$H6")"
+[ -z "$OUT" ] || fail "sentinel .doctor-silence must silence the advisory, got: $OUT"
 
 # --- config absent + NO vault anywhere -> silent (don't nag unrelated hosts) ---
 H3="$WORK/h3"; mkdir -p "$H3/.config"

--- a/tests/config-doctor.sh
+++ b/tests/config-doctor.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+DOCTOR="${ROOT_DIR}/scripts/config-doctor.sh"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/cd-XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# Run the hook with a controlled HOME/XDG so config resolution is deterministic
+# and not affected by the developer's real machine.
+run_doctor() {
+  HOME="$1" XDG_CONFIG_HOME="$1/.config" OBSIDIAN_LOCAL_MD="" bash "$DOCTOR"
+}
+
+# --- config present -> silent (nothing to advise) ---
+H1="$WORK/h1"; mkdir -p "$H1/.config/claude-obsidian" "$H1/Documents/Obsidian"
+printf -- '---\nvault_path: %s\n---\n' "$H1/Documents/Obsidian" \
+  > "$H1/.config/claude-obsidian/obsidian.local.md"
+OUT="$(run_doctor "$H1")"
+[ -z "$OUT" ] || fail "config present must emit nothing, got: $OUT"
+
+# --- config absent + a synced vault is detectable -> advisory ---
+H2="$WORK/h2"; mkdir -p "$H2/.config" "$H2/Documents/Obsidian"
+OUT="$(run_doctor "$H2")"
+[ -n "$OUT" ] || fail "config absent + vault present must emit an advisory"
+python3 -c "
+import json,sys
+d=json.loads('''$OUT''')
+o=d['hookSpecificOutput']
+assert o['hookEventName']=='SessionStart', o
+ctx=o['additionalContext']
+assert 'obsidian:setup' in ctx, ctx
+assert 'Documents/Obsidian' in ctx, ctx
+" || fail "advisory JSON malformed or missing setup/vault reference: $OUT"
+
+# --- config absent + NO vault anywhere -> silent (don't nag unrelated hosts) ---
+H3="$WORK/h3"; mkdir -p "$H3/.config"
+OUT="$(run_doctor "$H3")"
+[ -z "$OUT" ] || fail "no config + no vault must stay silent, got: $OUT"
+
+# --- wiring: hooks.json registers the SessionStart hook ---
+HJ="${ROOT_DIR}/hooks/hooks.json"
+python3 -c "
+import json
+h=json.load(open('$HJ'))['hooks']
+assert 'SessionStart' in h, 'no SessionStart hook registered'
+cmds=[hk['command'] for grp in h['SessionStart'] for hk in grp['hooks']]
+assert any('config-doctor.sh' in c for c in cmds), cmds
+" || fail "hooks.json does not register config-doctor.sh on SessionStart"
+
+echo "PASS: config-doctor"


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

Without an `obsidian.local.md`, the `Stop` hook (autosave) and the vaultkeeper watcher both silently `exit 0` — an unconfigured host is completely invisible. That's exactly the state that hid for a full debugging investigation on ML-1: the vault was synced there, but the plugin had never been set up, so the keeper could never self-activate and nothing said why.

Adds a `SessionStart` hook that makes the missing-config state discoverable:

- **`scripts/config-doctor.sh`** — resolves config; if present, silent. If **absent** *and* a synced vault is detectable (`~/Documents/Obsidian`, `~/Obsidian`, `~/sync/Obsidian`, `~/vault`), emits a `SessionStart` `additionalContext` advisory naming the host, the detected vault, and the `/obsidian:setup` command. Silent on hosts with no vault (don't nag machines not meant to run the plugin).
- **Advisory only, by design.** A hook cannot prompt — `additionalContext` is injected context, not an interactive dialog (`claude-code-hook-output-semantics`). The copy says "offer to run /obsidian:setup," not a false "blocked"/"required." The agent relays it and offers setup; the human decides.
- Registered on `SessionStart` in `hooks.json`; documented in the README Hooks table.
- Bumps plugin to **1.9.2** so the marketplace surfaces it as an update (the version-collision lesson from #20/#21).

## Testing Procedure

1. Check out this branch.
2. `bash tests/run-all.sh` → `ALL PASS` (20 suites). New suite: `bash tests/config-doctor.sh` → `PASS`.
3. Covers: config present → silent; config absent + vault present → valid-JSON advisory naming `/obsidian:setup` + the vault; config absent + no vault → silent; and the `hooks.json` SessionStart wiring.
4. Mutation check: replace the advisory `printf` in `config-doctor.sh` with `exit 0` and re-run `tests/config-doctor.sh` — it must FAIL. Restore.
5. `python3 -c "import json; json.load(open('hooks/hooks.json'))"` and `/bin/bash -n scripts/config-doctor.sh` both clean (bash 3.2 floor).

## Additional Notes / HelpScout Tickets

This is the config-presence analog of the vaultkeeper self-activation (#20): same "notice it isn't set up and surface it" principle, one layer earlier. Marketplace manifest (`nhangen/claude-plugins`) needs to follow to 1.9.2 in lockstep for the update to reach hosts.