### PR TITLE
Shell-agnostic lib self-location, honest no-config refusal, one tokenizer

### DIFF
--- a/agents/vault-librarian.md
+++ b/agents/vault-librarian.md
@@ -78,6 +78,10 @@ deduped.)
    - The refusal says **the top-level folder is not in the allow-list** (and offers a
      closest match) → the *target* is the problem. Surface it and ask the user where
      to file, or correct the target to the suggested match.
+   - The refusal says **the install is broken** (it could not find `resolve-config.sh`
+     beside itself) → neither the config nor the target. Surface it and stop; setup
+     will not fix a lib that lost its own path. Same rule as the config case: do not
+     ask where to file.
 
    If routing confidence is low, do **not** commit silently — append an
    `[ask:where should this go?]` entry to `$VAULT_PATH/Pending.md` and ask the user once.

--- a/agents/vault-librarian.md
+++ b/agents/vault-librarian.md
@@ -68,10 +68,19 @@ and `create-note` pass `folder_hint` today and must keep getting routed +
 deduped.)
 
 1. Route the content to a target folder. **Always state the chosen folder.** Call
-   `allowlist_validate "<target>"` — if it fails, do not write; surface the error
-   and ask the user where to file. If routing confidence is low, do **not** commit
-   silently — append an `[ask:where should this go?]` entry to `$VAULT_PATH/Pending.md`
-   and ask the user once.
+   `allowlist_validate "<target>"` — if it fails, do not write. It refuses for two
+   different reasons, and only one of them is a question for the user:
+   - The refusal mentions **`/obsidian:setup`** → the *config* is the problem (none
+     resolved, or its taxonomy table has no rows). Surface it, tell the user to run
+     `/obsidian:setup`, and stop. Do **not** ask where to file: no folder answer
+     fixes a missing taxonomy, and treating a named folder as authorization writes
+     outside the allow-list the gate just enforced.
+   - The refusal says **the top-level folder is not in the allow-list** (and offers a
+     closest match) → the *target* is the problem. Surface it and ask the user where
+     to file, or correct the target to the suggested match.
+
+   If routing confidence is low, do **not** commit silently — append an
+   `[ask:where should this go?]` entry to `$VAULT_PATH/Pending.md` and ask the user once.
 2. **Dedup:** call the shared scanner — `dedup_same_day "<vault>/<folder>" "$(date +%Y-%m-%d)" "<slug>"`. If it echoes a `path<TAB>score`, surface that note and ask whether to append rather than file a duplicate — never silently merge.
 3. Write the note using the matching template in `$VAULT_PATH/Templates/`. Its
    INDEX link is written by step 5 (`vault_index_apply`), not by hand. Link

--- a/scripts/lib/allowlist-validate.sh
+++ b/scripts/lib/allowlist-validate.sh
@@ -2,12 +2,19 @@
 # allowlist-validate.sh — Project Taxonomy allow-list parsing + target validation.
 # The taxonomy table in the config is the single source of valid top-level folders.
 
+# Captured at source time, not inside a function: `BASH_SOURCE` is a bashism that
+# zsh leaves unset, and zsh's `$0` is the sourced file only while it is being
+# read — inside a function it is the function name. Getting this wrong made
+# every self-relative lookup cwd-relative under zsh (the librarian and keeper
+# runtime), so config resolution failed and validation refused every write (#27).
+_av_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+
 _allowlist_config() {
   local cfg="${1:-}"
   if [ -z "$cfg" ]; then
-    cfg="$(bash "$(dirname "${BASH_SOURCE[0]}")/resolve-config.sh" 2>/dev/null || true)"
+    cfg="$(bash "${_av_lib_dir}/resolve-config.sh" 2>/dev/null || true)"
   fi
-  [ -n "$cfg" ] && [ -f "$cfg" ] || { printf 'allowlist: no config resolved\n' >&2; return 1; }
+  [ -n "$cfg" ] && [ -f "$cfg" ] || { printf 'allowlist: no config resolved — run /obsidian:setup\n' >&2; return 1; }
   printf '%s\n' "$cfg"
 }
 
