### PR TITLE
docs: fix README drift and version mismatch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "obsidian",
       "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, query past work with /recall, export conversations, create/retrieve notes, and auto-organize content.",
-      "version": "1.15.0",
+      "version": "1.16.1",
       "author": {
         "name": "nhangen"
       },

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Long Claude sessions and the commits they produce hold context that's gone the m
 | `/obsidian:bookmark [label]` | Mark a chapter boundary; saved as a separate note at session end. |
 | `/obsidian:recall <query>` | Cross-search vault, git history, GitHub PRs, and claude-mem. |
 | `/obsidian:ask` | Ask the vault librarian — index-grounded answers with citations, or file new info without back-and-forth. |
+| _(trigger-only, no slash command)_ | `reorganize` — analyzes and reorganizes the vault or a project folder via the `vault-organizer` subagent; proposes a plan and waits for approval before moving anything. Triggers on phrases like "reorganize my vault", "clean up obsidian". |
 
 ### Vault Librarian
 
@@ -70,9 +71,10 @@ selection are owned by the librarian — a keeper-saved note is identical to a
 librarian-filed one.
 
 **Opt-in by design.** Calling `keeper-save` routes through the librarian.
-Not calling it bypasses the librarian entirely — existing writers are unchanged.
-No existing writer is migrated by this change; migration is a separate opt-in
-decision per writer.
+Not calling it bypasses the librarian entirely. `create-note`, `daily-note`,
+and `save-conversation` have been migrated to route their writes through
+`keeper-save` (v1.11.0–1.13.0); any other writer not yet migrated is unchanged
+until it opts in.
 
 ## vaultkeeper watcher
 
@@ -189,6 +191,11 @@ skills/*/SKILL.md             Skill logic (save, find, recall, setup, …)
 hooks/hooks.json              Stop + PostToolUse hook registration
 scripts/                      Hook executables (commit-capture, session-save, …)
 scripts/lib/resolve-config.sh Version-independent config-path resolver
+scripts/lib/allowlist-validate.sh Frontmatter/path allowlist validation shared by writers
+scripts/lib/dedup-scan.sh     Shared dedup-against-existing-notes scan
+scripts/lib/keeper-save-payload.sh Payload parsing/validation for keeper-save
+scripts/lib/vault-index.sh    Shared INDEX.md read/refresh helpers
+scripts/keeper                CLI entry point for keeper insert/append operations
 agents/                       Subagents (vault-organizer for /obsidian reorganize paths)
 integrations/                 External tool integrations
 obsidian.local.md.example     Config template (real config lives at the stable path, gitignored)


### PR DESCRIPTION
## Summary
- Bump `marketplace.json` to 1.16.1 to match `plugin.json` (canonical version source)
- Fix keeper-save section: `create-note`, `daily-note`, and `save-conversation` are already migrated to route through it (v1.11.0-1.13.0), contradicting the old "no writer migrated" claim
- Add the v1.16.0 shared libs (`allowlist-validate.sh`, `dedup-scan.sh`, `keeper-save-payload.sh`, `vault-index.sh`) and `scripts/keeper` CLI to the Architecture file tree
- Add the `reorganize` skill to the Skills table (trigger-only, no slash command — no `commands/*reorganize*` file exists)

## Follow-up (out of scope here)
`skills/reorganize/SKILL.md` hardcodes a vault path (`/mnt/z/Users/nhang/Documents/Obsidian`) instead of resolving it from config. Worth fixing in a separate PR.

## Test plan
- [x] Verified each claim against source: `plugin.json` version, grep for `keeper` in the three migrated skills, `ls scripts/lib/` + `scripts/keeper`, and absence of a reorganize command file
- [x] `git status` confirms only the two intended files changed