### PR TITLE
keeper-bootstrap: report config-write, temp-file, and installer failures

### DIFF
--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -92,8 +92,15 @@ keeper_ensure_active() {
   if ! bash "$scripts/seed-frontmatter-schema.sh" "$vault" "$cfg" >/dev/null 2>&1; then
     printf 'vaultkeeper: frontmatter-schema seed failed; using default (tags type)\n' >&2
   fi
-  _kb_cfg_ensure keeper_autostart true "$cfg" || true
-  _kb_cfg_ensure keeper_interval_secs "$interval" "$cfg" || true
+  # Non-fatal, but not silent: `|| true` discarded a failed mktemp/awk/mv, and a
+  # config that never gains keeper_interval_secs then runs at the compiled-in
+  # default forever with nothing to explain why. Name the key and the
+  # consequence, the way the schema seed above names its fallback. `|| printf`
+  # keeps the exit status 0, so the hook still cannot be aborted by this.
+  _kb_cfg_ensure keeper_autostart true "$cfg" \
+    || printf 'vaultkeeper: could not write keeper_autostart to %s; opt-out state is unrecorded\n' "$cfg" >&2
+  _kb_cfg_ensure keeper_interval_secs "$interval" "$cfg" \
+    || printf 'vaultkeeper: could not write keeper_interval_secs to %s; readers will fall back to the %ss default\n' "$cfg" "$interval" >&2
 
   local ok=""
   if [ -n "${VAULTKEEPER_INSTALL:-}" ]; then

--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -30,10 +30,11 @@ _kb_scripts() {
 
 # Single source of truth for the namespace label: install-watcher.sh owns it.
 # Deliberately does NOT swallow the installer's stderr — that text is the only
-# thing separating a syntax error from a missing dependency, and every caller
-# either wants it (keeper_ensure_active quotes it) or never triggers it. The
-# unchecked `$(_kb_scripts)` it used to interpolate turned a lost scripts dir
-# into `bash /install-watcher.sh`; fail instead of calling the wrong path.
+# thing separating a syntax error from a missing dependency. Redirecting is each
+# caller's decision: keeper_ensure_active captures it to quote in its refusal,
+# keeper_scheduler_installed drops it because a predicate has no channel to
+# report on. The unchecked `$(_kb_scripts)` it used to interpolate turned a lost
+# scripts dir into `bash /install-watcher.sh`; fail instead of the wrong path.
 keeper_label() {
   local scripts
   scripts="$(_kb_scripts)" || return 1
@@ -42,7 +43,12 @@ keeper_label() {
 
 keeper_scheduler_installed() {
   local os="${KEEPER_OS:-$(uname -s)}" label
-  label="$(keeper_label)"
+  # A predicate has no channel to explain a fault on, so it must not leak the
+  # installer's exit status — that status became this assignment's, and an errexit
+  # caller died here, before the handler on the next line could turn it into a
+  # plain "not installed". Nor its stderr, which would land unprefixed on whoever
+  # asked. keeper_ensure_active is the caller that quotes the installer.
+  label="$(keeper_label 2>/dev/null)" || label=""
   [ -n "$label" ] || return 1
   # Check LIVE state, not an on-disk artifact: install-watcher writes the plist
   # before `launchctl load`, so a failed load can leave a plist that was never

--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -42,13 +42,17 @@ keeper_label() {
 }
 
 keeper_scheduler_installed() {
-  local os="${KEEPER_OS:-$(uname -s)}" label
-  # A predicate has no channel to explain a fault on, so it must not leak the
-  # installer's exit status — that status became this assignment's, and an errexit
-  # caller died here, before the handler on the next line could turn it into a
-  # plain "not installed". Nor its stderr, which would land unprefixed on whoever
-  # asked. keeper_ensure_active is the caller that quotes the installer.
-  label="$(keeper_label 2>/dev/null)" || label=""
+  # Accepts an already-resolved label so keeper_ensure_active does not pay for a
+  # second installer spawn; still resolves its own when called bare as a predicate.
+  local os="${KEEPER_OS:-$(uname -s)}" label="${1:-}"
+  if [ -z "$label" ]; then
+    # A predicate has no channel to explain a fault on, so it must not leak the
+    # installer's exit status — that status became this assignment's, and an
+    # errexit caller died here, before the handler below could turn it into a
+    # plain "not installed". Nor its stderr, which would land unprefixed on
+    # whoever asked. keeper_ensure_active is the caller that quotes the installer.
+    label="$(keeper_label 2>/dev/null)" || label=""
+  fi
   [ -n "$label" ] || return 1
   # Check LIVE state, not an on-disk artifact: install-watcher writes the plist
   # before `launchctl load`, so a failed load can leave a plist that was never
@@ -98,28 +102,33 @@ keeper_ensure_active() {
 
   # A missing/empty label means the installer is broken — that's an error to
   # report, not a "not installed" signal to barrel past into a doomed install.
-  # Capture the installer's own stderr so the refusal quotes the actual fault
-  # instead of guessing; a failed mktemp costs only the quote, not the refusal.
-  local label lblerr lbltmp
-  lbltmp="$(mktemp "${TMPDIR:-/tmp}/kblbl-XXXXXX" 2>/dev/null)" || lbltmp=""
   # `|| label=""` is load-bearing, not defensive: a broken installer exits
   # non-zero, that status becomes the assignment's, and an errexit caller would
   # die right here — before the refusal below could print a word.
-  if [ -n "$lbltmp" ]; then
-    label="$(keeper_label 2>"$lbltmp")" || label=""
-    lblerr="$(tr '\n' ' ' < "$lbltmp")" || lblerr=""
-    rm -f "$lbltmp"
-  else
-    label="$(keeper_label 2>/dev/null)" || label=""
-    lblerr=""
-  fi
+  local label lblerr=""
+  label="$(keeper_label 2>/dev/null)" || label=""
   if [ -z "$label" ]; then
+    # Only now is the installer's stderr worth a temp file. Capturing it on every
+    # call put a mktemp + rm on the session-end path of every working host to
+    # quote an installer that had nothing to say. Re-running it here costs a
+    # second spawn on the one path that is already refusing to do anything.
+    # Bounded and stripped of control bytes: this is third-party text headed for
+    # a hook's stderr, and `tr -c` folds the newlines as a side effect.
+    local lbltmp
+    lbltmp="$(mktemp "${TMPDIR:-/tmp}/kblbl-XXXXXX" 2>/dev/null)" || lbltmp=""
+    if [ -n "$lbltmp" ]; then
+      keeper_label >/dev/null 2>"$lbltmp" || true
+      lblerr="$(tr -c '[:print:]' ' ' < "$lbltmp" | head -c 300)" || lblerr=""
+      rm -f "$lbltmp"
+    fi
     printf 'vaultkeeper: %s/install-watcher.sh did not report the scheduler label%s; skipping activation\n' \
-      "$scripts" "${lblerr:+ — it said: ${lblerr% }}" >&2
+      "$scripts" "${lblerr:+ — it said: ${lblerr%"${lblerr##*[![:space:]]}"}}" >&2
     return 0
   fi
 
-  keeper_scheduler_installed && return 0
+  # Pass the label we already resolved: the predicate would otherwise spawn the
+  # installer a second time, every session, to ask what we just asked it.
+  keeper_scheduler_installed "$label" && return 0
 
   local tick="$scripts/vaultkeeper-tick.sh"
   if ! bash "$scripts/seed-frontmatter-schema.sh" "$vault" "$cfg" >/dev/null 2>&1; then

--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -57,7 +57,7 @@ _kb_cfg_ensure() {
     NR==1 && $0=="---" { print; print line; inserted=1; next }
     { print }
     END { if (!inserted) print line }
-  ' "$cfg" > "$tmp" && mv "$tmp" "$cfg"
+  ' "$cfg" > "$tmp" && mv "$tmp" "$cfg" || { rm -f "$tmp"; return 1; }
 }
 
 # keeper_ensure_active <config_file> <vault_path> [interval_secs]

--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -18,8 +18,9 @@
 _kb_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
 
 # Returns non-zero rather than printing an empty path. The old `cd ../ && pwd`
-# propagated its failure; a bare parameter strip cannot, and both callers use the
-# result unchecked to build `bash "$scripts/..."` command lines. Testing for the
+# propagated its failure; a bare parameter strip cannot, and both callers
+# interpolate the result into a `bash "$scripts/..."` command line, so an empty
+# success is worse for them than a failure. Testing for the
 # sibling covers a `cd` that failed (empty) and one that succeeded onto the
 # caller's cwd; it also covers `${x%/*}` having no root case, where "/" strips to "".
 _kb_scripts() {
@@ -86,14 +87,16 @@ keeper_ensure_active() {
 
   # `|| autostart=""` because a config without the key makes grep exit 1, and with
   # `pipefail` that becomes the assignment's status — errexit would abort the
-  # sourcing hook here, on the ordinary first-run config. Absent means "not false".
+  # errexit caller here, on the ordinary first-run config — session-save.sh is not
+# one today (`set -uo pipefail`, and it calls this with `|| true`), so this guards
+# the next sourcer rather than a live bug. Absent means "not false".
   local autostart
   autostart="$(grep '^keeper_autostart:' "$cfg" | head -1 | sed 's/^keeper_autostart:[[:space:]]*//')" || autostart=""
   [ "$autostart" = "false" ] && return 0
 
   # Resolve the scripts dir before the label, so a lib that cannot find its own
-  # siblings says that, instead of surfacing as "install-watcher.sh broken?" and
-  # naming a file that is perfectly fine.
+  # siblings says that, instead of blaming install-watcher.sh for a file that is
+  # perfectly fine.
   local scripts
   if ! scripts="$(_kb_scripts)"; then
     printf 'vaultkeeper: cannot find the scripts dir beside this lib (looked beside "%s"); activation skipped\n' "$_kb_lib_dir" >&2
@@ -134,11 +137,11 @@ keeper_ensure_active() {
   if ! bash "$scripts/seed-frontmatter-schema.sh" "$vault" "$cfg" >/dev/null 2>&1; then
     printf 'vaultkeeper: frontmatter-schema seed failed; using default (tags type)\n' >&2
   fi
-  # Non-fatal, but not silent: `|| true` discarded a failed mktemp/awk/mv, and a
-  # config that never gains keeper_interval_secs then runs at the compiled-in
-  # default forever with nothing to explain why. Name the key and the
-  # consequence, the way the schema seed above names its fallback. `|| printf`
-  # keeps the exit status 0, so the hook still cannot be aborted by this.
+  # `|| true` here meant a config that never gained keeper_interval_secs ran at
+  # the compiled-in default forever with nothing to explain why. Name the key and
+  # the consequence, the way the schema seed above names its fallback. Reachable
+  # once per host: the installed check above returns before this on every session
+  # after the first.
   _kb_cfg_ensure keeper_autostart true "$cfg" \
     || printf 'vaultkeeper: could not write keeper_autostart to %s; opt-out state is unrecorded\n' "$cfg" >&2
   _kb_cfg_ensure keeper_interval_secs "$interval" "$cfg" \

--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -74,8 +74,11 @@ keeper_ensure_active() {
   local cfg="$1" vault="$2" interval="${3:-900}"
   [ -f "$cfg" ] && [ -d "$vault" ] || return 0
 
+  # `|| autostart=""` because a config without the key makes grep exit 1, and with
+  # `pipefail` that becomes the assignment's status — errexit would abort the
+  # sourcing hook here, on the ordinary first-run config. Absent means "not false".
   local autostart
-  autostart="$(grep '^keeper_autostart:' "$cfg" | head -1 | sed 's/^keeper_autostart:[[:space:]]*//')"
+  autostart="$(grep '^keeper_autostart:' "$cfg" | head -1 | sed 's/^keeper_autostart:[[:space:]]*//')" || autostart=""
   [ "$autostart" = "false" ] && return 0
 
   # Resolve the scripts dir before the label, so a lib that cannot find its own
@@ -93,12 +96,15 @@ keeper_ensure_active() {
   # instead of guessing; a failed mktemp costs only the quote, not the refusal.
   local label lblerr lbltmp
   lbltmp="$(mktemp "${TMPDIR:-/tmp}/kblbl-XXXXXX" 2>/dev/null)" || lbltmp=""
+  # `|| label=""` is load-bearing, not defensive: a broken installer exits
+  # non-zero, that status becomes the assignment's, and an errexit caller would
+  # die right here — before the refusal below could print a word.
   if [ -n "$lbltmp" ]; then
-    label="$(keeper_label 2>"$lbltmp")"
-    lblerr="$(tr '\n' ' ' < "$lbltmp")"
+    label="$(keeper_label 2>"$lbltmp")" || label=""
+    lblerr="$(tr '\n' ' ' < "$lbltmp")" || lblerr=""
     rm -f "$lbltmp"
   else
-    label="$(keeper_label 2>/dev/null)"
+    label="$(keeper_label 2>/dev/null)" || label=""
     lblerr=""
   fi
   if [ -z "$label" ]; then

--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -15,7 +15,10 @@
 
 # Captured at source time — see the note in allowlist-validate.sh: zsh has no
 # BASH_SOURCE, and its `$0` only names the sourced file while it is being read.
-_kb_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+# `|| _kb_lib_dir=""` for the same reason as the assignments below: the `cd` can
+# legitimately fail, and this one runs at *source* time, where session-save.sh has
+# no `|| true` to catch it. Empty is a state _kb_scripts already refuses on.
+_kb_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)" || _kb_lib_dir=""
 
 # Returns non-zero rather than printing an empty path. The old `cd ../ && pwd`
 # propagated its failure; a bare parameter strip cannot, and both callers
@@ -121,7 +124,13 @@ keeper_ensure_active() {
     lbltmp="$(mktemp "${TMPDIR:-/tmp}/kblbl-XXXXXX" 2>/dev/null)" || lbltmp=""
     if [ -n "$lbltmp" ]; then
       keeper_label >/dev/null 2>"$lbltmp" || true
-      lblerr="$(tr -c '[:print:]' ' ' < "$lbltmp" | head -c 300)" || lblerr=""
+      # Truncate with a parameter expansion, not `| head -c`: head exits at its
+      # limit, tr takes SIGPIPE, and pipefail makes that rc=141 the assignment's
+      # status — so `|| lblerr=""` blanked a value that had just been filled
+      # correctly, and a loud installer went unquoted. Bounding the diagnostic
+      # must not be able to delete it.
+      lblerr="$(tr -c '[:print:]' ' ' < "$lbltmp")" || lblerr=""
+      lblerr="${lblerr:0:300}"
       rm -f "$lbltmp"
     fi
     printf 'vaultkeeper: %s/install-watcher.sh did not report the scheduler label%s; skipping activation\n' \

--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -29,7 +29,16 @@ _kb_scripts() {
 }
 
 # Single source of truth for the namespace label: install-watcher.sh owns it.
-keeper_label() { bash "$(_kb_scripts)/install-watcher.sh" label 2>/dev/null; }
+# Deliberately does NOT swallow the installer's stderr — that text is the only
+# thing separating a syntax error from a missing dependency, and every caller
+# either wants it (keeper_ensure_active quotes it) or never triggers it. The
+# unchecked `$(_kb_scripts)` it used to interpolate turned a lost scripts dir
+# into `bash /install-watcher.sh`; fail instead of calling the wrong path.
+keeper_label() {
+  local scripts
+  scripts="$(_kb_scripts)" || return 1
+  bash "$scripts/install-watcher.sh" label
+}
 
 keeper_scheduler_installed() {
   local os="${KEEPER_OS:-$(uname -s)}" label
@@ -80,9 +89,21 @@ keeper_ensure_active() {
 
   # A missing/empty label means the installer is broken — that's an error to
   # report, not a "not installed" signal to barrel past into a doomed install.
-  local label; label="$(keeper_label)"
+  # Capture the installer's own stderr so the refusal quotes the actual fault
+  # instead of guessing; a failed mktemp costs only the quote, not the refusal.
+  local label lblerr lbltmp
+  lbltmp="$(mktemp "${TMPDIR:-/tmp}/kblbl-XXXXXX" 2>/dev/null)" || lbltmp=""
+  if [ -n "$lbltmp" ]; then
+    label="$(keeper_label 2>"$lbltmp")"
+    lblerr="$(tr '\n' ' ' < "$lbltmp")"
+    rm -f "$lbltmp"
+  else
+    label="$(keeper_label 2>/dev/null)"
+    lblerr=""
+  fi
   if [ -z "$label" ]; then
-    printf 'vaultkeeper: cannot resolve scheduler label (install-watcher.sh broken?); skipping activation\n' >&2
+    printf 'vaultkeeper: %s/install-watcher.sh did not report the scheduler label%s; skipping activation\n' \
+      "$scripts" "${lblerr:+ — it said: ${lblerr% }}" >&2
     return 0
   fi
 

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -117,6 +117,20 @@ grep -q 'keeper_autostart' <<<"$RERR" \
 grep -q 'keeper_interval_secs' <<<"$RERR" \
   || fail "failed keeper_interval_secs write was silent: [$RERR]"
 
+# --- _kb_cfg_ensure cleans up its temp file when the swap fails (#40) ---
+# awk succeeds, `mv` fails, and the rendered config sits in TMPDIR forever. The
+# Stop hook runs this on every session, so the leak accumulates one file per
+# session for as long as the config stays unwritable. Subshell so the temporary
+# TMPDIR cannot outlive the call.
+LEAK="$WORK/leaktmp"; mkdir -p "$LEAK"
+chmod a-w "$ROD"
+if ( TMPDIR="$LEAK"; _kb_cfg_ensure leak_probe 1 "$RCFG" ); then
+  chmod u+w "$ROD"; fail "_kb_cfg_ensure reported success when mv could not write the config"
+fi
+chmod u+w "$ROD"
+LEFT="$(find "$LEAK" -name 'kbcfg-*' -type f | wc -l | tr -d ' ')"
+[ "$LEFT" = "0" ] || fail "_kb_cfg_ensure leaked $LEFT temp file(s) into $LEAK"
+
 # --- opt-out: keeper_autostart: false skips install entirely ---
 CFG2="$WORK/optout.local.md"; VAULT2="$WORK/vault2"
 printf -- '---\nvault_path: %s\nkeeper_autostart: false\n---\n' "$VAULT2" > "$CFG2"

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -209,4 +209,19 @@ BRKREAL="$(cd "$BRK" && pwd)"
 grep -qF "$BRKREAL/install-watcher.sh" <<<"$BERR" \
   || fail "refusal did not name the installer it actually called: [$BERR]"
 
+# --- the predicate answers; it never leaks the installer's status or stderr ---
+# keeper_scheduler_installed is public (the launchctl arms above call it bare) and
+# its `label="$(keeper_label)"` carried the installer's exit 3 as the assignment's
+# status: an errexit caller died on that line and never reached the
+# `[ -n "$label" ] || return 1` below it. In production the `&&` at the call site
+# hid that positionally. A predicate also has no channel to explain a fault on, so
+# the installer's stderr must not surface here unprefixed — keeper_ensure_active
+# is the caller that quotes it.
+PRC=0
+PERR="$(KEEPER_OS="Darwin" bash -c "set -euo pipefail; . '$BRK/lib/keeper-bootstrap.sh'; keeper_scheduler_installed" 2>&1 >/dev/null)" || PRC=$?
+[ "$PRC" = 1 ] \
+  || fail "keeper_scheduler_installed returned the installer's status ($PRC), so the handler under the assignment was never reached"
+[ -z "$PERR" ] \
+  || fail "the predicate leaked the installer's stderr to its caller: [$PERR]"
+
 echo "PASS: keeper-bootstrap"

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -212,6 +212,32 @@ BRKREAL="$(cd "$BRK" && pwd)"
 grep -qF "$BRKREAL/install-watcher.sh" <<<"$BERR" \
   || fail "refusal did not name the installer it actually called: [$BERR]"
 
+# --- a loud installer is still quoted, and the quote stays bounded (#41) ---
+# The bound must not be a pipeline: `tr ... | head -c 300` makes head exit early,
+# tr take SIGPIPE, and pipefail hand rc=141 to the assignment — so the `|| lblerr=""`
+# fallback blanked a value that had been filled correctly. That is this PR's own
+# subject (a diagnostic the shell throws away) reintroduced by its bound.
+# 300 KB, and control bytes that must not reach the hook's stderr live.
+LOUD="$WORK/loud/scripts"; mkdir -p "$LOUD/lib"
+cp "${ROOT_DIR}/scripts/lib/keeper-bootstrap.sh" "$LOUD/lib/"
+cat > "$LOUD/install-watcher.sh" <<'EOF'
+#!/usr/bin/env bash
+{ printf 'LOUD-HEAD\033[31m\r\a'; head -c 300000 /dev/zero | tr '\0' 'X'; printf 'LOUD-TAIL\n'; } >&2
+exit 4
+EOF
+chmod +x "$LOUD/install-watcher.sh"
+for _flags in 'set -uo pipefail;' 'set -euo pipefail;'; do
+  LERR="$(KEEPER_OS="Darwin" bash -c "${_flags} . '$LOUD/lib/keeper-bootstrap.sh'; keeper_ensure_active '$BCFG' '$BVAULT' 900" 2>&1 >/dev/null)" \
+    || fail "[$_flags] ensure_active must return 0 against a loud broken installer"
+  grep -q 'LOUD-HEAD' <<<"$LERR" \
+    || fail "[$_flags] the quote was dropped when the installer said too much: [${LERR:0:200}]"
+  [ "${#LERR}" -lt 600 ] \
+    || fail "[$_flags] refusal was ${#LERR} bytes; the quote is not bounded"
+  case "$LERR" in
+    *$'\r'*|*$'\a'*|*$'\033'*) fail "[$_flags] control bytes reached the hook's stderr: [${LERR:0:120}]" ;;
+  esac
+done
+
 # --- the session-end path on a working host spawns the installer once (#41) ---
 # Asking for the label twice — once in keeper_ensure_active, once inside the
 # predicate it calls — put a second install-watcher.sh process on every activated
@@ -226,9 +252,21 @@ printf '%s\n' "\$1" >> "$SPAWNS"
 printf '%s\n' "$LABEL"
 EOF
 chmod +x "$CNT/install-watcher.sh"
+# Count mktemp too: capturing the installer's stderr unconditionally meant the
+# working host paid a temp file per session to quote an installer with nothing to
+# say. The spawn count alone does not see that.
+MKC="$WORK/mktemp-calls.log"; : > "$MKC"
+cat > "$WORK/bin/mktemp" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$MKC"
+exec /usr/bin/mktemp "\$@"
+EOF
+chmod +x "$WORK/bin/mktemp"
 printf '%s\n' "$LABEL" > "$STATE"
 KEEPER_OS="Darwin" bash -c ". '$CNT/lib/keeper-bootstrap.sh'; keeper_ensure_active '$CFG' '$VAULT' 900" \
   || fail "ensure_active returned non-zero on an already-installed host"
+[ ! -s "$MKC" ] \
+  || fail "the session-end path on an installed host used mktemp: [$(cat "$MKC")]"
 SPAWNED="$(wc -l < "$SPAWNS" | tr -d ' ')"
 [ "$SPAWNED" = "1" ] \
   || fail "an installed host spawned install-watcher.sh $SPAWNED times per session, want 1"

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -209,6 +209,28 @@ BRKREAL="$(cd "$BRK" && pwd)"
 grep -qF "$BRKREAL/install-watcher.sh" <<<"$BERR" \
   || fail "refusal did not name the installer it actually called: [$BERR]"
 
+# --- the session-end path on a working host spawns the installer once (#41) ---
+# Asking for the label twice — once in keeper_ensure_active, once inside the
+# predicate it calls — put a second install-watcher.sh process on every activated
+# host's Stop hook, alongside a mktemp/rm pair capturing stderr from an installer
+# that had nothing to say. This is the dominant path: every session, forever.
+CNT="$WORK/counted/scripts"; mkdir -p "$CNT/lib"
+cp "${ROOT_DIR}/scripts/lib/keeper-bootstrap.sh" "$CNT/lib/"
+SPAWNS="$WORK/label-spawns.log"; : > "$SPAWNS"
+cat > "$CNT/install-watcher.sh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$1" >> "$SPAWNS"
+printf '%s\n' "$LABEL"
+EOF
+chmod +x "$CNT/install-watcher.sh"
+printf '%s\n' "$LABEL" > "$STATE"
+KEEPER_OS="Darwin" bash -c ". '$CNT/lib/keeper-bootstrap.sh'; keeper_ensure_active '$CFG' '$VAULT' 900" \
+  || fail "ensure_active returned non-zero on an already-installed host"
+SPAWNED="$(wc -l < "$SPAWNS" | tr -d ' ')"
+[ "$SPAWNED" = "1" ] \
+  || fail "an installed host spawned install-watcher.sh $SPAWNED times per session, want 1"
+: > "$STATE"
+
 # --- the predicate answers; it never leaks the installer's status or stderr ---
 # keeper_scheduler_installed is public (the launchctl arms above call it bare) and
 # its `label="$(keeper_label)"` carried the installer's exit 3 as the assignment's

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -6,7 +6,10 @@ fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 INSTALLER="${ROOT_DIR}/scripts/install-watcher.sh"
 
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/kb-XXXXXX")"
-trap 'rm -rf "$WORK"' EXIT
+# Two arms below chmod a config dir read-only. rm -rf clears it anyway on macOS
+# 15 as the owner (verified — no crumb is left), but that is a permission detail
+# this teardown should not depend on to avoid stranding a dir in the real TMPDIR.
+trap 'chmod -R u+w "$WORK" 2>/dev/null; rm -rf "$WORK"' EXIT
 
 # install-watcher.sh exposes the namespace label, and the bootstrap lib reads
 # from it — one source of truth, no drift between the two files.
@@ -101,7 +104,7 @@ grep -qi 'FAILED' <<<"$ERR" || fail "failed install was silent — no diagnostic
 # permission-denied filesystem does. Staying non-fatal is correct — a Stop hook
 # must not abort — but the config then never gains keeper_interval_secs and the
 # keeper runs at the compiled-in default forever, so it cannot be silent. Note
-# the contrast one line up in production: the schema seed already names its
+# the contrast just above it in production: the schema seed already names its
 # fallback when it fails.
 ROD="$WORK/ro"; mkdir -p "$ROD"
 RCFG="$ROD/obsidian.local.md"; RVAULT="$WORK/vaultro"

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -96,6 +96,27 @@ ERR="$(KEEPER_OS="Darwin" keeper_ensure_active "$CFGF" "$VAULTF" 900 2>&1 >/dev/
 [ -s "$FAILCALLS" ] || fail "failing install was never attempted"
 grep -qi 'FAILED' <<<"$ERR" || fail "failed install was silent — no diagnostic emitted: '$ERR'"
 
+# --- a failed config write leaves a trace (#40) ---
+# A read-only parent dir makes _kb_cfg_ensure's `mv` fail the way a full or
+# permission-denied filesystem does. Staying non-fatal is correct — a Stop hook
+# must not abort — but the config then never gains keeper_interval_secs and the
+# keeper runs at the compiled-in default forever, so it cannot be silent. Note
+# the contrast one line up in production: the schema seed already names its
+# fallback when it fails.
+ROD="$WORK/ro"; mkdir -p "$ROD"
+RCFG="$ROD/obsidian.local.md"; RVAULT="$WORK/vaultro"
+printf -- '---\nvault_path: %s\n---\n' "$RVAULT" > "$RCFG"
+mk_vault "$RVAULT"
+export VAULTKEEPER_INSTALL="$WORK/stub-install.sh"
+chmod a-w "$ROD"
+RERR="$(KEEPER_OS="Darwin" keeper_ensure_active "$RCFG" "$RVAULT" 900 2>&1 >/dev/null)" \
+  || { chmod u+w "$ROD"; fail "ensure_active must return 0 when a config write fails"; }
+chmod u+w "$ROD"
+grep -q 'keeper_autostart' <<<"$RERR" \
+  || fail "failed keeper_autostart write was silent: [$RERR]"
+grep -q 'keeper_interval_secs' <<<"$RERR" \
+  || fail "failed keeper_interval_secs write was silent: [$RERR]"
+
 # --- opt-out: keeper_autostart: false skips install entirely ---
 CFG2="$WORK/optout.local.md"; VAULT2="$WORK/vault2"
 printf -- '---\nvault_path: %s\nkeeper_autostart: false\n---\n' "$VAULT2" > "$CFG2"

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -190,10 +190,19 @@ cat > "$BRK/install-watcher.sh" <<'EOF'
 echo "BOOM-INSTALLER-DIAGNOSTIC" >&2
 exit 3
 EOF
-BERR="$(KEEPER_OS="Darwin" bash -c ". '$BRK/lib/keeper-bootstrap.sh'; keeper_ensure_active '$CFG' '$VAULT' 900" 2>&1 >/dev/null)" \
-  || fail "ensure_active must return 0 when the installer is broken (never abort the hook)"
-grep -q 'BOOM-INSTALLER-DIAGNOSTIC' <<<"$BERR" \
-  || fail "installer stderr was discarded; refusal said only: [$BERR]"
+# Both flag sets: session-save.sh is `set -uo pipefail` today, but an errexit
+# caller aborted at `label="$(keeper_label ...)"` — the installer's exit 3 became
+# the assignment's status — killing the hook before the refusal ever printed. A
+# diagnostic the shell never reaches is the #34 defect, so pin both.
+BCFG="$WORK/broken.local.md"; BVAULT="$WORK/vaultb"
+printf -- '---\nvault_path: %s\n---\n' "$BVAULT" > "$BCFG"   # no keeper_autostart key
+mk_vault "$BVAULT"
+for _flags in '' 'set -euo pipefail;'; do
+  BERR="$(KEEPER_OS="Darwin" bash -c "${_flags} . '$BRK/lib/keeper-bootstrap.sh'; keeper_ensure_active '$BCFG' '$BVAULT' 900" 2>&1 >/dev/null)" \
+    || fail "[${_flags:-no flags}] ensure_active must return 0 when the installer is broken (never abort the hook)"
+  grep -q 'BOOM-INSTALLER-DIAGNOSTIC' <<<"$BERR" \
+    || fail "[${_flags:-no flags}] installer stderr was discarded; refusal said only: [$BERR]"
+done
 # Compare against the pwd-normalized path: _kb_lib_dir resolves through
 # `cd && pwd`, so a TMPDIR with a trailing slash collapses "T//kb-x" to "T/kb-x".
 BRKREAL="$(cd "$BRK" && pwd)"

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -178,4 +178,26 @@ grep -q 'cannot find the scripts dir' <<<"$OERR" \
 grep -q 'install-watcher.sh broken' <<<"$OERR" \
   && fail "self-location failure blamed install-watcher.sh: [$OERR]"
 
+# --- a broken installer is reported in its own words (#40) ---
+# _kb_scripts succeeds here — install-watcher.sh is present beside the lib — so
+# this is the case #34 left behind: the installer itself is broken. Its stderr is
+# the only thing separating a syntax error from a missing dependency, and
+# `2>/dev/null` threw it away, leaving the refusal to guess "broken?".
+BRK="$WORK/broken/scripts"; mkdir -p "$BRK/lib"
+cp "${ROOT_DIR}/scripts/lib/keeper-bootstrap.sh" "$BRK/lib/"
+cat > "$BRK/install-watcher.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "BOOM-INSTALLER-DIAGNOSTIC" >&2
+exit 3
+EOF
+BERR="$(KEEPER_OS="Darwin" bash -c ". '$BRK/lib/keeper-bootstrap.sh'; keeper_ensure_active '$CFG' '$VAULT' 900" 2>&1 >/dev/null)" \
+  || fail "ensure_active must return 0 when the installer is broken (never abort the hook)"
+grep -q 'BOOM-INSTALLER-DIAGNOSTIC' <<<"$BERR" \
+  || fail "installer stderr was discarded; refusal said only: [$BERR]"
+# Compare against the pwd-normalized path: _kb_lib_dir resolves through
+# `cd && pwd`, so a TMPDIR with a trailing slash collapses "T//kb-x" to "T/kb-x".
+BRKREAL="$(cd "$BRK" && pwd)"
+grep -qF "$BRKREAL/install-watcher.sh" <<<"$BERR" \
+  || fail "refusal did not name the installer it actually called: [$BERR]"
+
 echo "PASS: keeper-bootstrap"


### PR DESCRIPTION
Closes #40

## Description (Issue Fixed & New Behavior)

Three silent-failure fixes in `scripts/lib/keeper-bootstrap.sh`, one commit each, plus one found while verifying them.

**1. A failed config write names the key** (`fa724c9`). `_kb_cfg_ensure ... || true` discarded every failure. Both failure modes do print something of their own — `mktemp` reports `mkstemp failed on ...` and `mv` reports "Permission denied", and line 64 redirects neither — but nothing said *which key was lost or what happens next* — so a config that never gains `keeper_interval_secs` runs at the compiled-in 900s default forever with no trace. Both keys are now reported by name, matching the schema-seed line above them which already names its fallback. `|| printf` still evaluates to 0, so the Stop hook stays unabortable.

**2. No temp-file leak on a failed swap** (`3c69d7f`). When `awk` succeeded and `mv` failed, the fully-rendered config stayed in `TMPDIR`. Reachable once per host, not once per session: `keeper_scheduler_installed && return 0` sits above this, so every session after the first returns before reaching it. The leak is one rendered config, on first activation, on a host whose config dir is unwritable. The cleanup clause also covers the `awk`-failure path, which leaked a partial render.

**3. A broken installer is quoted, not guessed at** (`c2b1a93`). `keeper_label` swallowed `install-watcher.sh`'s stderr, so a syntax error, a missing dependency, and an unreadable file all arrived as an empty string and the refusal guessed `install-watcher.sh broken?`. #34 split out the case where the *lib* can't find the installer; what remained was real installer breakage, and its stderr is the only thing identifying which. `keeper_label` now lets that through, and fails when `_kb_scripts` does instead of interpolating an unchecked path into `bash "$(_kb_scripts)/..."` and calling `/install-watcher.sh`.

**4. The refusals can actually be reached under errexit** (`49ed251`) — not in the issue; found while verifying #3. Under `set -euo pipefail` the broken-installer path aborted the caller and printed **nothing**, making it strictly worse than the guess it replaced. Two assignments took their status from a command that legitimately fails: `label="$(keeper_label ...)"` (broken installer exits non-zero) and `autostart="$(grep '^keeper_autostart:' ...)"` (a config without the key makes grep exit 1, and `pipefail` promotes it — that's the ordinary first-run config). Both now `|| <var>=""`. That is almost purely a reachability change, with one edge: discarding stdout on a non-zero exit means an installer that prints a label *and* exits non-zero now refuses where it previously proceeded. Today's `install-watcher.sh` cannot do that (`label)` is a bare `printf`), so nothing in tree behaves differently. Same failure class as the `.`-under-errexit finding on #34: an error handler the shell never reaches.

`session-save.sh` is `set -uo pipefail` and calls this with `|| true`, so nothing in production was aborting today — item 4 is about the next sourcer.

**5. The errexit guard at the third call site** (`19fbf32`) — from the review panel on this PR. `keeper_scheduler_installed`'s own `label="$(keeper_label)"` was the call #4 missed, so a direct call under `set -euo pipefail` died on that line and never reached the `[ -n "$label" ] || return 1` below it: `rc=3` against a broken installer, `rc=1` with nothing printed against an orphaned lib. Production escaped it only because the call site is the left operand of `&&`, which suppresses errexit positionally. It also drops the installer's stderr — a predicate has no channel to explain a fault, so that text was arriving unprefixed at whoever asked a yes/no question.

**6. The installer is quoted only when it failed** (`1e6b4a8`). Capturing its stderr unconditionally put a `mktemp`/`tr`/`rm` and a *second* `install-watcher.sh` process on the session-end path of every activated host, to quote an installer that was working. The temp file now appears only on the branch that is already refusing to act, which deletes the untested mktemp-failure `else` arm instead of testing it, and the predicate takes the resolved label as an argument so it stops re-asking. The captured text is bounded (`tr -c '[:print:]'` + `head -c 300`) — it is third-party output headed for a hook's stderr, and 200 KB arrived as one live-ANSI line.

**7. Four comments corrected** (`a59f870`). Two were falsified by commits 1-4 above ("both callers use the result unchecked"; the quoted `install-watcher.sh broken?` refusal), one named the wrong actor ("the sourcing hook" — `session-save.sh` isn't errexit and calls with `|| true`), one asserted the per-session frequency corrected in item 2. Plus a `chmod` before the test teardown's `rm -rf`.

Panel also found one thing outside this diff worth its own issue: on this machine 710 of 710 keeper ticks log `vault-scan.sh: ... Too many open files` and then report `vaultkeeper: scan complete`. Filed separately, along with the temp-swap invariant still unfixed in three sibling libs, the plist clobber on install, the `|| autostart=""` pipeline scope, and the never-retried schema seed.

## Testing Procedure

1. Check out this branch and run `bash tests/run-all.sh` — expect `ALL PASS` (28 suites).
2. Run `bash tests/keeper-bootstrap.sh` alone. `mv: ... Permission denied` lines on stderr are expected: two arms deliberately make the config unwritable.
3. Confirm each assertion pins its fix — revert one line, watch the named test fail, restore:
   - restore `|| true` on the two `_kb_cfg_ensure` calls → `failed keeper_autostart write was silent`
   - drop `|| { rm -f "$tmp"; return 1; }` from `_kb_cfg_ensure` → `_kb_cfg_ensure leaked 1 temp file(s)`
   - restore `2>/dev/null` in `keeper_label` → `installer stderr was discarded`
   - drop either `|| label=""` / `|| autostart=""` → `[set -euo pipefail;] ensure_active must return 0`
4. Verify the errexit arm is real, not theory: `bash -c "set -euo pipefail; . scripts/lib/keeper-bootstrap.sh; ..."` against a stub installer that exits non-zero returned `rc=1` with empty output before `49ed251`.
5. zsh checked separately (the keeper runtime has no `BASH_SOURCE`): label resolves, and the broken-installer refusal prints with the installer's own text.

## Additional Notes / HelpScout Tickets

Pre-existing issues in a file #34 touched; #34 fixed the self-location half and left these. Findings originated in the PR #34 review panel.

While verifying, confirmed this host's launchd agent points at the version-resilient delegator `~/.claude/hooks/obsidian-vaultkeeper-tick.sh` (resolves newest installed version), not a version-pinned path — so #35's orphaning does not apply to this host as currently installed. #35 is still valid for a fresh `install-watcher.sh` install, which does bake an absolute versioned path.
