### PR TITLE
Index coverage: links carry their path, folders walk recursively

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "obsidian",
       "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, query past work with /recall, export conversations, create/retrieve notes, and auto-organize content.",
-      "version": "1.16.1",
+      "version": "1.16.2",
       "author": {
         "name": "nhangen"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/agents/vault-librarian.md
+++ b/agents/vault-librarian.md
@@ -36,12 +36,15 @@ slice is one or two domain folders, never the whole vault.
 
 1. Route the question to its slice (folder + INDEX).
 2. Refresh the slice: ``ADDED="$(vault_index_apply "$FOLDER" "$FOLDER/INDEX.md")"``.
-   `vault_index_apply` writes the ``- [[<title>]]`` links itself (append-only) —
-   do **not** append them by hand, that is a second implementation that drifts.
-   The `ADD` set it returns is the **coverage** result: these notes existed but
-   were not indexed. It also runs `vault_index_coverage_check`; if that reports a
-   defect on stderr, report it — state claiming more notes than `INDEX.md` links
-   means queries have been reading a narrower slice than they believed.
+   `vault_index_apply` writes the links itself (append-only), as
+   ``- [[<path/from/vault/root>]]`` — a bare basename is ambiguous once two notes
+   in different subfolders share one. Do **not** append them by hand; that is a
+   second implementation that drifts. The `ADD` set it returns on stdout is the
+   **coverage** result: these notes existed but were not indexed. If apply
+   reports `coverage defect` on stderr, links it meant to write did not land —
+   say so rather than treating the slice as complete. To assess a whole folder
+   rather than one run, call ``vault_index_coverage_check "$FOLDER"
+   "$FOLDER/INDEX.md"``; it prints every tracked note that has no link.
 3. Read only the notes the INDEX points at for the topic.
 4. **Coverage invariant:** if the slice had `ADD`/gaps you could not fully
    summarize, or the INDEX is otherwise known-incomplete, say so and lower your

--- a/agents/vault-librarian.md
+++ b/agents/vault-librarian.md
@@ -36,9 +36,12 @@ slice is one or two domain folders, never the whole vault.
 
 1. Route the question to its slice (folder + INDEX).
 2. Refresh the slice: ``ADDED="$(vault_index_apply "$FOLDER" "$FOLDER/INDEX.md")"``.
-   For each filename in `$ADDED`, append a human link ``- [[<title>]]`` to
-   `INDEX.md` (append-only; never rewrite the file). The `ADD` set is the
-   **coverage** result — these notes existed but were not indexed.
+   `vault_index_apply` writes the ``- [[<title>]]`` links itself (append-only) —
+   do **not** append them by hand, that is a second implementation that drifts.
+   The `ADD` set it returns is the **coverage** result: these notes existed but
+   were not indexed. It also runs `vault_index_coverage_check`; if that reports a
+   defect on stderr, report it — state claiming more notes than `INDEX.md` links
+   means queries have been reading a narrower slice than they believed.
 3. Read only the notes the INDEX points at for the topic.
 4. **Coverage invariant:** if the slice had `ADD`/gaps you could not fully
    summarize, or the INDEX is otherwise known-incomplete, say so and lower your
@@ -67,13 +70,14 @@ deduped.)
    silently — append an `[ask:where should this go?]` entry to `$VAULT_PATH/Pending.md`
    and ask the user once.
 2. **Dedup:** call the shared scanner — `dedup_same_day "<vault>/<folder>" "$(date +%Y-%m-%d)" "<slug>"`. If it echoes a `path<TAB>score`, surface that note and ask whether to append rather than file a duplicate — never silently merge.
-3. Write the note using the matching template in `$VAULT_PATH/Templates/`.
-   Append a link to the correct INDEX (`Decisions/INDEX.md`,
-   `Artifacts/INDEX.md`, or the domain MOC). Link session notes to the daily
-   note under `## Session Links`.
+3. Write the note using the matching template in `$VAULT_PATH/Templates/`. Its
+   INDEX link is written by step 5 (`vault_index_apply`), not by hand. Link
+   session notes to the daily note under `## Session Links`. A domain MOC that
+   is not the folder's `INDEX.md` is still a manual append.
 4. Unknown fields → `[ask]` markers in the note + entries in `Pending.md`
    (defer the question; do not interrogate the user mid-task).
-5. Refresh the touched INDEX: ``vault_index_apply "$FOLDER" "$FOLDER/INDEX.md"``.
+5. Refresh the touched INDEX: ``vault_index_apply "$FOLDER" "$FOLDER/INDEX.md"`` —
+   this is what links the new note.
 6. Return what you wrote, where, and a one-line summary.
 
 ## APPEND — "add this to today's note / log this entry"