@@ -25,7 +32,17 @@ allowlist_list() {
 }
 
 allowlist_validate() {
-  local target="$1" cfg="${2:-}" entry ntarget nentry best="" bestd=9999 d top
+  local target="$1" cfg="${2:-}" entry ntarget nentry best="" bestd=9999 d top list
+  # Read the allow-list once. An empty list means the taxonomy could not be read
+  # at all — a different failure from "the target is not on the list", and
+  # reporting it as the latter (with a blank closest match) sent readers looking
+  # for a typo in a target that was fine (#27).
+  list="$(allowlist_list "$cfg")" || return 1
+  if [ -z "$list" ]; then
+    printf 'Refusing to write to %s — the config has no readable ## Project Taxonomy allow-list. Run /obsidian:setup or add the table.\n' "$target" >&2
+    return 1
+  fi
+
   ntarget="$(printf '%s' "$target" | tr 'A-Z' 'a-z')"; ntarget="${ntarget%/}"
   while IFS= read -r entry; do
     [ -z "$entry" ] && continue
@@ -33,14 +50,18 @@ allowlist_validate() {
     case "$ntarget/" in
       "$nentry"/*) return 0 ;;
     esac
-  done < <(allowlist_list "$cfg")
+  done <<EOF
+$list
+EOF
 
   top="${target%%/*}"
   while IFS= read -r entry; do
     [ -z "$entry" ] && continue
     d="$(_lev "$(printf '%s' "$top" | tr 'A-Z' 'a-z')" "$(printf '%s' "${entry%%/*}" | tr 'A-Z' 'a-z')")"
     if [ "$d" -lt "$bestd" ]; then bestd="$d"; best="$entry"; fi
-  done < <(allowlist_list "$cfg")
+  done <<EOF
+$list
+EOF
 
   printf 'Refusing to write to %s — top-level folder is not in the allow-list. Closest match: %s. Add it to ## Project Taxonomy or correct the target.\n' "$target" "$best" >&2
   return 1

--- a/scripts/lib/allowlist-validate.sh
+++ b/scripts/lib/allowlist-validate.sh
@@ -43,10 +43,12 @@ allowlist_list() {
 
 allowlist_validate() {
   local target="$1" cfg="${2:-}" entry ntarget nentry best="" bestd=9999 d top list
-  # Read the allow-list once. An empty list means the taxonomy could not be read
-  # at all — a different failure from "the target is not on the list", and
-  # reporting it as the latter (with a blank closest match) sent readers looking
-  # for a typo in a target that was fine (#27).
+  # An empty list means no valid taxonomy rows parsed — a missing heading, or a
+  # table with only a header. Distinct from "the target is not on the list", which
+  # offers a closest match; reporting the former as the latter points the reader at
+  # a typo in a target that was fine. A config that is present but unreadable does
+  # not arrive here: awk fails, allowlist_list propagates, and the `|| return 1`
+  # below short-circuits.
   list="$(allowlist_list "$cfg")" || return 1
   if [ -z "$list" ]; then
     printf 'Refusing to write to %s — the config has no readable ## Project Taxonomy allow-list. Run /obsidian:setup or add the table.\n' "$target" >&2

--- a/scripts/lib/allowlist-validate.sh
+++ b/scripts/lib/allowlist-validate.sh
@@ -12,6 +12,16 @@ _av_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
 _allowlist_config() {
   local cfg="${1:-}"
   if [ -z "$cfg" ]; then
+    # Check the capture landed somewhere real before trusting it. Testing for the
+    # sibling rather than for an empty string catches both failure shapes: `cd`
+    # failing (empty) and `dirname ""` -> "." -> `cd .` succeeding onto the
+    # caller's cwd. Without this, either one resolves no config and reports it as
+    # a missing config, sending the reader to /obsidian:setup for what is a broken
+    # install — the same misdirection this file's own refusal was fixed for.
+    if [ ! -f "${_av_lib_dir}/resolve-config.sh" ]; then
+      printf 'allowlist: cannot find resolve-config.sh beside this lib (looked in "%s") — the install is broken, not the config\n' "$_av_lib_dir" >&2
+      return 1
+    fi
     cfg="$(bash "${_av_lib_dir}/resolve-config.sh" 2>/dev/null || true)"
   fi
   [ -n "$cfg" ] && [ -f "$cfg" ] || { printf 'allowlist: no config resolved — run /obsidian:setup\n' >&2; return 1; }

--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -13,7 +13,11 @@
 # crontab line, so each host installs its own scheduler the first time normal
 # workflow runs on it. Opt out with `keeper_autostart: false` in the config.
 
-_kb_scripts() { cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd; }
+# Captured at source time — see the note in allowlist-validate.sh: zsh has no
+# BASH_SOURCE, and its `$0` only names the sourced file while it is being read.
+_kb_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+
+_kb_scripts() { printf '%s\n' "${_kb_lib_dir%/*}"; }
 
 # Single source of truth for the namespace label: install-watcher.sh owns it.
 keeper_label() { bash "$(_kb_scripts)/install-watcher.sh" label 2>/dev/null; }

--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -17,7 +17,16 @@
 # BASH_SOURCE, and its `$0` only names the sourced file while it is being read.
 _kb_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
 
-_kb_scripts() { printf '%s\n' "${_kb_lib_dir%/*}"; }
+# Returns non-zero rather than printing an empty path. The old `cd ../ && pwd`
+# propagated its failure; a bare parameter strip cannot, and both callers use the
+# result unchecked to build `bash "$scripts/..."` command lines. Testing for the
+# sibling covers a `cd` that failed (empty) and one that succeeded onto the
+# caller's cwd; it also covers `${x%/*}` having no root case, where "/" strips to "".
+_kb_scripts() {
+  local d="${_kb_lib_dir%/*}"
+  [ -n "$d" ] && [ -f "$d/install-watcher.sh" ] || return 1
+  printf '%s\n' "$d"
+}
 
 # Single source of truth for the namespace label: install-watcher.sh owns it.
 keeper_label() { bash "$(_kb_scripts)/install-watcher.sh" label 2>/dev/null; }
@@ -60,6 +69,15 @@ keeper_ensure_active() {
   autostart="$(grep '^keeper_autostart:' "$cfg" | head -1 | sed 's/^keeper_autostart:[[:space:]]*//')"
   [ "$autostart" = "false" ] && return 0
 
+  # Resolve the scripts dir before the label, so a lib that cannot find its own
+  # siblings says that, instead of surfacing as "install-watcher.sh broken?" and
+  # naming a file that is perfectly fine.
+  local scripts
+  if ! scripts="$(_kb_scripts)"; then
+    printf 'vaultkeeper: cannot find the scripts dir beside this lib (looked beside "%s"); activation skipped\n' "$_kb_lib_dir" >&2
+    return 0
+  fi
+
   # A missing/empty label means the installer is broken — that's an error to
   # report, not a "not installed" signal to barrel past into a doomed install.
   local label; label="$(keeper_label)"
@@ -70,7 +88,6 @@ keeper_ensure_active() {
 
   keeper_scheduler_installed && return 0
 
-  local scripts; scripts="$(_kb_scripts)"
   local tick="$scripts/vaultkeeper-tick.sh"
   if ! bash "$scripts/seed-frontmatter-schema.sh" "$vault" "$cfg" >/dev/null 2>&1; then
     printf 'vaultkeeper: frontmatter-schema seed failed; using default (tags type)\n' >&2

--- a/scripts/lib/resolve-config.sh
+++ b/scripts/lib/resolve-config.sh
@@ -45,7 +45,14 @@ resolve_obsidian_config() {
 # canonical stable path regardless of existence (used by the setup wizard to
 # decide where to write). Skills can call:
 #   CONFIG="$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-config.sh")"
-if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+# This one stays a bare BASH_SOURCE comparison, unlike the source-time captures in
+# allowlist-validate.sh / keeper-bootstrap.sh / vault-scan.sh. Do NOT "fix" it to
+# `${BASH_SOURCE[0]:-$0}`: under zsh that compares $0 to itself, the branch fires
+# while merely being sourced, and the `exit` below kills the sourcing shell — which
+# is session-save.sh, the Stop hook. Six bash scripts source this file. The `:-`
+# below is only for `set -u` safety; it leaves the comparison false under zsh,
+# which is correct in both directions there.
+if [ "${BASH_SOURCE[0]:-}" = "${0}" ]; then
   if [ "${1:-}" = "--stable" ]; then
     obsidian_config_stable_path
     exit 0

--- a/scripts/lib/vault-scan.sh
+++ b/scripts/lib/vault-scan.sh
@@ -18,10 +18,15 @@
 # Directory captured at source time; see the note in allowlist-validate.sh for
 # why BASH_SOURCE alone is not enough (zsh).
 _vs_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
-. "${_vs_lib_dir}/dedup-scan.sh" 2>/dev/null || {
-  printf 'vault-scan: cannot source dedup-scan.sh from "%s" — clustering has no tokenizer\n' "$_vs_lib_dir" >&2
+# Pre-test, not `. file || handler`: `.` is a POSIX special builtin, so under a
+# `set -e` caller — which vaultkeeper-tick.sh is, and it is the only production
+# sourcer — the shell exits at the failed source and the handler never runs. Same
+# shape as the sibling check in allowlist-validate.sh.
+if [ ! -r "${_vs_lib_dir}/dedup-scan.sh" ]; then
+  printf 'vault-scan: cannot read dedup-scan.sh beside this lib (looked in "%s") — clustering has no tokenizer\n' "$_vs_lib_dir" >&2
   return 1 2>/dev/null || exit 1
-}
+fi
+. "${_vs_lib_dir}/dedup-scan.sh"
 
 _scan_find_md() {
   find "$1" -type f -name '*.md' \

--- a/scripts/lib/vault-scan.sh
+++ b/scripts/lib/vault-scan.sh
@@ -2,7 +2,12 @@
 # vault-scan.sh — compute surfacing candidates from the vault. .md only;
 # excludes .obsidian/, .trash/, .git/, .vaultkeeper-quarantine/. Never reads
 # .base files (they are not .md, so the find filters exclude them).
-# Requires frontmatter.sh.
+# Requires frontmatter.sh. Sources dedup-scan.sh for the shared tokenize_slug so
+# clustering cannot drift from dedup/MOC — vaultkeeper-tick.sh does not source it.
+# Directory captured at source time; see the note in allowlist-validate.sh for
+# why BASH_SOURCE alone is not enough (zsh).
+_vs_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+command -v tokenize_slug >/dev/null 2>&1 || . "${_vs_lib_dir}/dedup-scan.sh"
 
 _scan_find_md() {
   find "$1" -type f -name '*.md' \
@@ -18,6 +23,7 @@ scan_frontmatter_gaps() {
     miss="$(frontmatter_missing "$f" "$required" | sort | paste -sd, -)"
     [ -n "$miss" ] && printf 'GAP\t%s\t%s\n' "${f#"$vault"/}" "$miss"
   done < <(_scan_find_md "$vault")
+  return 0   # reports on stdout; a failed final test must not become the status
 }
 
 scan_unfiled() {
@@ -26,6 +32,7 @@ scan_unfiled() {
   while IFS= read -r f; do
     printf 'UNFILED\t%s\n' "${f#"$vault"/}"
   done < <(find "$vault/Inbox" -type f -name '*.md')
+  return 0   # reports on stdout; a failed final test must not become the status
 }
 
 scan_open_asks() {
@@ -35,6 +42,7 @@ scan_open_asks() {
       printf 'ASK\t%s\n' "${f#"$vault"/}"
     fi
   done < <(_scan_find_md "$vault")
+  return 0   # reports on stdout; a failed final test must not become the status
 }
 
 # Cluster: per immediate subfolder, count distinct files containing each slug
@@ -52,13 +60,14 @@ scan_clusters() {
     done < <(
       while IFS= read -r f; do
         base="$(basename "$f" .md)"
-        for tok in $(printf '%s\n' "$base" | tr ' ' '-' | tr '-' '\n' | sort -u); do
-          [ -z "$tok" ] && continue
-          # drop purely numeric tokens
-          printf '%s' "$tok" | grep -qE '^[0-9]+$' && continue
-          [ "${#tok}" -le 1 ] && continue
-          printf '%s\n' "$tok"
-        done
+        # Shared tokenizer, so clustering agrees with dedup and MOC promotion
+        # instead of drifting as a third inline copy (#27). Spaces are folded to
+        # the same separator first — tokenize_slug splits on `-` only, and this
+        # vault has filenames with spaces. `sort -u` keeps the count "distinct
+        # files containing the token", not total occurrences.
+        printf '%s\n' "$base" | tr ' ' '-' | while IFS= read -r slug; do
+          tokenize_slug "$slug"
+        done | sort -u
       done < <(find "$dir" -maxdepth 1 -type f -name '*.md') \
         | sort | uniq -c
     )
@@ -68,4 +77,5 @@ scan_clusters() {
             ! -path '*/.git'      ! -path '*/.git/*' \
             ! -path '*/.vaultkeeper-quarantine' ! -path '*/.vaultkeeper-quarantine/*' \
             ! -path '*/.vaultkeeper'            ! -path '*/.vaultkeeper/*')
+  return 0   # reports on stdout; a failed final test must not become the status
 }

--- a/scripts/lib/vault-scan.sh
+++ b/scripts/lib/vault-scan.sh
@@ -2,12 +2,26 @@
 # vault-scan.sh — compute surfacing candidates from the vault. .md only;
 # excludes .obsidian/, .trash/, .git/, .vaultkeeper-quarantine/. Never reads
 # .base files (they are not .md, so the find filters exclude them).
-# Requires frontmatter.sh. Sources dedup-scan.sh for the shared tokenize_slug so
-# clustering cannot drift from dedup/MOC — vaultkeeper-tick.sh does not source it.
+# Requires frontmatter.sh. Sources dedup-scan.sh itself for the shared
+# tokenize_slug, so clustering agrees with dedup and MOC promotion instead of
+# carrying its own copy — vaultkeeper-tick.sh sources this file but not
+# dedup-scan.sh. Unconditionally, on purpose: a `command -v tokenize_slug` guard
+# would hand the job to whatever the caller already had in scope, which is exactly
+# the drift a shared tokenizer is for. dedup-scan.sh is function definitions with
+# no source-time state, so re-sourcing it costs one file read and is idempotent.
+#
+# scan_* report on stdout and their exit status carries no "found something"
+# signal — they always return 0. `[ cond ] && printf` as a function's last
+# statement otherwise leaks the failed test out as the return value, which is what
+# `X="$(scan_clusters …)"` under `set -e` aborts on.
+#
 # Directory captured at source time; see the note in allowlist-validate.sh for
 # why BASH_SOURCE alone is not enough (zsh).
 _vs_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
-command -v tokenize_slug >/dev/null 2>&1 || . "${_vs_lib_dir}/dedup-scan.sh"
+. "${_vs_lib_dir}/dedup-scan.sh" 2>/dev/null || {
+  printf 'vault-scan: cannot source dedup-scan.sh from "%s" — clustering has no tokenizer\n' "$_vs_lib_dir" >&2
+  return 1 2>/dev/null || exit 1
+}
 
 _scan_find_md() {
   find "$1" -type f -name '*.md' \
@@ -23,7 +37,7 @@ scan_frontmatter_gaps() {
     miss="$(frontmatter_missing "$f" "$required" | sort | paste -sd, -)"
     [ -n "$miss" ] && printf 'GAP\t%s\t%s\n' "${f#"$vault"/}" "$miss"
   done < <(_scan_find_md "$vault")
-  return 0   # reports on stdout; a failed final test must not become the status
+  return 0
 }
 
 scan_unfiled() {
@@ -32,7 +46,7 @@ scan_unfiled() {
   while IFS= read -r f; do
     printf 'UNFILED\t%s\n' "${f#"$vault"/}"
   done < <(find "$vault/Inbox" -type f -name '*.md')
-  return 0   # reports on stdout; a failed final test must not become the status
+  return 0
 }
 
 scan_open_asks() {
@@ -42,7 +56,7 @@ scan_open_asks() {
       printf 'ASK\t%s\n' "${f#"$vault"/}"
     fi
   done < <(_scan_find_md "$vault")
-  return 0   # reports on stdout; a failed final test must not become the status
+  return 0
 }
 
 # Cluster: per immediate subfolder, count distinct files containing each slug
@@ -60,11 +74,10 @@ scan_clusters() {
     done < <(
       while IFS= read -r f; do
         base="$(basename "$f" .md)"
-        # Shared tokenizer, so clustering agrees with dedup and MOC promotion
-        # instead of drifting as a third inline copy (#27). Spaces are folded to
-        # the same separator first — tokenize_slug splits on `-` only, and this
-        # vault has filenames with spaces. `sort -u` keeps the count "distinct
-        # files containing the token", not total occurrences.
+        # Spaces are folded to the same separator before tokenizing: tokenize_slug
+        # splits on `-` only, and this vault has filenames with spaces. `sort -u`
+        # keeps the count "distinct files containing the token", not total
+        # occurrences.
         printf '%s\n' "$base" | tr ' ' '-' | while IFS= read -r slug; do
           tokenize_slug "$slug"
         done | sort -u
@@ -77,5 +90,5 @@ scan_clusters() {
             ! -path '*/.git'      ! -path '*/.git/*' \
             ! -path '*/.vaultkeeper-quarantine' ! -path '*/.vaultkeeper-quarantine/*' \
             ! -path '*/.vaultkeeper'            ! -path '*/.vaultkeeper/*')
-  return 0   # reports on stdout; a failed final test must not become the status
+  return 0
 }

--- a/skills/create-note/SKILL.md
+++ b/skills/create-note/SKILL.md
@@ -53,7 +53,8 @@ native here.
 
        . "${CLAUDE_PLUGIN_ROOT}/scripts/lib/allowlist-validate.sh"
        if ! allowlist_validate "<resolved-target>"; then
-         # refusal + closest match already printed to stderr; surface it and stop.
+         # allowlist_validate already printed the refusal to stderr; surface it and stop.
+         # A refusal naming /obsidian:setup is a config fault — do not ask for a folder.
          exit 0
        fi
 

--- a/skills/save-conversation/SKILL.md
+++ b/skills/save-conversation/SKILL.md
@@ -167,11 +167,12 @@ Source the shared validator and call it — do not re-implement the parse/normal
 
     . "${CLAUDE_PLUGIN_ROOT}/scripts/lib/allowlist-validate.sh"
     if ! allowlist_validate "<target>"; then
-      # allowlist_validate printed the refusal + closest match to stderr; surface it and stop.
+      # allowlist_validate printed the refusal to stderr; surface it and stop. A refusal
+      # naming /obsidian:setup is a config fault, not a bad target — do not ask for a folder.
       exit 0
     fi
 
-`allowlist_validate` reads the `## Project Taxonomy` table as the canonical allow-list, normalizes case, matches the target's top-level prefix (dated subfolders and per-repo namespacing under a root are valid), and on failure prints the closest match. Do not create unrecognized top-level folders.
+`allowlist_validate` reads the `## Project Taxonomy` table as the canonical allow-list, normalizes case, matches the target's top-level prefix (dated subfolders and per-repo namespacing under a root are valid), and on failure prints a refusal. Two shapes: a target that is not allow-listed comes with a closest match; a config that resolves to no taxonomy rows names `/obsidian:setup` instead and has no match to offer. Do not create unrecognized top-level folders, and do not treat a config fault as a routing question.
 
 If `strict_domains: false`, skip this validation.
 
@@ -238,7 +239,7 @@ source: claude-code
 6. **Generate title** — create descriptive kebab-case title from topic, e.g. `2026-02-19-obsidian-vault-consolidation`
 7. **Build content** — format conversation as structured markdown per template above (or use `Templates/session.md` from vault if it exists)
 8. **Determine full path** — `<vault_path>/<target-folder>/<YYYY-MM-DD-title>.md`
-9. **Validate allow-list** — `strict_domains` defaults to `true` when absent; only an explicit `false` skips validation. See "Allow-list Validation (strict_domains)" above. If the top-level folder is not allow-listed, refuse and surface the closest match. Do not create the folder. If routing landed in `Inbox/` because no clear domain matched, prompt for confirmation ("No clear domain match — routing to `Inbox/`. Confirm or supply a topic hint") rather than writing silently.
+9. **Validate allow-list** — `strict_domains` defaults to `true` when absent; only an explicit `false` skips validation. See "Allow-list Validation (strict_domains)" above. If the top-level folder is not allow-listed, refuse and surface the closest match. If the refusal names `/obsidian:setup` instead, the config is the problem — surface it and stop rather than asking where to file. Do not create the folder. If routing landed in `Inbox/` because no clear domain matched, prompt for confirmation ("No clear domain match — routing to `Inbox/`. Confirm or supply a topic hint") rather than writing silently.
 10. **Same-day dedup check** — see "Same-Day Dedup Check" below. Before writing, scan the **confirmed** target folder (after any Inbox redirect or topic-hint correction from step 7) for same-day notes and offer append vs new-file when an existing match scores above the threshold.
 11. **Write through the keeper.** The keeper creates parent dirs, applies the
     template, writes the file, and links the INDEX — this skill does not `mkdir`

--- a/tests/allowlist-validate.sh
+++ b/tests/allowlist-validate.sh
@@ -36,5 +36,28 @@ if allowlist_validate "Dailyish/x.md" "$CFG" 2>/dev/null; then fail "Dailyish mu
 
 if command -v zsh >/dev/null 2>&1; then
   zsh -c ". '$ROOT_DIR/scripts/lib/allowlist-validate.sh'; allowlist_list '$CFG'" >/dev/null 2>"$TMP/zerr" || { cat "$TMP/zerr" >&2; fail "allowlist-validate broke under zsh"; }
+
+  # The arm above passes $CFG explicitly, so it never exercises self-resolution —
+  # which is how the real failure hid. The lib locates resolve-config.sh via
+  # BASH_SOURCE; zsh leaves that unset, so dirname "" -> "." and the lookup
+  # silently became cwd-dependent. Under zsh from any other cwd, config
+  # resolution failed and strict validation refused every target.
+  OBSIDIAN_LOCAL_MD="$CFG" zsh -c "cd / && . '$ROOT_DIR/scripts/lib/allowlist-validate.sh'; allowlist_validate 'Daily/2026-06-29.md'" 2>"$TMP/zerr2" \
+    || { cat "$TMP/zerr2" >&2; fail "zsh + foreign cwd: lib could not locate its own resolve-config.sh"; }
+  # Same shape under bash, for symmetry — a cwd-independent lib must not care.
+  OBSIDIAN_LOCAL_MD="$CFG" bash -c "cd / && . '$ROOT_DIR/scripts/lib/allowlist-validate.sh'; allowlist_validate 'Daily/2026-06-29.md'" 2>"$TMP/berr" \
+    || { cat "$TMP/berr" >&2; fail "bash + foreign cwd: lib could not locate its own resolve-config.sh"; }
 fi
+
+# No config anywhere: the refusal must name the actual problem. Reporting a
+# blank "Closest match:" makes a missing config look like a bad target.
+EMPTY="$TMP/empty-xdg"; mkdir -p "$EMPTY"
+if env -u OBSIDIAN_LOCAL_MD -u CLAUDE_PLUGIN_ROOT XDG_CONFIG_HOME="$EMPTY" \
+     bash -c ". '$ROOT_DIR/scripts/lib/allowlist-validate.sh'; allowlist_validate 'Daily/x.md'" 2>"$TMP/noerr"; then
+  fail "validation must fail closed when no config resolves"
+fi
+grep -q 'obsidian:setup' "$TMP/noerr" \
+  || fail "no-config refusal should point at /obsidian:setup, got: $(cat "$TMP/noerr")"
+grep -q 'Closest match:[[:space:]]*$' "$TMP/noerr" \
+  && fail "no-config refusal printed a blank closest match: $(cat "$TMP/noerr")"
 echo "PASS: allowlist-validate"

--- a/tests/allowlist-validate.sh
+++ b/tests/allowlist-validate.sh
@@ -102,4 +102,17 @@ for _cfg in "$NOTAX" "$EMPTYTAX"; do
   grep -q 'Closest match' "$TMP/taxerr" \
     && fail "empty-taxonomy refusal must not offer a closest match ($_cfg): $(cat "$TMP/taxerr")"
 done
+# A lib that landed away from its siblings must name the install, not the config.
+# Reporting this as "no config resolved — run /obsidian:setup" is the #27
+# misdirection one layer up: setup cannot fix a lib that lost its own path.
+ORPHAN="$TMP/orphan"; mkdir -p "$ORPHAN"
+cp "$ROOT_DIR/scripts/lib/allowlist-validate.sh" "$ORPHAN/"
+if bash -c ". '$ORPHAN/allowlist-validate.sh'; allowlist_validate 'Daily/x.md'" 2>"$TMP/orpherr"; then
+  fail "validation must fail closed when the lib cannot find resolve-config.sh"
+fi
+grep -q 'the install is broken, not the config' "$TMP/orpherr" \
+  || fail "orphaned lib should name the install; got: $(cat "$TMP/orpherr")"
+grep -q 'no config resolved' "$TMP/orpherr" \
+  && fail "orphaned lib blamed the config: $(cat "$TMP/orpherr")"
+
 echo "PASS: allowlist-validate"

--- a/tests/allowlist-validate.sh
+++ b/tests/allowlist-validate.sh
@@ -58,6 +58,42 @@ if env -u OBSIDIAN_LOCAL_MD -u CLAUDE_PLUGIN_ROOT XDG_CONFIG_HOME="$EMPTY" \
 fi
 grep -q 'obsidian:setup' "$TMP/noerr" \
   || fail "no-config refusal should point at /obsidian:setup, got: $(cat "$TMP/noerr")"
-grep -q 'Closest match:[[:space:]]*$' "$TMP/noerr" \
-  && fail "no-config refusal printed a blank closest match: $(cat "$TMP/noerr")"
+# The symptom was the missing config being reported as an un-allow-listed target.
+# Assert the absence of that claim, not the blank match it left behind: the old
+# `Closest match:[[:space:]]*$` anchor could never fire, because the message
+# continues past the match ("Closest match: %s. Add it to ...").
+grep -q 'not in the allow-list' "$TMP/noerr" \
+  && fail "no-config refusal blamed the target instead of the config: $(cat "$TMP/noerr")"
+
+# A config that resolves but yields no allow-list rows is its own failure, and it
+# reaches a different branch than the no-config case above (there, allowlist_list
+# fails and short-circuits before the list is ever inspected). Both routes in:
+NOTAX="$TMP/no-taxonomy.md"
+cat > "$NOTAX" <<'EOF'
+---
+vault_path: /tmp/nowhere
+---
+
+## Routing Rules
+
+Nothing here declares a taxonomy.
+EOF
+EMPTYTAX="$TMP/empty-taxonomy.md"
+cat > "$EMPTYTAX" <<'EOF'
+## Project Taxonomy
+
+| Domain | Vault path | Precedence | Notes |
+|--------|-----------|------------|-------|
+
+## Routing Rules
+EOF
+for _cfg in "$NOTAX" "$EMPTYTAX"; do
+  if allowlist_validate "Daily/x.md" "$_cfg" 2>"$TMP/taxerr"; then
+    fail "validation must fail closed when the taxonomy has no rows ($_cfg)"
+  fi
+  grep -q 'no readable ## Project Taxonomy allow-list' "$TMP/taxerr" \
+    || fail "empty-taxonomy refusal should name the taxonomy ($_cfg), got: $(cat "$TMP/taxerr")"
+  grep -q 'Closest match' "$TMP/taxerr" \
+    && fail "empty-taxonomy refusal must not offer a closest match ($_cfg): $(cat "$TMP/taxerr")"
+done
 echo "PASS: allowlist-validate"

--- a/tests/allowlist-validate.sh
+++ b/tests/allowlist-validate.sh
@@ -34,19 +34,25 @@ grep -q 'Projects/Development' "$TMP/err" || fail "closest match not surfaced: $
 # a folder that only shares a prefix substring but not a path segment is refused
 if allowlist_validate "Dailyish/x.md" "$CFG" 2>/dev/null; then fail "Dailyish must not match Daily"; fi
 
+# Every arm above passes $CFG explicitly, so none of them exercises self-resolution
+# — which is how the real failure hid. The lib *used to* locate resolve-config.sh
+# with `dirname "${BASH_SOURCE[0]}"`; zsh leaves BASH_SOURCE unset, so that was
+# `dirname ""` -> "." and the lookup became cwd-dependent. From any cwd other than
+# scripts/lib, config resolution failed and strict validation refused every target.
+# This arm runs unconditionally: a cwd-independent lib must not care which shell
+# it is, so bash catches a broken capture (`_av_lib_dir="."`) just as well.
+OBSIDIAN_LOCAL_MD="$CFG" bash -c "cd / && . '$ROOT_DIR/scripts/lib/allowlist-validate.sh'; allowlist_validate 'Daily/2026-06-29.md'" 2>"$TMP/berr" \
+  || { cat "$TMP/berr" >&2; fail "bash + foreign cwd: lib could not locate its own resolve-config.sh"; }
+
 if command -v zsh >/dev/null 2>&1; then
   zsh -c ". '$ROOT_DIR/scripts/lib/allowlist-validate.sh'; allowlist_list '$CFG'" >/dev/null 2>"$TMP/zerr" || { cat "$TMP/zerr" >&2; fail "allowlist-validate broke under zsh"; }
-
-  # The arm above passes $CFG explicitly, so it never exercises self-resolution —
-  # which is how the real failure hid. The lib locates resolve-config.sh via
-  # BASH_SOURCE; zsh leaves that unset, so dirname "" -> "." and the lookup
-  # silently became cwd-dependent. Under zsh from any other cwd, config
-  # resolution failed and strict validation refused every target.
+  # zsh is the shell that actually regressed, so this is the load-bearing arm.
   OBSIDIAN_LOCAL_MD="$CFG" zsh -c "cd / && . '$ROOT_DIR/scripts/lib/allowlist-validate.sh'; allowlist_validate 'Daily/2026-06-29.md'" 2>"$TMP/zerr2" \
     || { cat "$TMP/zerr2" >&2; fail "zsh + foreign cwd: lib could not locate its own resolve-config.sh"; }
-  # Same shape under bash, for symmetry — a cwd-independent lib must not care.
-  OBSIDIAN_LOCAL_MD="$CFG" bash -c "cd / && . '$ROOT_DIR/scripts/lib/allowlist-validate.sh'; allowlist_validate 'Daily/2026-06-29.md'" 2>"$TMP/berr" \
-    || { cat "$TMP/berr" >&2; fail "bash + foreign cwd: lib could not locate its own resolve-config.sh"; }
+else
+  # Say so out loud. A silent skip reports `ok` for a shell-portability fix whose
+  # only tripwire never ran.
+  printf 'SKIP: zsh absent — zsh self-location coverage did not run on this host\n' >&2
 fi
 
 # No config anywhere: the refusal must name the actual problem. Reporting a

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -116,4 +116,15 @@ SAVE="${ROOT_DIR}/scripts/session-save.sh"
 grep -q 'keeper-bootstrap.sh' "$SAVE" || fail "session-save.sh does not source keeper-bootstrap.sh"
 grep -q 'keeper_ensure_active' "$SAVE" || fail "session-save.sh never calls keeper_ensure_active"
 
+# --- self-location is shell- and cwd-independent ---
+# The Stop hook sources this lib, and the librarian/keeper runtime is zsh, which
+# has no BASH_SOURCE. Resolving the scripts dir from "." meant the lib only found
+# its siblings when the caller happened to be standing in scripts/lib.
+EXPECT="${ROOT_DIR}/scripts"
+for sh in bash zsh; do
+  command -v "$sh" >/dev/null 2>&1 || continue
+  GOT="$("$sh" -c "cd / && . '${ROOT_DIR}/scripts/lib/keeper-bootstrap.sh'; _kb_scripts" 2>/dev/null)"
+  [ "$GOT" = "$EXPECT" ] || fail "$sh + foreign cwd: _kb_scripts gave [$GOT], want [$EXPECT]"
+done
+
 echo "PASS: keeper-bootstrap"

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -127,4 +127,20 @@ for sh in bash zsh; do
   [ "$GOT" = "$EXPECT" ] || fail "$sh + foreign cwd: _kb_scripts gave [$GOT], want [$EXPECT]"
 done
 
+# A lib that cannot find its siblings must say so, not print an empty path and
+# report success — both callers build `bash "$scripts/..."` from it unchecked, and
+# the resulting empty-label branch used to blame install-watcher.sh by name.
+ORPHAN="$WORK/orphan/lib"; mkdir -p "$ORPHAN"
+cp "${ROOT_DIR}/scripts/lib/keeper-bootstrap.sh" "$ORPHAN/"
+if bash -c ". '$ORPHAN/keeper-bootstrap.sh'; _kb_scripts" >"$WORK/orph.out" 2>/dev/null; then
+  fail "_kb_scripts must fail when install-watcher.sh is not beside the lib, printed: [$(cat "$WORK/orph.out")]"
+fi
+[ -s "$WORK/orph.out" ] && fail "_kb_scripts printed a path on failure: [$(cat "$WORK/orph.out")]"
+OERR="$(KEEPER_OS="Darwin" bash -c ". '$ORPHAN/keeper-bootstrap.sh'; keeper_ensure_active '$CFG' '$VAULT' 900" 2>&1 >/dev/null)" \
+  || fail "keeper_ensure_active must still return 0 when self-location fails (never abort the hook)"
+grep -q 'cannot find the scripts dir' <<<"$OERR" \
+  || fail "self-location failure was not named; got: [$OERR]"
+grep -q 'install-watcher.sh broken' <<<"$OERR" \
+  && fail "self-location failure blamed install-watcher.sh: [$OERR]"
+
 echo "PASS: keeper-bootstrap"

--- a/tests/vault-scan.sh
+++ b/tests/vault-scan.sh
@@ -141,4 +141,22 @@ if printf '%s\n' "$SPACE_CLUSTERS" | grep "SpaceTest" | awk -F'\t' '{print $4}' 
   fail "space-filename produced a spurious count-1 cluster token"
 fi
 
+# The canonical tokenizer wins over whatever the caller already had in scope. The
+# old `command -v tokenize_slug ||` guard adopted the caller's definition instead,
+# which is the drift the shared tokenizer exists to prevent.
+HOSTILE="$(bash -c "tokenize_slug() { printf 'HOSTILE\n'; }; . '$ROOT_DIR/scripts/lib/frontmatter.sh'; . '$ROOT_DIR/scripts/lib/vault-scan.sh'; scan_clusters '$V' 3")"
+grep -qF 'HOSTILE' <<<"$HOSTILE" && fail "a caller-defined tokenize_slug won over the canonical one: [$HOSTILE]"
+grep -qF "CLUSTER"$'\t'"Projects"$'\t'"weekly" <<<"$HOSTILE" \
+  || fail "canonical tokenizer produced no clusters after overriding the caller's: [$HOSTILE]"
+
+# A missing dedup-scan.sh must be named at source time, not surface later as a
+# clean-looking empty scan.
+VSORPH="$TMP/vs-orphan"; mkdir -p "$VSORPH"
+cp "$ROOT_DIR/scripts/lib/vault-scan.sh" "$VSORPH/"
+if bash -c ". '$ROOT_DIR/scripts/lib/frontmatter.sh'; . '$VSORPH/vault-scan.sh'" 2>"$TMP/vserr"; then
+  fail "sourcing vault-scan.sh without dedup-scan.sh beside it must fail"
+fi
+grep -q 'cannot source dedup-scan.sh' "$TMP/vserr" \
+  || fail "missing tokenizer was not named; got: $(cat "$TMP/vserr")"
+
 echo "PASS: vault-scan"

--- a/tests/vault-scan.sh
+++ b/tests/vault-scan.sh
@@ -77,6 +77,23 @@ ARC=0; ( set -e; scan_open_asks "$V" >/dev/null ) || ARC=$?
 [ "$ARC" = "0" ] || fail "scan_open_asks returned $ARC"
 rm -rf "$V/ZZlast"
 
+# Self-location: this lib resolves dedup-scan.sh next to itself at source time, so a
+# cwd-relative capture leaves tokenize_slug undefined and clustering silently empty.
+# It is the only one of the three captures whose failure also kills the caller —
+# vaultkeeper-tick.sh runs `set -euo pipefail`, and a failed `.` aborts it at source
+# time. Run from a foreign cwd under both shells; zsh is the one that regressed.
+for _sh in bash zsh; do
+  command -v "$_sh" >/dev/null 2>&1 || {
+    printf 'SKIP: %s absent — self-location coverage did not run on this host\n' "$_sh" >&2
+    continue
+  }
+  _out="$("$_sh" -c "cd / && set -u; . '$ROOT_DIR/scripts/lib/frontmatter.sh'; . '$ROOT_DIR/scripts/lib/vault-scan.sh'; scan_clusters '$V' 3" 2>"$TMP/selferr")" \
+    || { cat "$TMP/selferr" >&2; fail "$_sh + foreign cwd: vault-scan could not locate its own dedup-scan.sh"; }
+  grep -qF "CLUSTER"$'\t'"Projects"$'\t'"weekly" <<<"$_out" \
+    || fail "$_sh + foreign cwd: clustering produced no tokens (tokenize_slug undefined?): [$_out]"
+  [ -s "$TMP/selferr" ] && { cat "$TMP/selferr" >&2; fail "$_sh + foreign cwd: vault-scan wrote to stderr"; }
+done
+
 # Spaces still split into tokens (a filename with spaces is common in this vault).
 mkdir -p "$V/Spaced"
 : > "$V/Spaced/beta note one.md"

--- a/tests/vault-scan.sh
+++ b/tests/vault-scan.sh
@@ -77,6 +77,17 @@ ARC=0; ( set -e; scan_open_asks "$V" >/dev/null ) || ARC=$?
 [ "$ARC" = "0" ] || fail "scan_open_asks returned $ARC"
 rm -rf "$V/ZZlast"
 
+# The GRC arm above cannot fail on this fixture: $V always contains a gap file, so
+# the loop's last body command succeeds and the natural status is already 0. The
+# status only leaks when NO file has a gap — then the body ends on a false
+# `[ -n "$miss" ] &&` and the while returns 1. Needs its own vault.
+VC="$TMP/vault-complete"; mkdir -p "$VC"
+printf -- '---\ntags: [x]\ntype: a\n---\n\nall fields present\n' > "$VC/complete-one.md"
+printf -- '---\ntags: [y]\ntype: b\n---\n\nall fields present\n' > "$VC/complete-two.md"
+[ -z "$(scan_frontmatter_gaps "$VC" "tags type")" ] || fail "complete vault should report no gaps"
+GRC2=0; ( set -e; scan_frontmatter_gaps "$VC" "tags type" >/dev/null ) || GRC2=$?
+[ "$GRC2" = "0" ] || fail "scan_frontmatter_gaps returned $GRC2 on a gap-free vault"
+
 # Self-location: this lib resolves dedup-scan.sh next to itself at source time, so a
 # cwd-relative capture leaves tokenize_slug undefined and clustering silently empty.
 # It is the only one of the three captures whose failure also kills the caller —

--- a/tests/vault-scan.sh
+++ b/tests/vault-scan.sh
@@ -60,11 +60,15 @@ mkdir -p "$V/Casing"
 CCLUST="$(scan_clusters "$V" 3)"
 has "CLUSTER"$'\t'"Casing"$'\t'"alpha"$'\t'"3" "$CCLUST"
 grep -qF 'ALPHA' <<<"$CCLUST" && fail "cluster tokens must be case-folded, got:"$'\n'"$CCLUST"
-# scan_* report through stdout, so their exit status must be success even when
-# they find nothing. scan_clusters used to return the status of its last
-# threshold test: one trailing folder with no above-threshold token made it
-# return 1, which aborts any `set -e` caller — and vaultkeeper-tick.sh runs
-# `set -euo pipefail` and assigns from it.
+# scan_* report on stdout; their exit status carries no "found something" signal.
+# scan_clusters used to leak the status of its last threshold test, so one trailing
+# folder with no above-threshold token made it return 1 after writing correct
+# output — which aborts `X="$(scan_clusters …)"` under `set -e`.
+#
+# vaultkeeper-tick.sh happens to survive that, despite `set -euo pipefail`: its
+# brace group ends with an `if` that returns 0 either way, so the scan's status
+# never becomes the group's. Positional luck, not protection — move that `if` and
+# the tick aborts. Verified both ways before writing this.
 mkdir -p "$V/ZZlast"
 : > "$V/ZZlast/solitary-note.md"
 CRC=0; ( set -e; scan_clusters "$V" 3 >/dev/null ) || CRC=$?

--- a/tests/vault-scan.sh
+++ b/tests/vault-scan.sh
@@ -49,6 +49,42 @@ has "CLUSTER"$'\t'"Projects"$'\t'"weekly"$'\t'"3" "$CLUSTERS"
 lacks "CLUSTER"$'\t'"Projects"$'\t'"review" "$CLUSTERS"
 grep -q '\.base' <<<"$CLUSTERS" && fail ".base leaked into clusters"
 
+# Clustering routes through the shared tokenize_slug, so it agrees with dedup and
+# MOC promotion instead of carrying a third inline tokenizer. The visible effect
+# is case folding: these three belong to one cluster, and an uppercased token is
+# not its own separate one.
+mkdir -p "$V/Casing"
+: > "$V/Casing/Alpha-first.md"
+: > "$V/Casing/alpha-second.md"
+: > "$V/Casing/ALPHA-third.md"
+CCLUST="$(scan_clusters "$V" 3)"
+has "CLUSTER"$'\t'"Casing"$'\t'"alpha"$'\t'"3" "$CCLUST"
+grep -qF 'ALPHA' <<<"$CCLUST" && fail "cluster tokens must be case-folded, got:"$'\n'"$CCLUST"
+# scan_* report through stdout, so their exit status must be success even when
+# they find nothing. scan_clusters used to return the status of its last
+# threshold test: one trailing folder with no above-threshold token made it
+# return 1, which aborts any `set -e` caller — and vaultkeeper-tick.sh runs
+# `set -euo pipefail` and assigns from it.
+mkdir -p "$V/ZZlast"
+: > "$V/ZZlast/solitary-note.md"
+CRC=0; ( set -e; scan_clusters "$V" 3 >/dev/null ) || CRC=$?
+[ "$CRC" = "0" ] || fail "scan_clusters returned $CRC with a below-threshold trailing folder"
+GRC=0; ( set -e; scan_frontmatter_gaps "$V" "tags type" >/dev/null ) || GRC=$?
+[ "$GRC" = "0" ] || fail "scan_frontmatter_gaps returned $GRC"
+URC=0; ( set -e; scan_unfiled "$V" >/dev/null ) || URC=$?
+[ "$URC" = "0" ] || fail "scan_unfiled returned $URC"
+ARC=0; ( set -e; scan_open_asks "$V" >/dev/null ) || ARC=$?
+[ "$ARC" = "0" ] || fail "scan_open_asks returned $ARC"
+rm -rf "$V/ZZlast"
+
+# Spaces still split into tokens (a filename with spaces is common in this vault).
+mkdir -p "$V/Spaced"
+: > "$V/Spaced/beta note one.md"
+: > "$V/Spaced/beta note two.md"
+: > "$V/Spaced/beta-note-three.md"
+SCLUST="$(scan_clusters "$V" 3)"
+has "CLUSTER"$'\t'"Spaced"$'\t'"beta"$'\t'"3" "$SCLUST"
+
 # keeper-owned files must not appear in any scan output
 for _scan_out in "$GAPS" "$ASKS" "$CLUSTERS"; do
   grep -qF 'Librarian.md' <<<"$_scan_out" && fail "Librarian.md leaked into scan output"

--- a/tests/vault-scan.sh
+++ b/tests/vault-scan.sh
@@ -154,13 +154,18 @@ grep -qF "CLUSTER"$'\t'"Projects"$'\t'"weekly" <<<"$HOSTILE" \
   || fail "canonical tokenizer produced no clusters after overriding the caller's: [$HOSTILE]"
 
 # A missing dedup-scan.sh must be named at source time, not surface later as a
-# clean-looking empty scan.
+# clean-looking empty scan. Asserted under `set -euo pipefail`, because that is
+# what the only production sourcer (vaultkeeper-tick.sh) runs — and it is the
+# context a `. file || handler` guard silently fails to cover, since `.` is a
+# special builtin and errexit exits before the handler.
 VSORPH="$TMP/vs-orphan"; mkdir -p "$VSORPH"
 cp "$ROOT_DIR/scripts/lib/vault-scan.sh" "$VSORPH/"
-if bash -c ". '$ROOT_DIR/scripts/lib/frontmatter.sh'; . '$VSORPH/vault-scan.sh'" 2>"$TMP/vserr"; then
-  fail "sourcing vault-scan.sh without dedup-scan.sh beside it must fail"
-fi
-grep -q 'cannot source dedup-scan.sh' "$TMP/vserr" \
-  || fail "missing tokenizer was not named; got: $(cat "$TMP/vserr")"
+for _flags in '' 'set -euo pipefail;'; do
+  if bash -c "$_flags . '$ROOT_DIR/scripts/lib/frontmatter.sh'; . '$VSORPH/vault-scan.sh'" 2>"$TMP/vserr"; then
+    fail "sourcing vault-scan.sh without dedup-scan.sh beside it must fail [flags: ${_flags:-none}]"
+  fi
+  grep -q 'cannot read dedup-scan.sh' "$TMP/vserr" \
+    || fail "missing tokenizer was not named [flags: ${_flags:-none}]; got: $(cat "$TMP/vserr")"
+done
 
 echo "PASS: vault-scan"


### PR DESCRIPTION
Closes #27

## Description (Issue Fixed & New Behavior)

#27 tracked two deferred follow-ups from #26. Working them surfaced a third, more serious problem underneath the first, and a fourth alongside it. An 8-agent review panel then found a fifth (a test that could not fail) and corrected my own explanation of the third — see "What the panel changed" below.

**Libs could not find their own siblings under zsh.** `allowlist-validate.sh` and `keeper-bootstrap.sh` located neighbouring scripts with `dirname "${BASH_SOURCE[0]}"`. `BASH_SOURCE` is a bashism — zsh leaves it unset, so that expression evaluates to `dirname ""` = `.` and every self-relative lookup silently became **cwd-relative**. zsh is the runtime: the librarian bootstrap sources these libs and `scripts/keeper` runs under it. From any directory other than `scripts/lib`, `allowlist_validate` resolved no config, failed closed, and **refused every write**.

This was not theoretical — it fired while saving a session note, which is why that save validated the allow-list by hand against the taxonomy table instead of trusting the validator. Both libs now capture their directory at source time via `"${BASH_SOURCE[0]:-$0}"`. zsh's `$0` is the sourced file while it is being read, which is exactly why the capture cannot live inside a function — there, `$0` is the function name.

**The refusal message hid which failure had happened** (item 2 of #27, filed as cosmetic). With no config, both scan loops iterate zero times, so the message read `Closest match: ` with nothing after it — a missing config presenting as a bad target. The allow-list is now read once, and a config whose taxonomy yields no rows gets its own message naming `/obsidian:setup`.

**Clustering carried its own inline tokenizer** (item 1 of #27). `scan_clusters` tokenized slugs inline; #26 unified dedup and MOC promotion onto `tokenize_slug` but not this path, so background surfacing could drift from the paths it feeds. It now calls the shared tokenizer, unconditionally.

**The scanners returned the status of their last test.** `scan_clusters` leaked the result of its final `[ cnt -ge threshold ]` comparison, so a vault whose last-scanned folder had no above-threshold token returned 1 *after writing correct output*. All four `scan_*` now return 0 explicitly, and the contract is stated once in the file header.

## What the panel changed

**I had the `set -e` victim wrong.** The original body said `vaultkeeper-tick.sh` "runs `set -euo pipefail` and assigns from it", implying the tick was aborting. It wasn't. The tick's brace group ends with `if [ -n "$CONFLICTS" ]; then …; fi`, which returns 0 either way, so the scan's status never becomes the group's status. Verified both directions: with that `if` last the assignment survives; delete only that line and the same construct exits 1. The fix is still correct — the tick is protected by which line happens to be last, and nothing recorded that — but the shape actually at risk is a bare `X="$(scan_clusters …)"` under `set -e`.

**A test that could not fail.** `tests/allowlist-validate.sh` asserted `Closest match:[[:space:]]*$`, anchored to end of line, against a message whose text continues past the match. It returned zero hits for every input. And the new empty-taxonomy branch had no coverage at all: with no config, `allowlist_list` fails and the `|| return 1` short-circuits before the list is inspected, so nothing in the suite reached it. Both now covered, both mutation-checked.

**Self-location still misdirected on failure.** Fixing the capture left its own failure path reproducing #27: `cd` failing leaves the var empty, and `dirname ""` → `.` → `cd .` *succeeds* onto the caller's cwd. Either way the user was told "no config resolved — run /obsidian:setup" with a good config on disk, and `keeper-bootstrap` blamed `install-watcher.sh` by name when that file was fine. Both libs now test for the expected sibling and name the install.

**`resolve-config.sh` keeps its bare comparison, deliberately.** It is the last `BASH_SOURCE` site in `scripts/lib/`, which reads like an oversight. Making it `${BASH_SOURCE[0]:-$0}` compares `$0` to itself under zsh, fires the CLI branch while merely being sourced, and the `exit` takes out the sourcing shell — `session-save.sh`, the Stop hook. Verified. Took `${BASH_SOURCE[0]:-}` (unchanged semantics, `set -u` clean) and wrote the reason down.

**Prose drift.** The gate now refuses for two reasons; the librarian and both SKILL.md call sites described one. They promised a "closest match" two of three refusals don't print, and told the LLM to "ask the user where to file" on a *config* fault — where a named folder becomes de-facto authorization to write outside the allow-list.

## Behaviour change to be aware of

**Cluster tokens are now case-folded**, so `Alpha-`, `alpha-`, and `ALPHA-` fall in one cluster. Two consequences on the first tick after this lands:

- Previously-distinct mixed-case tokens merge, cross the threshold, and produce **genuinely new** `CLUSTER` rows — the intended improvement.
- Any cluster whose token was previously emitted mixed-case reads as new against the persisted candidates snapshot, so `Pending.md` gets a **one-time batch of duplicate `- [ ] CLUSTER:` lines** next to rows you may already have acted on. `Pending.md` is hand-edited, so this is worth knowing before it happens rather than after. Not normalizing the snapshot here on purpose — that touches `keeper-state.sh`, which is outside this PR.

## Testing Procedure

1. Check out this branch and run `bash tests/run-all.sh` — expect `ALL PASS` (29 suites).
2. Confirm the self-location coverage runs on your host. `bash tests/allowlist-validate.sh` and `bash tests/vault-scan.sh` should print no `SKIP:` line if zsh is installed; if it isn't, they now say so out loud instead of reporting `ok` for coverage that never ran.
3. Mutation-check the headline fix: `sed -i '' '10s/.*/_av_lib_dir="."/' scripts/lib/allowlist-validate.sh`, then `bash tests/allowlist-validate.sh` → expect `FAIL: bash + foreign cwd`. Restore with `git checkout -- scripts/lib/allowlist-validate.sh`.
4. Mutation-check the new refusal coverage: delete the `if [ -z "$list" ]` block from `allowlist_validate`, run `bash tests/allowlist-validate.sh` → expect `FAIL: empty-taxonomy refusal should name the taxonomy`. Restore.
5. Mutation-check the scanner status: delete the `return 0` at `scripts/lib/vault-scan.sh:40`, run `bash tests/vault-scan.sh` → expect `FAIL: scan_frontmatter_gaps returned 1 on a gap-free vault`. Restore.
6. Confirm the rejected variant is genuinely dangerous: change `resolve-config.sh`'s guard to `${BASH_SOURCE[0]:-$0}` and run `zsh -c '. scripts/lib/resolve-config.sh; echo SURVIVED'` → the echo never prints. Restore.
7. Verify the write gate from a foreign cwd under zsh: `cd / && zsh -c ". <repo>/scripts/lib/allowlist-validate.sh; allowlist_validate 'Daily/2026-07-28.md'"` → exit 0, no output.

## Additional Notes

Follow-ups from the panel, filed separately rather than expanded into this PR: the scheduler orphaning on plugin upgrade (label-only installed check against a version-pinned plist path — the keeper silently stops after every update); `tokenize_slug` not folding spaces, which leaves same-day dedup blind to `beta note one` vs `beta-note-two`; `surfacing_pending_transition` appending without deduping against `Pending.md`; unchecked `find` status reporting a partial scan as complete; and the flat test fixture that never exercises the `.vaultkeeper*` exclusions.
