### PR TITLE
Fix: vault-organizer resolves vault path per-host

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/agents/vault-organizer.md
+++ b/agents/vault-organizer.md
@@ -8,7 +8,14 @@ You are a specialized agent for analyzing and reorganizing the Obsidian vault.
 
 ## Vault
 
-`/mnt/z/Users/nhang/Documents/Obsidian` (WSL alias: `~/obsidian`)
+Find the vault path for THIS machine — never hardcode it. Read `vault_path` from the per-host config:
+
+```bash
+CONFIG="${OBSIDIAN_LOCAL_MD:-${XDG_CONFIG_HOME:-$HOME/.config}/claude-obsidian/obsidian.local.md}"
+VAULT=$(grep -m1 '^vault_path:' "$CONFIG" | sed 's/^vault_path:[[:space:]]*//')
+```
+
+(Same config the obsidian skills use. e.g. `/Users/nhangen/Documents/Obsidian` on macOS, `/mnt/z/Users/nhang/Documents/Obsidian` on WSL.) If the config is missing, stop and ask the user to run `/obsidian:setup`.
 
 ## Taxonomy
 

--- a/agents/vault-organizer.md
+++ b/agents/vault-organizer.md
@@ -12,7 +12,7 @@ Find the vault path for THIS machine — never hardcode it. Read `vault_path` fr
 
 ```bash
 CONFIG="${OBSIDIAN_LOCAL_MD:-${XDG_CONFIG_HOME:-$HOME/.config}/claude-obsidian/obsidian.local.md}"
-VAULT=$(grep -m1 '^vault_path:' "$CONFIG" | sed 's/^vault_path:[[:space:]]*//')
+VAULT=$(grep -m1 '^vault_path:' "$CONFIG" | sed 's/^vault_path:[[:space:]]*//; s/[[:space:]]*#.*//; s/^"//; s/"[[:space:]]*$//; s/[[:space:]]*$//')
 ```
 
 (Same config the obsidian skills use. e.g. `/Users/nhangen/Documents/Obsidian` on macOS, `/mnt/z/Users/nhang/Documents/Obsidian` on WSL.) If the config is missing, stop and ask the user to run `/obsidian:setup`.
@@ -34,7 +34,7 @@ TARS/             — AI agent configs
 
 ## Process
 
-1. Get full vault tree: `find ~/obsidian -name "*.md" -not -path "*/.obsidian/*" | sort`
+1. Get full vault tree: `find "$VAULT" -name "*.md" -not -path "*/.obsidian/*" | sort`
 2. Identify issues:
    - Files in wrong domain folder
    - Notes in root that should be in a subfolder
@@ -43,7 +43,7 @@ TARS/             — AI agent configs
 3. Build a proposed move list — every change as `OLD → NEW`
 4. Present to user for approval — include count of changes
 5. On approval:
-   a. Write rollback manifest to `Reference/vault-reorg-YYYY-MM-DD.md`
+   a. Write rollback manifest to `$VAULT/Reference/vault-reorg-YYYY-MM-DD.md`
    b. Execute each move with `mv`
    c. Report completion summary
 6. On rejection: ask what to adjust, re-propose


### PR DESCRIPTION
Closes #none

## Description
The `vault-organizer` agent hardcoded the vault path (`/mnt/z/.../Obsidian`, WSL/ML-1 only), so it pointed at a nonexistent path on macOS. Now it reads `vault_path` from the per-host obsidian config (the same config the skills resolve), so it works on macOS and WSL. Version 1.9.2 → 1.9.3.

## Testing
1. On macOS and on WSL, dispatch the `obsidian:vault-organizer` agent.
2. Confirm it resolves the vault to the local machine's path (`/Users/nhangen/Documents/Obsidian` vs `/mnt/z/...`), not the hardcoded one.

## Notes
Agent prompt + version string only — no code path/tests affected.