--- a/scripts/keeper
+++ b/scripts/keeper
@@ -131,14 +131,16 @@ cmd_insert() {
   # resolves to the file — the librarian's filename-based INDEX convention.
   [ -n "$title" ] || title="$(basename "$target" .md)"
 
-  # Folder INDEX: append the human link (create INDEX on absence), then sync
-  # index state so a later QUERY won't re-emit this note as ADDED (no double link).
+  # Folder INDEX: vault_index_apply is the single link writer — it derives the
+  # resolvable target and dedups. Hand-appending here too meant a --title that
+  # differed from the stem produced two entries, the title one resolving to
+  # nothing. Keep stderr: apply's coverage report is the only signal that the
+  # slice is under-indexed.
   local idx="$folder/INDEX.md"
   [ -f "$idx" ] || printf '# %s Index\n' "$(basename "$folder")" > "$idx"
-  grep -qxF -- "- [[$title]]" "$idx" || printf -- '- [[%s]]\n' "$title" >> "$idx"
   . "$KEEPER_DIR/lib/note-hash.sh"
   . "$KEEPER_DIR/lib/vault-index.sh"
-  vault_index_apply "$folder" "$idx" >/dev/null 2>&1 || true
+  vault_index_apply "$folder" "$idx" >/dev/null || true
 
   # Optional: link the note into Daily/<date> under ## Session Links.
   if [ -n "$sldate" ]; then
@@ -146,8 +148,14 @@ cmd_insert() {
     mkdir -p "$vault_abs/Daily"
     [ -f "$daily" ] || printf -- '---\ndate: %s\ntags: [daily]\n---\n\n# %s\n' "$sldate" "$sldate" > "$daily"
     grep -q '^## Session Links' "$daily" || printf '\n## Session Links\n' >> "$daily"
-    if ! grep -qxF -- "- [[$title]]" "$daily"; then
-      awk -v link="- [[$title]]" '{print} /^## Session Links/ && !d {print link; d=1}' \
+    # Link the note by its vault-relative path so it resolves from Daily/, with
+    # the human title as an alias. Dedup on the path: two different notes can
+    # share a title, and keying on title text dropped the second one's link.
+    local ltarget="${target%.md}" link
+    link="- [[$ltarget]]"
+    [ "$title" = "$(basename "$target" .md)" ] || link="- [[$ltarget|$title]]"
+    if ! grep -qF -- "[[$ltarget]]" "$daily" && ! grep -qF -- "[[$ltarget|" "$daily"; then
+      awk -v link="$link" '{print} /^## Session Links/ && !d {print link; d=1}' \
         "$daily" > "$daily.ktmp" && mv "$daily.ktmp" "$daily"
     fi
   fi

--- a/scripts/keeper
+++ b/scripts/keeper
@@ -151,7 +151,11 @@ cmd_insert() {
     # Link the note by its vault-relative path so it resolves from Daily/, with
     # the human title as an alias. Dedup on the path: two different notes can
     # share a title, and keying on title text dropped the second one's link.
-    local ltarget="${target%.md}" link
+    local ltarget link
+    # Same target derivation as the folder INDEX (vault root = nearest .obsidian
+    # ancestor), so the two links can't disagree about where the root is when
+    # --vault points below it.
+    ltarget="$(vault_link_target "$folder" "$(basename "$target" .md)")"
     link="- [[$ltarget]]"
     [ "$title" = "$(basename "$target" .md)" ] || link="- [[$ltarget|$title]]"
     if ! grep -qF -- "[[$ltarget]]" "$daily" && ! grep -qF -- "[[$ltarget|" "$daily"; then

--- a/scripts/lib/vault-index.sh
+++ b/scripts/lib/vault-index.sh
@@ -22,17 +22,54 @@ state_hash_for() {
 # True when INDEX.md already points at this note. Fixed-string matching: note
 # titles routinely contain regex metacharacters (dates, parens, brackets, +).
 #
-# `title` may be a folder-relative path (sub/dir/note) for a note below the
-# root. A hand-written or path-form INDEX links the same note as
-# [[Vault/sub/dir/note]] while an apply-written one uses [[note]], so match on
-# the trailing segment and accept any path prefix. Matching only one form
-# re-appends a link that is already there — observed appending duplicate
-# [[TODO]] lines to an INDEX that already had [[Altamira/TODO]].
+# `rel` is the note's folder-relative path stem (`note`, or `sub/dir/note`
+# below the root). Match the WHOLE relative path, optionally behind a longer
+# prefix, so a hand-written [[Vault/sub/dir/note]] counts as the same link an
+# apply would write.
+#
+# `dup_leaves` (newline-separated, from vault_index_dup_leaves) lists basenames
+# held by more than one note in this folder. For a basename NOT in that set, a
+# bare [[note]] link is also accepted: it is unambiguous, Obsidian resolves it
+# vault-wide, and an older INDEX (or one written before a note moved into a
+# subfolder) links that form. For a basename that IS duplicated, only the full
+# path counts — matching the leaf let the first link satisfy every namesake, so
+# the rest were dropped while state still claimed them: 1001 links for 1061
+# notes under Projects/Development, and permanent, since a hashed note never
+# replans as an ADD.
 vault_index_has_link() {
-  local idx="$1" title="$2" leaf="${2##*/}"
+  local idx="$1" rel="$2" dups="${3-}" leaf="${2##*/}"
   [ -f "$idx" ] || return 1
-  grep -qF -e "[[${leaf}]]" -e "[[${leaf}|" -e "[[${leaf}#" \
-           -e "/${leaf}]]" -e "/${leaf}|" -e "/${leaf}#" -- "$idx"
+  grep -qF -e "[[${rel}]]" -e "[[${rel}|" -e "[[${rel}#" \
+           -e "/${rel}]]" -e "/${rel}|" -e "/${rel}#" -- "$idx" && return 0
+  [ "$leaf" = "$rel" ] && return 1                       # already tried as a leaf
+  grep -qxF -- "$leaf" <<<"$dups" && return 1            # ambiguous: path form required
+  grep -qF -e "[[${leaf}]]" -e "[[${leaf}|" -e "[[${leaf}#" -- "$idx"
+}
+
+# Basenames held by more than one note in the folder — the set for which a bare
+# [[leaf]] link is ambiguous and must not be treated as a match.
+vault_index_dup_leaves() {
+  find "$1" -type f -name '*.md' -exec basename {} .md \; | LC_ALL=C sort | uniq -d
+}
+
+# Link target to write for a note: vault-root-relative, because Obsidian
+# resolves a slashed target against the vault root. A folder-relative
+# `sub/dir/note` would not resolve from an INDEX below the root, and a bare
+# basename is ambiguous the moment two subfolders share one. The vault root is
+# the nearest ancestor holding `.obsidian/`; with none (tests, a bare folder)
+# fall back to the folder-relative path, which is at least unambiguous.
+vault_link_target() {
+  local folder="$1" rel="$2" abs dir
+  abs="$(cd "$folder" 2>/dev/null && pwd -P)" || { printf '%s\n' "$rel"; return; }
+  dir="$abs"
+  while [ "$dir" != "/" ]; do
+    if [ -d "$dir/.obsidian" ]; then
+      [ "$dir" = "$abs" ] && printf '%s\n' "$rel" || printf '%s/%s\n' "${abs#"$dir"/}" "$rel"
+      return
+    fi
+    dir="$(dirname "$dir")"
+  done
+  printf '%s\n' "$rel"
 }
 
 # Coverage assertion: state must never claim more notes than INDEX.md links.
@@ -55,10 +92,11 @@ vault_index_coverage_check() {
 
 vault_index_plan() {
   local folder="$1" idx="$2"
-  local state last f base stored mt cur idxbase
+  local state last f base stored mt cur idxbase dups
   state="$(index_state_file "$idx")"
   last="$(state_last_reconciled "$state")"
   idxbase="$(basename "$idx")"
+  dups="$(vault_index_dup_leaves "$folder")"
 
   # DROP: state entries whose note no longer exists at that key. A note moved
   # into a subfolder drops its stale basename key and is re-added under its
@@ -91,7 +129,7 @@ vault_index_plan() {
       printf 'ADD\t%s\n' "$base"          # coverage gap — name-only, no content read
       continue
     fi
-    if ! vault_index_has_link "$idx" "${base%.md}"; then
+    if ! vault_index_has_link "$idx" "${base%.md}" "$dups"; then
       printf 'ADD\t%s\n' "$base"          # hashed but unlinked — state drifted ahead of INDEX
       continue
     fi
@@ -163,15 +201,12 @@ vault_index_apply() {
     if [ ! -f "$idx" ]; then
       printf '# %s Index\n' "$(basename "$folder")" > "$idx"
     fi
-    local leaf
+    local rel dups
+    dups="$(vault_index_dup_leaves "$folder")"
     for fn in "${added[@]}"; do
-      # Link text is the basename, never the folder-relative path: Obsidian
-      # resolves a slashed target against the VAULT root, so [[sub/dir/note]]
-      # would not resolve from a folder INDEX. A bare basename resolves
-      # vault-wide. has_link still matches either form, so a hand-written
-      # path-form link already present is respected.
-      leaf="${fn##*/}"
-      vault_index_has_link "$idx" "${leaf%.md}" || printf -- '- [[%s]]\n' "${leaf%.md}" >> "$idx"
+      rel="${fn%.md}"
+      vault_index_has_link "$idx" "$rel" "$dups" \
+        || printf -- '- [[%s]]\n' "$(vault_link_target "$folder" "$rel")" >> "$idx"
     done
   fi
 

--- a/scripts/lib/vault-index.sh
+++ b/scripts/lib/vault-index.sh
@@ -76,10 +76,10 @@ vault_link_target() {
 # Returns 1 and reports on stderr when it does — that is a defect, not a normal
 # state, and it means queries are reading a narrower slice than they believe.
 vault_index_coverage_check() {
-  local folder="$1" idx="$2" state dups fn unlinked=0
+  local folder="$1" idx="$2" dups="${3-}" state fn unlinked=0
   state="$(index_state_file "$idx")"
   [ -f "$state" ] || return 0
-  dups="$(vault_index_dup_leaves "$folder")"
+  [ -n "$dups" ] || dups="$(vault_index_dup_leaves "$folder")"
   # Asserted per note, against the same predicate the writer dedups on. Counting
   # links instead let any surplus line — a duplicate, a link to a DROPped note,
   # a `*` bullet the count pattern missed — pay for a note that has none.
@@ -202,19 +202,30 @@ vault_index_apply() {
   # Leaving this to prose is what let state run 203 notes ahead of a 12-link
   # INDEX (#30): once state claims coverage, the note never replans as an ADD.
   # Append-only — never rewrite or reorder an existing INDEX.
+  local rel dups missed=0
   if (( ${#added[@]} )); then
     if [ ! -f "$idx" ]; then
       printf '# %s Index\n' "$(basename "$folder")" > "$idx"
     fi
-    local rel dups
     dups="$(vault_index_dup_leaves "$folder")"
     for fn in "${added[@]}"; do
       rel="${fn%.md}"
       vault_index_has_link "$idx" "$rel" "$dups" \
         || printf -- '- [[%s]]\n' "$(vault_link_target "$folder" "$rel")" >> "$idx"
     done
+    # Verify what this run was supposed to write. A full-folder sweep here would
+    # re-ask plan's question about every note — 1073 greps and a third
+    # dup_leaves pass on a large folder, all of it already answered — so scope
+    # it to the set this run touched. vault_index_coverage_check is the
+    # standalone full-folder assertion for a sweep.
+    for fn in "${added[@]}"; do
+      vault_index_has_link "$idx" "${fn%.md}" "$dups" || missed=$(( missed + 1 ))
+    done
+    if [ "$missed" -gt 0 ]; then
+      printf 'vault_index_apply: coverage defect in %s — %s link(s) could not be written\n' \
+        "$idx" "$missed" >&2
+    fi
   fi
 
-  vault_index_coverage_check "$folder" "$idx" || true
   (( ${#added[@]} )) && printf '%s\n' "${added[@]}" || true
 }

--- a/scripts/lib/vault-index.sh
+++ b/scripts/lib/vault-index.sh
@@ -76,18 +76,23 @@ vault_link_target() {
 # Returns 1 and reports on stderr when it does — that is a defect, not a normal
 # state, and it means queries are reading a narrower slice than they believe.
 vault_index_coverage_check() {
-  local idx="$2" state tracked linked
+  local folder="$1" idx="$2" state dups fn unlinked=0
   state="$(index_state_file "$idx")"
-  # Plain `[ -f x ] && y=...` would abort a `set -e` caller on an absent file.
-  tracked=0; linked=0
-  if [ -f "$state" ]; then tracked="$(grep -cv '^#' "$state" || true)"; fi
-  if [ -f "$idx" ];   then linked="$(grep -cF -- '- [[' "$idx" || true)"; fi
-  if [ "$linked" -lt "$tracked" ]; then
-    printf 'vault_index_coverage_check: coverage defect in %s — %s links for %s tracked notes\n' \
-      "$idx" "$linked" "$tracked" >&2
-    return 1
-  fi
-  return 0
+  [ -f "$state" ] || return 0
+  dups="$(vault_index_dup_leaves "$folder")"
+  # Asserted per note, against the same predicate the writer dedups on. Counting
+  # links instead let any surplus line — a duplicate, a link to a DROPped note,
+  # a `*` bullet the count pattern missed — pay for a note that has none.
+  while IFS=$'\t' read -r fn _h; do
+    case "$fn" in ''|\#*) continue ;; esac
+    vault_index_has_link "$idx" "${fn%.md}" "$dups" && continue
+    printf '%s\n' "$fn"
+    unlinked=$(( unlinked + 1 ))
+  done < "$state"
+  [ "$unlinked" -eq 0 ] && return 0
+  printf 'vault_index_coverage_check: coverage defect in %s — %s tracked note(s) have no INDEX link\n' \
+    "$idx" "$unlinked" >&2
+  return 1
 }
 
 vault_index_plan() {

--- a/scripts/lib/vault-index.sh
+++ b/scripts/lib/vault-index.sh
@@ -19,6 +19,32 @@ state_hash_for() {
   awk -F '\t' -v f="$2" '$1==f {print $2; exit}' "$1"
 }
 
+# True when INDEX.md already points at this note. Fixed-string matching: note
+# titles routinely contain regex metacharacters (dates, parens, brackets, +).
+vault_index_has_link() {
+  local idx="$1" title="$2"
+  [ -f "$idx" ] || return 1
+  grep -qF -e "[[${title}]]" -e "[[${title}|" -e "[[${title}#" -- "$idx"
+}
+
+# Coverage assertion: state must never claim more notes than INDEX.md links.
+# Returns 1 and reports on stderr when it does — that is a defect, not a normal
+# state, and it means queries are reading a narrower slice than they believe.
+vault_index_coverage_check() {
+  local idx="$2" state tracked linked
+  state="$(index_state_file "$idx")"
+  # Plain `[ -f x ] && y=...` would abort a `set -e` caller on an absent file.
+  tracked=0; linked=0
+  if [ -f "$state" ]; then tracked="$(grep -cv '^#' "$state" || true)"; fi
+  if [ -f "$idx" ];   then linked="$(grep -cF -- '- [[' "$idx" || true)"; fi
+  if [ "$linked" -lt "$tracked" ]; then
+    printf 'vault_index_coverage_check: coverage defect in %s — %s links for %s tracked notes\n' \
+      "$idx" "$linked" "$tracked" >&2
+    return 1
+  fi
+  return 0
+}
+
 vault_index_plan() {
   local folder="$1" idx="$2"
   local state last f base stored mt cur idxbase
@@ -48,6 +74,10 @@ vault_index_plan() {
     stored="$(state_hash_for "$state" "$base")"
     if [ -z "$stored" ]; then
       printf 'ADD\t%s\n' "$base"          # coverage gap — name-only, no content read
+      continue
+    fi
+    if ! vault_index_has_link "$idx" "${base%.md}"; then
+      printf 'ADD\t%s\n' "$base"          # hashed but unlinked — state drifted ahead of INDEX
       continue
     fi
     if ! note_hash_valid "$stored"; then
@@ -107,5 +137,20 @@ vault_index_apply() {
   { printf '# last_reconciled:%s\n' "$(now_epoch)"; sort "$tmp"; } > "$tmp2"
   mv "$tmp2" "$state"
   rm -f "$tmp" "$tmp2"
+
+  # Write the links here rather than returning them for a caller to remember.
+  # Leaving this to prose is what let state run 203 notes ahead of a 12-link
+  # INDEX (#30): once state claims coverage, the note never replans as an ADD.
+  # Append-only — never rewrite or reorder an existing INDEX.
+  if (( ${#added[@]} )); then
+    if [ ! -f "$idx" ]; then
+      printf '# %s Index\n' "$(basename "$folder")" > "$idx"
+    fi
+    for fn in "${added[@]}"; do
+      vault_index_has_link "$idx" "${fn%.md}" || printf -- '- [[%s]]\n' "${fn%.md}" >> "$idx"
+    done
+  fi
+
+  vault_index_coverage_check "$folder" "$idx" || true
   (( ${#added[@]} )) && printf '%s\n' "${added[@]}" || true
 }

--- a/scripts/lib/vault-index.sh
+++ b/scripts/lib/vault-index.sh
@@ -95,13 +95,39 @@ vault_index_coverage_check() {
   return 1
 }
 
+# Folder-relative prefixes (trailing slash) of subdirectories holding their own
+# INDEX.md. Those notes belong to that index; a parent indexing them too both
+# duplicates the child and dissolves the librarian's "a slice is one or two
+# folders" model — Projects/Development has 11 child indexes over 1073 notes.
+vault_index_owned_subdirs() {
+  local folder="$1" f rel
+  find "$folder" -mindepth 2 -type f -name 'INDEX.md' 2>/dev/null | while IFS= read -r f; do
+    rel="${f#"$folder"/}"
+    printf '%s/\n' "${rel%/INDEX.md}"
+  done
+}
+
+# True when a folder-relative path sits under a subtree that owns its index.
+vault_index_is_owned() {
+  local rel="$1" owned="$2" prefix
+  [ -n "$owned" ] || return 1
+  while IFS= read -r prefix; do
+    [ -n "$prefix" ] || continue
+    case "$rel" in "$prefix"*) return 0 ;; esac
+  done <<EOF
+$owned
+EOF
+  return 1
+}
+
 vault_index_plan() {
   local folder="$1" idx="$2"
-  local state last f base stored mt cur idxbase dups
+  local state last f base stored mt cur idxbase dups owned
   state="$(index_state_file "$idx")"
   last="$(state_last_reconciled "$state")"
   idxbase="$(basename "$idx")"
   dups="$(vault_index_dup_leaves "$folder")"
+  owned="$(vault_index_owned_subdirs "$folder")"
 
   # DROP: state entries whose note no longer exists at that key. A note moved
   # into a subfolder drops its stale basename key and is re-added under its
@@ -112,7 +138,11 @@ vault_index_plan() {
     while IFS=$'\t' read -r fn _h; do
       [ -z "$fn" ] && continue
       case "$fn" in \#*) continue ;; esac
-      [ -f "$folder/$fn" ] || printf 'DROP\t%s\n' "$fn"
+      if [ ! -f "$folder/$fn" ]; then
+        printf 'DROP\t%s\n' "$fn"
+      elif vault_index_is_owned "$fn" "$owned"; then
+        printf 'DROP\t%s\n' "$fn"   # a child index now owns it; hand it over
+      fi
     done < "$state"
   fi
 
@@ -129,6 +159,7 @@ vault_index_plan() {
         continue ;;
     esac
     [ "${base##*/}" = "$idxbase" ] && continue
+    vault_index_is_owned "$base" "$owned" && continue
     stored="$(state_hash_for "$state" "$base")"
     if [ -z "$stored" ]; then
       printf 'ADD\t%s\n' "$base"          # coverage gap — name-only, no content read

--- a/scripts/lib/vault-index.sh
+++ b/scripts/lib/vault-index.sh
@@ -21,10 +21,18 @@ state_hash_for() {
 
 # True when INDEX.md already points at this note. Fixed-string matching: note
 # titles routinely contain regex metacharacters (dates, parens, brackets, +).
+#
+# `title` may be a folder-relative path (sub/dir/note) for a note below the
+# root. A hand-written or path-form INDEX links the same note as
+# [[Vault/sub/dir/note]] while an apply-written one uses [[note]], so match on
+# the trailing segment and accept any path prefix. Matching only one form
+# re-appends a link that is already there — observed appending duplicate
+# [[TODO]] lines to an INDEX that already had [[Altamira/TODO]].
 vault_index_has_link() {
-  local idx="$1" title="$2"
+  local idx="$1" title="$2" leaf="${2##*/}"
   [ -f "$idx" ] || return 1
-  grep -qF -e "[[${title}]]" -e "[[${title}|" -e "[[${title}#" -- "$idx"
+  grep -qF -e "[[${leaf}]]" -e "[[${leaf}|" -e "[[${leaf}#" \
+           -e "/${leaf}]]" -e "/${leaf}|" -e "/${leaf}#" -- "$idx"
 }
 
 # Coverage assertion: state must never claim more notes than INDEX.md links.
@@ -52,7 +60,11 @@ vault_index_plan() {
   last="$(state_last_reconciled "$state")"
   idxbase="$(basename "$idx")"
 
-  # DROP: state entries whose note no longer exists.
+  # DROP: state entries whose note no longer exists at that key. A note moved
+  # into a subfolder drops its stale basename key and is re-added under its
+  # path key by the walk below; because has_link matches the trailing segment,
+  # its existing INDEX link is not duplicated. Net effect of organizing a
+  # folder is a re-key, not a loss of coverage.
   if [ -f "$state" ]; then
     while IFS=$'\t' read -r fn _h; do
       [ -z "$fn" ] && continue
@@ -61,16 +73,19 @@ vault_index_plan() {
     done < "$state"
   fi
 
-  for f in "$folder"/*.md; do
+  # Recursive: a folder organized into subfolders must stay visible. A
+  # single-level glob reported all 103 relocated notes as deleted and tracked
+  # none of them, so the index machinery actively penalized an organized vault.
+  while IFS= read -r f; do
     [ -e "$f" ] || continue
-    base="$(basename "$f")"
+    base="${f#"$folder"/}"           # folder-relative path, so subfolders are visible
     # Skip filenames containing tabs or newlines — they corrupt TSV state.
     case "$base" in
       *$'\t'*|*$'\n'*)
         printf 'vault_index_plan: skipping TSV-incompatible filename: %s\n' "$base" >&2
         continue ;;
     esac
-    [ "$base" = "$idxbase" ] && continue
+    [ "${base##*/}" = "$idxbase" ] && continue
     stored="$(state_hash_for "$state" "$base")"
     if [ -z "$stored" ]; then
       printf 'ADD\t%s\n' "$base"          # coverage gap — name-only, no content read
@@ -89,7 +104,9 @@ vault_index_plan() {
       cur="$(note_hash "$f")"
       [ "$cur" != "$stored" ] && printf 'CHANGED\t%s\n' "$base"   # confirmed by hash
     fi
-  done
+  done <<EOF
+$(find "$folder" -type f -name '*.md' | LC_ALL=C sort)
+EOF
 }
 
 vault_index_apply() {
@@ -146,8 +163,15 @@ vault_index_apply() {
     if [ ! -f "$idx" ]; then
       printf '# %s Index\n' "$(basename "$folder")" > "$idx"
     fi
+    local leaf
     for fn in "${added[@]}"; do
-      vault_index_has_link "$idx" "${fn%.md}" || printf -- '- [[%s]]\n' "${fn%.md}" >> "$idx"
+      # Link text is the basename, never the folder-relative path: Obsidian
+      # resolves a slashed target against the VAULT root, so [[sub/dir/note]]
+      # would not resolve from a folder INDEX. A bare basename resolves
+      # vault-wide. has_link still matches either form, so a hand-written
+      # path-form link already present is respected.
+      leaf="${fn##*/}"
+      vault_index_has_link "$idx" "${leaf%.md}" || printf -- '- [[%s]]\n' "${leaf%.md}" >> "$idx"
     done
   fi
 

--- a/tests/keeper-cli.sh
+++ b/tests/keeper-cli.sh
@@ -5,7 +5,10 @@ KEEPER="$ROOT_DIR/scripts/keeper"
 fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/keeper-cli-XXXXXX")"; trap 'rm -rf "$TMP"' EXIT
 
-V="$TMP/vault"; mkdir -p "$V"
+# A real vault has .obsidian at its root; vault_index_apply finds it to write
+# vault-root-relative link targets. Without it the fixture exercises a shape
+# production never sees.
+V="$TMP/vault"; mkdir -p "$V/.obsidian"
 printf '%s\n' '---' 'date: 2026-06-29' '---' '' '# Repo — 2026-06-29' > "$TMP/init.md"
 printf 'first body line\nsecond line\n' > "$TMP/body.md"
 
@@ -70,41 +73,66 @@ bash "$KEEPER" append --vault "$V" --target a.md --bogus z 2>/dev/null && fail "
 # --- insert subcommand ---
 printf '%s\n' '---' 'date: 2026-06-29' '---' '' '# My Session Note' 'content' > "$TMP/note.md"
 
-# I1: insert writes the note verbatim + creates folder INDEX with a human link
+# I1: insert writes the note verbatim; vault_index_apply owns the INDEX link.
+# One note gets exactly ONE link, and it resolves — keeper must not hand-append
+# a `- [[$title]]` of its own. When --title differed from the filename stem that
+# produced two entries, the title one dangling, and the count-based coverage
+# check read the result as healthy.
 NF="$V/Decisions/2026-06-29-my-note.md"
 bash "$KEEPER" insert --vault "$V" --target "Decisions/2026-06-29-my-note.md" \
   --body-file "$TMP/note.md" --title "My Session Note" >/dev/null
 [ -f "$NF" ]                          || fail "insert did not write the note"
 grep -q '^# My Session Note' "$NF"    || fail "insert body not written verbatim"
 [ -f "$V/Decisions/INDEX.md" ]        || fail "insert did not create folder INDEX"
-grep -qxF -- '- [[My Session Note]]' "$V/Decisions/INDEX.md" || fail "insert did not append INDEX link"
+[ "$(grep -cF -- '- [[' "$V/Decisions/INDEX.md")" = "1" ] \
+  || fail "expected exactly one INDEX link, got:"$'\n'"$(cat "$V/Decisions/INDEX.md")"
+grep -qxF -- '- [[Decisions/2026-06-29-my-note]]' "$V/Decisions/INDEX.md" \
+  || fail "INDEX link is not the resolvable path form:"$'\n'"$(cat "$V/Decisions/INDEX.md")"
+grep -qF -- '[[My Session Note]]' "$V/Decisions/INDEX.md" \
+  && fail "keeper hand-appended a title link; apply owns the link write"
 
 # I2: refuse-on-exists (never overwrite)
 bash "$KEEPER" insert --vault "$V" --target "Decisions/2026-06-29-my-note.md" --body-file "$TMP/note.md" 2>/dev/null && fail "insert must refuse to overwrite an existing note"
 
-# I3: --session-link-date links into Daily/<date> under ## Session Links
+# I3: --session-link-date links into Daily/<date> under ## Session Links.
+# The link target is the note's vault-relative path so it resolves from Daily/;
+# the human title rides along as an alias. A bare `- [[Other Note]]` pointed at
+# no file at all.
 DLY="$V/Daily/2026-06-29.md"
 bash "$KEEPER" insert --vault "$V" --target "Decisions/2026-06-29-other.md" \
   --body-file "$TMP/note.md" --title "Other Note" --session-link-date 2026-06-29 >/dev/null
 [ -f "$DLY" ]                          || fail "session-link-date did not create the daily note"
 grep -q '^## Session Links' "$DLY"     || fail "Session Links section missing"
-grep -qxF -- '- [[Other Note]]' "$DLY" || fail "Session Links entry missing"
+grep -qxF -- '- [[Decisions/2026-06-29-other|Other Note]]' "$DLY" \
+  || fail "Session Links entry is not the resolvable path|alias form:"$'\n'"$(cat "$DLY")"
 
-# I4: Session Links idempotent — a second note with the same title does not double-link
+# I4: two distinct notes sharing a title each get their own Session Links entry —
+# they are different files. Deduping on title text dropped the second note's
+# link entirely, silently losing it from the day's log.
 bash "$KEEPER" insert --vault "$V" --target "Decisions/2026-06-29-dup.md" \
   --body-file "$TMP/note.md" --title "Other Note" --session-link-date 2026-06-29 >/dev/null
-[ "$(grep -cF -- '- [[Other Note]]' "$DLY")" = "1" ] || fail "Session Links link duplicated"
+grep -qxF -- '- [[Decisions/2026-06-29-dup|Other Note]]' "$DLY" \
+  || fail "second same-titled note lost its Session Links entry:"$'\n'"$(cat "$DLY")"
+
+# I4b: re-linking the SAME note is still idempotent (dedup is per path, not per title).
+bash "$KEEPER" insert --vault "$V" --target "Decisions/2026-06-29-again.md" \
+  --body-file "$TMP/note.md" --title "Again" --session-link-date 2026-06-29 >/dev/null
+bash "$KEEPER" insert --vault "$V" --target "Decisions/2026-06-29-again.md" \
+  --body-file "$TMP/note.md" --title "Again" --session-link-date 2026-06-29 2>/dev/null \
+  && fail "insert must refuse to overwrite; I4b cannot test dedup this way"
+[ "$(grep -cF -- '[[Decisions/2026-06-29-again' "$DLY")" = "1" ] \
+  || fail "Session Links entry duplicated for one note"
 
 # I5: malformed --session-link-date rejected
 bash "$KEEPER" insert --vault "$V" --target "Decisions/z.md" --body-file "$TMP/note.md" --session-link-date "2026/06/29" 2>/dev/null && fail "malformed session-link-date must fail"
 
 # I6: --title default is the filename stem (date prefix KEPT, so the wikilink resolves)
 bash "$KEEPER" insert --vault "$V" --target "Notes/2026-06-29-derived-title.md" --body-file "$TMP/note.md" >/dev/null
-grep -qxF -- '- [[2026-06-29-derived-title]]' "$V/Notes/INDEX.md" || fail "default title (filename stem) failed"
+grep -qxF -- '- [[Notes/2026-06-29-derived-title]]' "$V/Notes/INDEX.md" || fail "default title (filename stem) failed"
 
 # I7: --title default without a date prefix keeps the full basename
 bash "$KEEPER" insert --vault "$V" --target "Notes/plain.md" --body-file "$TMP/note.md" >/dev/null
-grep -qxF -- '- [[plain]]' "$V/Notes/INDEX.md" || fail "default title (no date prefix) failed"
+grep -qxF -- '- [[Notes/plain]]' "$V/Notes/INDEX.md" || fail "default title (no date prefix) failed"
 
 # I8: insert path-traversal guard
 bash "$KEEPER" insert --vault "$V" --target "../evil.md" --body-file "$TMP/note.md" 2>/dev/null && fail "insert path traversal must fail"
@@ -118,7 +146,7 @@ if command -v zsh >/dev/null 2>&1; then
   zsh "$KEEPER" insert --vault "$V" --target "Notes/2026-06-29-zinsert.md" \
     --body-file "$TMP/note.md" --title "Z Insert" --session-link-date 2026-06-29 >/dev/null 2>>"$TMP/zerr" \
     || { cat "$TMP/zerr" >&2; fail "keeper insert broke under zsh"; }
-  grep -qxF -- '- [[Z Insert]]' "$V/Notes/INDEX.md" || fail "zsh keeper insert did not link INDEX"
+  grep -qxF -- '- [[Notes/2026-06-29-zinsert]]' "$V/Notes/INDEX.md" || fail "zsh keeper insert did not link INDEX"
 fi
 
 echo "PASS: keeper-cli"

--- a/tests/vault-index-apply.sh
+++ b/tests/vault-index-apply.sh
@@ -21,8 +21,10 @@ grep -qxF "b.md" <<<"$ADDED" || fail "expected b.md in ADD output"
 grep -q '^# last_reconciled:[0-9]\+$' "$STATE" || fail "no last_reconciled stamp"
 note_hash_valid "$(state_hash_for "$STATE" "a.md")" || fail "a.md hash not stored validly"
 
-# INDEX.md must be untouched by apply (append-only is the subagent's job).
-[ "$(cat "$IDX")" = "$IDX_BEFORE" ] || fail "apply must not modify INDEX.md"
+# apply owns the link write (#30) but must only ever append: the prior content
+# stays byte-identical at the top of the file. See tests/vault-index-links.sh
+# for the link/coverage contract itself.
+[ "$(head -c ${#IDX_BEFORE} "$IDX")" = "$IDX_BEFORE" ] || fail "apply must not rewrite existing INDEX.md content"
 
 # Idempotent: second apply with no changes -> empty plan, no new ADD.
 # Use explicit timestamps instead of sleep to avoid wall-clock dependency.

--- a/tests/vault-index-links.sh
+++ b/tests/vault-index-links.sh
@@ -205,16 +205,25 @@ grep -qxF -- '- [[Proj/flat]]'     "$VIDX" || fail "vault-relative: root target 
 # end-state instead passes with that call deleted, because plan's unlinked->ADD
 # branch closes the gap either way. A read-only INDEX is a gap apply cannot
 # close, so its own report is the only thing that can surface it.
-RO="$TMP/ReadOnly"; mkdir -p "$RO"
-ROIDX="$RO/INDEX.md"; printf '# RO Index\n' > "$ROIDX"
-printf 'ro\n' > "$RO/ro.md"
-chmod 444 "$ROIDX"
-ROERR="$(vault_index_apply "$RO" "$ROIDX" 2>&1 >/dev/null || true)"
-chmod 644 "$ROIDX"
-case "$ROERR" in
-  *"coverage defect"*) : ;;
-  *) fail "apply did not report the gap it could not close; got:"$'\n'"$ROERR" ;;
-esac
+if [ "$(id -u)" = "0" ]; then
+  printf 'skip: read-only INDEX assertion (running as root ignores 0444)\n' >&2
+else
+  RO="$TMP/ReadOnly"; mkdir -p "$RO"
+  ROIDX="$RO/INDEX.md"; printf '# RO Index\n' > "$ROIDX"
+  printf 'ro\n' > "$RO/ro.md"
+  chmod 444 "$ROIDX"
+  ROERR="$(vault_index_apply "$RO" "$ROIDX" 2>&1 >/dev/null || true)"
+  ROOUT="$(vault_index_apply "$RO" "$ROIDX" 2>/dev/null || true)"
+  chmod 644 "$ROIDX"
+  case "$ROERR" in
+    *"coverage defect"*) : ;;
+    *) fail "apply did not report the gap it could not close; got:"$'\n'"$ROERR" ;;
+  esac
+  # stdout stays the ADD set: callers parse it (ADDED="$(vault_index_apply …)").
+  # A diagnostic leaking onto stdout puts a non-filename line in that list.
+  [ "$ROOUT" = "ro.md" ] \
+    || fail "apply's stdout must be the ADD set alone, got:"$'\n'"$ROOUT"
+fi
 
 # --- per-note assertion: a surplus link cannot pay for a missing one ---------
 # The count-based version reported this healthy — 2 links, 2 tracked, one of

--- a/tests/vault-index-links.sh
+++ b/tests/vault-index-links.sh
@@ -95,8 +95,6 @@ vault_index_apply "$F6" "$F6/INDEX.md" >/dev/null
 vault_index_coverage_check "$F6" "$F6/INDEX.md" 2>/dev/null \
   || fail "coverage check failed on an empty folder"
 
-echo "PASS: vault-index-links"
-
 # --- recursion: notes below the root are tracked, not reported deleted -------
 # Regression guard for the second half of #30 (see #32): a single-level glob
 # reported every relocated note as a DROP and tracked none of them, so
@@ -201,5 +199,38 @@ printf 'note\n' > "$V/Proj/sub/note.md"; printf 'flat\n' > "$V/Proj/flat.md"
 vault_index_apply "$V/Proj" "$VIDX" >/dev/null
 grep -qxF -- '- [[Proj/sub/note]]' "$VIDX" || fail "vault-relative: nested target wrong"$'\n'"$(cat "$VIDX")"
 grep -qxF -- '- [[Proj/flat]]'     "$VIDX" || fail "vault-relative: root target wrong"$'\n'"$(cat "$VIDX")"
+
+# --- apply itself reports a gap it could not close -------------------------
+# Pins the coverage_check call inside vault_index_apply. Asserting the healed
+# end-state instead passes with that call deleted, because plan's unlinked->ADD
+# branch closes the gap either way. A read-only INDEX is a gap apply cannot
+# close, so its own report is the only thing that can surface it.
+RO="$TMP/ReadOnly"; mkdir -p "$RO"
+ROIDX="$RO/INDEX.md"; printf '# RO Index\n' > "$ROIDX"
+printf 'ro\n' > "$RO/ro.md"
+chmod 444 "$ROIDX"
+ROERR="$(vault_index_apply "$RO" "$ROIDX" 2>&1 >/dev/null || true)"
+chmod 644 "$ROIDX"
+case "$ROERR" in
+  *"coverage defect"*) : ;;
+  *) fail "apply did not report the gap it could not close; got:"$'\n'"$ROERR" ;;
+esac
+
+# --- per-note assertion: a surplus link cannot pay for a missing one ---------
+# The count-based version reported this healthy — 2 links, 2 tracked, one of
+# them a leftover pointing at a note that no longer exists.
+SU="$TMP/Surplus"; mkdir -p "$SU"
+SUIDX="$SU/INDEX.md"; printf '# S Index\n' > "$SUIDX"
+printf 'one\n' > "$SU/one.md"; printf 'two\n' > "$SU/two.md"
+vault_index_apply "$SU" "$SUIDX" >/dev/null 2>&1
+rm "$SU/two.md"                          # its link stays (append-only), state drops it
+printf 'three\n' > "$SU/three.md"        # new note, tracked below
+vault_index_apply "$SU" "$SUIDX" >/dev/null 2>&1
+grep -vF -- '- [[S/three]]' "$SUIDX" | grep -vF -- '- [[three]]' > "$SUIDX.tmp" && mv "$SUIDX.tmp" "$SUIDX"
+if UNLINKED="$(vault_index_coverage_check "$SU" "$SUIDX" 2>/dev/null)"; then
+  fail "surplus stale link paid for a missing one; INDEX:"$'\n'"$(cat "$SUIDX")"
+fi
+grep -qF 'three.md' <<<"$UNLINKED" \
+  || fail "coverage check did not name the unlinked note, got: $UNLINKED"
 
 printf 'ok   vault-index-links.sh (recursion + collisions + vault-relative targets + move re-key)\n'

--- a/tests/vault-index-links.sh
+++ b/tests/vault-index-links.sh
@@ -200,6 +200,45 @@ vault_index_apply "$V/Proj" "$VIDX" >/dev/null
 grep -qxF -- '- [[Proj/sub/note]]' "$VIDX" || fail "vault-relative: nested target wrong"$'\n'"$(cat "$VIDX")"
 grep -qxF -- '- [[Proj/flat]]'     "$VIDX" || fail "vault-relative: root target wrong"$'\n'"$(cat "$VIDX")"
 
+# --- a subtree that owns its own INDEX.md is not the parent's business -------
+# Recursion must not make a parent re-index what its children already index.
+# Projects/Development holds 11 child INDEX.md files and 1073 notes below it;
+# without this the parent absorbed all of them into one file (#33).
+O="$TMP/Owned"; mkdir -p "$O/.obsidian" "$O/P/child" "$O/P/loose/deeper"
+OIDX="$O/P/INDEX.md";  printf '# P Index\n' > "$OIDX"
+CIDX="$O/P/child/INDEX.md"; printf '# Child Index\n' > "$CIDX"
+printf 'top\n'    > "$O/P/top.md"
+printf 'owned\n'  > "$O/P/child/owned.md"
+printf 'deep\n'   > "$O/P/child/deeper-owned.md"
+printf 'loose\n'  > "$O/P/loose/deeper/loose.md"
+vault_index_apply "$O/P" "$OIDX" >/dev/null 2>&1
+OSTATE="$(index_state_file "$OIDX")"
+grep -qxF -- '- [[P/top]]' "$OIDX"              || fail "owned: parent lost its own note"$'\n'"$(cat "$OIDX")"
+grep -qxF -- '- [[P/loose/deeper/loose]]' "$OIDX" \
+  || fail "owned: unindexed subtree must still be covered by the parent"$'\n'"$(cat "$OIDX")"
+grep -qF -- 'child/owned' "$OIDX" && fail "owned: parent indexed a note owned by child/INDEX.md"$'\n'"$(cat "$OIDX")"
+grep -qF -- 'child/' "$OSTATE"    && fail "owned: parent tracked a note owned by child/INDEX.md"$'\n'"$(cat "$OSTATE")"
+[ "$(grep -vc '^#' "$OSTATE")" = "2" ] || fail "owned: expected 2 tracked, got $(grep -vc '^#' "$OSTATE")"
+# The child index still covers its own notes.
+vault_index_apply "$O/P/child" "$CIDX" >/dev/null 2>&1
+grep -qxF -- '- [[P/child/owned]]' "$CIDX" || fail "owned: child index missing its own note"$'\n'"$(cat "$CIDX")"
+# Coverage is clean on both, and the parent does not claim the child's notes.
+vault_index_coverage_check "$O/P" "$OIDX" >/dev/null 2>&1 || fail "owned: parent reports a defect"
+vault_index_coverage_check "$O/P/child" "$CIDX" >/dev/null 2>&1 || fail "owned: child reports a defect"
+
+# A child index appearing later hands its notes over: the parent drops them.
+N="$TMP/NewChild"; mkdir -p "$N/.obsidian" "$N/P/sub"
+NIDX="$N/P/INDEX.md"; printf '# N Index\n' > "$NIDX"
+printf 'a\n' > "$N/P/sub/a.md"
+vault_index_apply "$N/P" "$NIDX" >/dev/null 2>&1
+NSTATE="$(index_state_file "$NIDX")"
+grep -qF -- 'sub/a.md' "$NSTATE" || fail "newchild: not tracked before the child index existed"
+printf '# Sub Index\n' > "$N/P/sub/INDEX.md"
+vault_index_apply "$N/P" "$NIDX" >/dev/null 2>&1
+grep -qF -- 'sub/a.md' "$NSTATE" && fail "newchild: parent still tracks a note the child now owns"$'\n'"$(cat "$NSTATE")"
+vault_index_coverage_check "$N/P" "$NIDX" >/dev/null 2>&1 \
+  || fail "newchild: parent reports a defect for a note it handed off"
+
 # --- apply itself reports a gap it could not close -------------------------
 # Pins the coverage_check call inside vault_index_apply. Asserting the healed
 # end-state instead passes with that call deleted, because plan's unlinked->ADD

--- a/tests/vault-index-links.sh
+++ b/tests/vault-index-links.sh
@@ -109,16 +109,16 @@ printf 'two\n'   > "$R/sub/deep/two.md"
 RSTATE="$(index_state_file "$RIDX")"
 
 vault_index_apply "$R" "$RIDX" >/dev/null
-for n in flat one two; do
+for n in flat sub/one sub/deep/two; do
   grep -qxF -- "- [[$n]]" "$RIDX" || fail "recursion: no link written for $n"$'\n'"$(cat "$RIDX")"
 done
 [ "$(grep -vc '^#' "$RSTATE")" = "3" ] || fail "recursion: expected 3 tracked, got $(grep -vc '^#' "$RSTATE")"$'\n'"$(cat "$RSTATE")"
 # state must be keyed by folder-relative path, or two same-named notes in
 # different subfolders collide on one key.
 grep -qF 'sub/deep/two.md' "$RSTATE" || fail "recursion: state not keyed by relative path"$'\n'"$(cat "$RSTATE")"
-# link text must be the bare basename: Obsidian resolves a slashed target
-# against the vault root, so [[sub/deep/two]] would not resolve here.
-grep -qF -- '- [[sub/deep/two]]' "$RIDX" && fail "recursion: link written as path, not basename"
+# Link text carries the path, never the bare basename — see the collision test
+# below. No .obsidian ancestor here, so the target is folder-relative.
+grep -qF -- '- [[two]]' "$RIDX" && fail "recursion: link written as bare basename"
 
 # settled: a second apply is a no-op
 vault_index_apply "$R" "$RIDX" >/dev/null
@@ -147,4 +147,59 @@ grep -qF 'bucket/mover.md' "$MSTATE" || fail "moved: not re-keyed to new path"$'
 [ "$(grep -vc '^#' "$MSTATE")" = "1" ] || fail "moved: stale key left behind"$'\n'"$(cat "$MSTATE")"
 [ "$(grep -cF -- '- [[' "$MIDX")" = "1" ] || fail "moved: link duplicated after move"$'\n'"$(cat "$MIDX")"
 
-printf 'ok   vault-index-links.sh (recursion + path-form dedup + move re-key)\n'
+# --- basename collisions across subfolders each get their own link -----------
+# Sibling subfolders routinely hold same-named notes (12 INDEX.md, 5 different
+# 2026-05-31.md under Projects/Development). Matching or writing the bare
+# basename made the first link satisfy every namesake, so the rest were dropped
+# while state still claimed them: 1001 links for 1061 notes, permanent, because
+# a hashed note never replans as an ADD.
+C="$TMP/Collide"; mkdir -p "$C/a" "$C/b" "$C/c/deep"
+CIDX="$C/INDEX.md"; printf '# Collide Index\n' > "$CIDX"
+for d in a b c/deep; do printf 'dated\n' > "$C/$d/2026-05-31.md"; done
+vault_index_apply "$C" "$CIDX" >/dev/null 2>"$TMP/collide.err"
+CSTATE="$(index_state_file "$CIDX")"
+[ "$(grep -vc '^#' "$CSTATE")" = "3" ] || fail "collide: expected 3 tracked"$'\n'"$(cat "$CSTATE")"
+[ "$(grep -cF -- '- [[' "$CIDX")" = "3" ] \
+  || fail "collide: namesakes collapsed to $(grep -cF -- '- [[' "$CIDX") link(s)"$'\n'"$(cat "$CIDX")"
+for d in a b c/deep; do
+  grep -qxF -- "- [[$d/2026-05-31]]" "$CIDX" || fail "collide: no distinct link for $d"$'\n'"$(cat "$CIDX")"
+done
+[ -s "$TMP/collide.err" ] && fail "collide: coverage defect reported"$'\n'"$(cat "$TMP/collide.err")"
+vault_index_apply "$C" "$CIDX" >/dev/null 2>&1
+[ "$(grep -cF -- '- [[' "$CIDX")" = "3" ] || fail "collide: second apply duplicated links"$'\n'"$(cat "$CIDX")"
+
+# --- a legacy bare link does not satisfy its namesakes -----------------------
+# The real repair path: an INDEX written by the leaf-matching version already
+# holds a bare [[2026-05-31]] standing in for several notes. Each namesake must
+# still earn its own path link, or the folder stays stuck at the old coverage.
+L="$TMP/Legacy"; mkdir -p "$L/a" "$L/b"
+LIDX="$L/INDEX.md"; printf '# Legacy Index\n- [[2026-05-31]]\n' > "$LIDX"
+for d in a b; do printf 'dated\n' > "$L/$d/2026-05-31.md"; done
+vault_index_apply "$L" "$LIDX" >/dev/null 2>&1
+for d in a b; do
+  grep -qxF -- "- [[$d/2026-05-31]]" "$LIDX" \
+    || fail "legacy: bare link absorbed $d/2026-05-31"$'\n'"$(cat "$LIDX")"
+done
+
+# --- a legacy bare link IS honored when the basename is unique ---------------
+# Same shape, one note: the bare form is unambiguous and Obsidian resolves it
+# vault-wide, so re-linking it would just duplicate the entry. This is also the
+# moved-note case (root [[mover]] -> bucket/mover).
+U="$TMP/Unique"; mkdir -p "$U/a"
+UIDX="$U/INDEX.md"; printf '# Unique Index\n- [[solo]]\n' > "$UIDX"
+printf 'solo\n' > "$U/a/solo.md"
+vault_index_apply "$U" "$UIDX" >/dev/null 2>&1
+[ "$(grep -cF -- '- [[' "$UIDX")" = "1" ] \
+  || fail "unique: bare link duplicated"$'\n'"$(cat "$UIDX")"
+
+# --- link target is vault-root-relative when inside a vault ------------------
+# Obsidian resolves a slashed target against the vault root, so a
+# folder-relative [[sub/note]] would not resolve from an INDEX below the root.
+V="$TMP/Vault"; mkdir -p "$V/.obsidian" "$V/Proj/sub"
+VIDX="$V/Proj/INDEX.md"
+printf 'note\n' > "$V/Proj/sub/note.md"; printf 'flat\n' > "$V/Proj/flat.md"
+vault_index_apply "$V/Proj" "$VIDX" >/dev/null
+grep -qxF -- '- [[Proj/sub/note]]' "$VIDX" || fail "vault-relative: nested target wrong"$'\n'"$(cat "$VIDX")"
+grep -qxF -- '- [[Proj/flat]]'     "$VIDX" || fail "vault-relative: root target wrong"$'\n'"$(cat "$VIDX")"
+
+printf 'ok   vault-index-links.sh (recursion + collisions + vault-relative targets + move re-key)\n'

--- a/tests/vault-index-links.sh
+++ b/tests/vault-index-links.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# vault-index-links.sh — issue #30: state must never claim coverage INDEX.md lacks.
+# apply writes the links itself; plan treats "hashed but unlinked" as an ADD.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "${ROOT_DIR}/scripts/lib/note-hash.sh"
+. "${ROOT_DIR}/scripts/lib/vault-index.sh"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/vault-links-XXXXXX")"; trap 'rm -rf "$TMP"' EXIT
+
+# --- apply writes the link, not just the hash ---
+F="$TMP/Decisions"; mkdir -p "$F"
+IDX="$F/INDEX.md"; printf '# Decisions Index\n' > "$IDX"
+printf 'note A\n' > "$F/a.md"
+printf 'note B\n' > "$F/b.md"
+STATE="$(index_state_file "$IDX")"
+
+vault_index_apply "$F" "$IDX" >/dev/null
+grep -qxF -- '- [[a]]' "$IDX" || fail "apply did not write link for a.md"$'\n'"$(cat "$IDX")"
+grep -qxF -- '- [[b]]' "$IDX" || fail "apply did not write link for b.md"
+# Append-only: the pre-existing header survives, at the top.
+[ "$(head -1 "$IDX")" = '# Decisions Index' ] || fail "apply rewrote INDEX.md instead of appending"
+
+# --- idempotent: a second apply adds no duplicate link ---
+touch -t 202001010000 "$F/a.md" "$F/b.md"
+vault_index_apply "$F" "$IDX" >/dev/null
+[ "$(grep -cxF -- '- [[a]]' "$IDX")" = 1 ] || fail "duplicate link appended for a.md"
+
+# --- self-heal: state ahead of INDEX (the issue-30 drift) must reappear as ADD ---
+# Simulate the damaged vault: drop a.md's link from INDEX while its hash stays in state.
+grep -vxF -- '- [[a]]' "$IDX" > "$IDX.tmp" && mv "$IDX.tmp" "$IDX"
+grep -qxF -- '- [[a]]' "$IDX" && fail "setup: a.md link should be gone"
+note_hash_valid "$(state_hash_for "$STATE" "a.md")" || fail "setup: a.md hash should still be in state"
+
+PLAN="$(vault_index_plan "$F" "$IDX")"
+grep -qxF "ADD"$'\t'"a.md" <<<"$PLAN" \
+  || fail "hashed-but-unlinked note must plan as ADD, got:"$'\n'"$PLAN"
+
+ADDED="$(vault_index_apply "$F" "$IDX")"
+grep -qxF "a.md" <<<"$ADDED" || fail "drifted note must be reported in the ADD set"
+grep -qxF -- '- [[a]]' "$IDX" || fail "apply did not re-add the missing link"
+
+# --- a hand-written link is respected: no ADD, no duplicate ---
+F2="$TMP/Hand"; mkdir -p "$F2"
+IDX2="$F2/INDEX.md"; printf '# Hand Index\n- [[h]]\n' > "$IDX2"
+printf 'hand note\n' > "$F2/h.md"
+vault_index_apply "$F2" "$IDX2" >/dev/null
+[ "$(grep -cxF -- '- [[h]]' "$IDX2")" = 1 ] || fail "apply duplicated a hand-written link"
+
+# Link variants (alias / heading) count as linked.
+F3="$TMP/Variants"; mkdir -p "$F3"
+IDX3="$F3/INDEX.md"; printf '# V Index\n- [[v1|Alias]]\n- [[v2#Section]]\n' > "$IDX3"
+printf 'v1\n' > "$F3/v1.md"; printf 'v2\n' > "$F3/v2.md"
+vault_index_apply "$F3" "$IDX3" >/dev/null
+[ "$(grep -c -- '\[\[v1' "$IDX3")" = 1 ] || fail "aliased link not recognized as coverage"
+[ "$(grep -c -- '\[\[v2' "$IDX3")" = 1 ] || fail "heading link not recognized as coverage"
+
+# --- titles with regex metacharacters must match literally ---
+F4="$TMP/Meta"; mkdir -p "$F4"
+IDX4="$F4/INDEX.md"; printf '# Meta Index\n' > "$IDX4"
+printf 'meta\n' > "$F4/2026-07-27 notes (draft) [v1+2].md"
+vault_index_apply "$F4" "$IDX4" >/dev/null
+grep -qxF -- '- [[2026-07-27 notes (draft) [v1+2]]]' "$IDX4" \
+  || fail "metachar title not linked literally:"$'\n'"$(cat "$IDX4")"
+touch -t 202001010000 "$F4/2026-07-27 notes (draft) [v1+2].md"
+vault_index_apply "$F4" "$IDX4" >/dev/null
+[ "$(grep -c -- '\[\[2026-07-27' "$IDX4")" = 1 ] || fail "metachar title link duplicated"
+
+# --- missing INDEX.md is created, not silently skipped ---
+F5="$TMP/Fresh"; mkdir -p "$F5"
+IDX5="$F5/INDEX.md"
+printf 'fresh\n' > "$F5/f.md"
+vault_index_apply "$F5" "$IDX5" >/dev/null
+[ -f "$IDX5" ] || fail "apply did not create a missing INDEX.md"
+grep -qxF -- '- [[f]]' "$IDX5" || fail "apply did not link into the created INDEX.md"
+
+# --- coverage check: state tracking more notes than INDEX links is a defect ---
+# Callable on its own so a damaged vault can be assessed without a write.
+vault_index_coverage_check "$F" "$IDX" 2>/dev/null || fail "healthy slice reported as a defect"
+grep -vxF -- '- [[b]]' "$IDX" > "$IDX.tmp" && mv "$IDX.tmp" "$IDX"
+if WARN="$(vault_index_coverage_check "$F" "$IDX" 2>&1 >/dev/null)"; then
+  fail "coverage check passed while INDEX had fewer links than state tracks"
+fi
+case "$WARN" in *coverage*) : ;; *) fail "coverage defect not reported on stderr: $WARN" ;; esac
+
+# apply runs the check itself, so the defect cannot be skipped by a caller that
+# forgets to ask — and it heals the gap it just reported.
+vault_index_apply "$F" "$IDX" >/dev/null
+vault_index_coverage_check "$F" "$IDX" 2>/dev/null || fail "apply left a coverage defect behind"
+
+# --- empty folder: neither state nor INDEX exists yet; must not abort set -e ---
+F6="$TMP/Empty"; mkdir -p "$F6"
+vault_index_apply "$F6" "$F6/INDEX.md" >/dev/null
+vault_index_coverage_check "$F6" "$F6/INDEX.md" 2>/dev/null \
+  || fail "coverage check failed on an empty folder"
+
+echo "PASS: vault-index-links"

--- a/tests/vault-index-links.sh
+++ b/tests/vault-index-links.sh
@@ -96,3 +96,55 @@ vault_index_coverage_check "$F6" "$F6/INDEX.md" 2>/dev/null \
   || fail "coverage check failed on an empty folder"
 
 echo "PASS: vault-index-links"
+
+# --- recursion: notes below the root are tracked, not reported deleted -------
+# Regression guard for the second half of #30 (see #32): a single-level glob
+# reported every relocated note as a DROP and tracked none of them, so
+# organizing a folder silently untracked it.
+R="$TMP/Recursive"; mkdir -p "$R/sub/deep"
+RIDX="$R/INDEX.md"; printf '# Recursive Index\n' > "$RIDX"
+printf 'flat\n'  > "$R/flat.md"
+printf 'one\n'   > "$R/sub/one.md"
+printf 'two\n'   > "$R/sub/deep/two.md"
+RSTATE="$(index_state_file "$RIDX")"
+
+vault_index_apply "$R" "$RIDX" >/dev/null
+for n in flat one two; do
+  grep -qxF -- "- [[$n]]" "$RIDX" || fail "recursion: no link written for $n"$'\n'"$(cat "$RIDX")"
+done
+[ "$(grep -vc '^#' "$RSTATE")" = "3" ] || fail "recursion: expected 3 tracked, got $(grep -vc '^#' "$RSTATE")"$'\n'"$(cat "$RSTATE")"
+# state must be keyed by folder-relative path, or two same-named notes in
+# different subfolders collide on one key.
+grep -qF 'sub/deep/two.md' "$RSTATE" || fail "recursion: state not keyed by relative path"$'\n'"$(cat "$RSTATE")"
+# link text must be the bare basename: Obsidian resolves a slashed target
+# against the vault root, so [[sub/deep/two]] would not resolve here.
+grep -qF -- '- [[sub/deep/two]]' "$RIDX" && fail "recursion: link written as path, not basename"
+
+# settled: a second apply is a no-op
+vault_index_apply "$R" "$RIDX" >/dev/null
+[ -z "$(vault_index_plan "$R" "$RIDX")" ] || fail "recursion: not idempotent"$'\n'"$(vault_index_plan "$R" "$RIDX")"
+
+# --- has_link matches a path-form link, so apply does not duplicate ----------
+# A hand-written INDEX links [[Vault/sub/note]]; matching only the basename
+# form re-appended a duplicate (observed on a real 106-note index).
+P="$TMP/PathForm"; mkdir -p "$P/sub"
+PIDX="$P/INDEX.md"
+printf '# PathForm Index\n- [[PathForm/sub/note]]\n' > "$PIDX"
+printf 'note\n' > "$P/sub/note.md"
+vault_index_apply "$P" "$PIDX" >/dev/null
+[ "$(grep -cF -- '- [[' "$PIDX")" = "1" ] || fail "path-form link was duplicated"$'\n'"$(cat "$PIDX")"
+
+# --- a note moved into a subfolder re-keys instead of losing coverage --------
+M="$TMP/Moved"; mkdir -p "$M"
+MIDX="$M/INDEX.md"; printf '# Moved Index\n' > "$MIDX"
+printf 'mover\n' > "$M/mover.md"
+vault_index_apply "$M" "$MIDX" >/dev/null
+MSTATE="$(index_state_file "$MIDX")"
+grep -qxF -- 'mover.md' <(cut -f1 "$MSTATE" | grep -v '^#') || fail "moved: not tracked before move"
+mkdir -p "$M/bucket" && mv "$M/mover.md" "$M/bucket/mover.md"
+vault_index_apply "$M" "$MIDX" >/dev/null
+grep -qF 'bucket/mover.md' "$MSTATE" || fail "moved: not re-keyed to new path"$'\n'"$(cat "$MSTATE")"
+[ "$(grep -vc '^#' "$MSTATE")" = "1" ] || fail "moved: stale key left behind"$'\n'"$(cat "$MSTATE")"
+[ "$(grep -cF -- '- [[' "$MIDX")" = "1" ] || fail "moved: link duplicated after move"$'\n'"$(cat "$MIDX")"
+
+printf 'ok   vault-index-links.sh (recursion + path-form dedup + move re-key)\n'

--- a/tests/vault-librarian-agent.sh
+++ b/tests/vault-librarian-agent.sh
@@ -10,6 +10,8 @@ grep -q '^description:' "$A" || fail "missing frontmatter description"
 need "resolve-config.sh"          # resolves vault dynamically
 need "vault_index_apply"          # refreshes slice before answering
 need "coverage"                   # coverage invariant present
+need "vault_index_coverage_check" # coverage defect is reported, not assumed away
+need "append them by hand"        # #30: link writing belongs to apply, not prose
 need "find-notes"                 # raw-text fallback to find-notes skill
 need "Pending.md"                 # low-confidence routing -> [ask]
 need "dry-run"                    # destructive ops gated


### PR DESCRIPTION
Closes #30
Closes #32
Closes #33

## Description (Issue Fixed & New Behavior)

`vault_index_apply()` recorded note hashes in the hidden `.INDEX.state` sidecar but never wrote the `- [[note]]` links into `INDEX.md` — that append was a prose step in `agents/vault-librarian.md`. Once the two desynced the drift was permanent and silent: state said "already seen," so the note never came back in the `ADD` set, and nothing ever re-added its link. A sweep of the live vault found **16 of 24 INDEX folders** in that state, worst cases 2 links against 313 tracked notes and 13 against 132. Every topic query against those folders reported normal confidence while reading a fraction of the slice.

**Link writing moves into the library.** `vault_index_apply` appends the link for each note it newly hashes — append-only, deduped, creating `INDEX.md` when absent. `vault_index_plan` treats "hash in state but no link in `INDEX.md`" as an `ADD`, so a gap from any cause heals on the next reconcile instead of hiding forever. The librarian no longer hand-appends links, and neither does `scripts/keeper`; a second implementation of the same write is how the drift started.

**The walk is recursive, and links carry their path.** A single-level glob reported every note in an organized subfolder as deleted, so organizing a folder silently untracked it. The walk now descends, state is keyed by folder-relative path, and link targets are vault-root-relative (`- [[Projects/Development/nhangen/tron/2026-07-27]]`). A bare basename is ambiguous the moment two notes in different subfolders share one — this vault has 49 notes named `2026-07.md` and four named `2026-07-27.md` under `Projects/Development` alone — so `vault_index_dup_leaves` requires the path form for any duplicated basename and accepts a legacy bare link only when it is unambiguous.

**Coverage is asserted per note, not by counting.** Comparing `- [[` line count against tracked-note count let any surplus line pay for a note that had none: a link left behind by a `DROP`, a duplicate, a bullet the count pattern missed. `vault_index_coverage_check` now asks `vault_index_has_link` for each tracked note — the same predicate the writer dedups on, so there is one definition of "linked" — and prints the unlinked filenames. `vault_index_apply` separately verifies the set it just tried to write and reports on stderr; that report is what surfaces a link write that failed while state was already stamped.

**`keeper` stops competing with it.** `cmd_insert` hand-appended `- [[$title]]` before calling apply, so a `--title` that differed from the filename stem produced two entries for one note, the title one resolving to nothing. It also ran apply with `2>/dev/null`, discarding the coverage report on the only deterministic caller. The daily Session Links entry now links the note by path with the title as an alias, deduped on path — keying on title text was dropping the second same-titled note's link entirely.

## Testing Procedure

1. Check out this branch and run the suite: `bash tests/run-all.sh` — expect `ALL PASS` (28 suites).
2. Confirm each fix is pinned by reverting it and watching a named test fail:
   - delete the link append in `vault_index_apply` → `apply did not write link for a.md`
   - delete `plan`'s unlinked→`ADD` branch → `hashed-but-unlinked note must plan as ADD`
   - delete apply's post-write verify → `apply did not report the gap it could not close`
   - route that report to stdout instead of stderr → same test (stdout must stay the ADD set)
   - restore `keeper`'s hand-append → `expected exactly one INDEX link`
   - restore the count-based coverage check → `surplus stale link paid for a missing one`
3. Reproduce the original drift end to end:
   ```bash
   . scripts/lib/note-hash.sh; . scripts/lib/vault-index.sh
   R=$(mktemp -d); mkdir -p "$R/.obsidian" "$R/S"; D="$R/S"
   printf '# S Index\n' > "$D/INDEX.md"; printf 'a\n' > "$D/a.md"; printf 'b\n' > "$D/b.md"
   vault_index_apply "$D" "$D/INDEX.md"                                   # links both
   grep -vF -- '[[S/a]]' "$D/INDEX.md" > "$D/t" && mv "$D/t" "$D/INDEX.md"  # damage it
   vault_index_apply "$D" "$D/INDEX.md"                                   # prints a.md, restores the link
   vault_index_coverage_check "$D" "$D/INDEX.md" && echo "clean"
   ```
4. Confirm namesakes in sibling subfolders each get a distinct resolvable link:
   ```bash
   V=$(mktemp -d); mkdir -p "$V/.obsidian" "$V/P/x" "$V/P/y"
   printf '1\n' > "$V/P/x/2026-07-27.md"; printf '2\n' > "$V/P/y/2026-07-27.md"
   vault_index_apply "$V/P" "$V/P/INDEX.md" >/dev/null; grep -F -- '- [[' "$V/P/INDEX.md"
   # -> - [[P/x/2026-07-27]] and - [[P/y/2026-07-27]]
   ```
5. Verify `keeper insert` writes exactly one resolvable link per note, including when the title differs from the stem, and under zsh:
   ```bash
   V=$(mktemp -d); mkdir -p "$V/.obsidian"; printf 'body\n' > /tmp/b.md
   bash scripts/keeper insert --vault "$V" --target "Decisions/2026-07-27-note.md" \
     --body-file /tmp/b.md --title "A Human Title" --session-link-date 2026-07-27
   grep -F -- '- [[' "$V/Decisions/INDEX.md"   # one link, path form
   grep -F -- '- [[' "$V/Daily/2026-07-27.md"  # path|alias, resolves
   ```
6. Sanity-check cost on a large folder before merging: a warm reconcile of a 1073-note folder runs ~10s, which is the librarian's per-query path. See the note below.

## Additional Notes / HelpScout Tickets

Reviewed by an 8-agent panel; findings are recorded in the pattern-tracker. Two of its blockers were fixed on the branch during review (bare-stem collisions, and the hand-repaired `Altamira` index turning out safe — verified 106 links in, 106 out, no duplicates).

**#33 is fixed here.** The recursive walk now stops at any subdirectory holding its own `INDEX.md` — that subtree has an owner — and a note that comes under new ownership is dropped from the parent's state rather than lingering as a claim the parent no longer backs with a link. Subtrees with no index of their own are still covered by the nearest ancestor that has one, which is what #32 was about. On a copy of the real `Projects/Development`: the parent goes from 1061 tracked notes to the 291 it actually owns, and a warm reconcile — the librarian's per-query path — from 10s to 4s.

Deferred to follow-up work, each independent:  found in the same review and left out on purpose: `vault_link_target`'s folder-relative fallback when no `.obsidian` ancestor exists, the unlocked read-modify-write on the append (27 duplicate links across 40 notes with 8 concurrent workers, though no in-repo scheduler produces that today), `find` lacking `vault-scan.sh`'s exclusions so `.sync-conflict-*` files get indexed as notes, and stale bare links orphaned once a namesake appears.
