### PR TITLE
Fix fd exhaustion in scan_clusters and stop recording partial scans as complete

### DIFF
--- a/scripts/lib/surfacing.sh
+++ b/scripts/lib/surfacing.sh
@@ -3,13 +3,19 @@
 # append only genuinely-new candidates to Pending.md (transition-gated against
 # the prior-scan snapshot). Requires note-hash.sh + keeper-state.sh.
 
+# surfacing_digest <vault> [status]
+# `status` is stamped as `scan_status:` when non-empty. The caller passes INCOMPLETE
+# when the scanners faulted: this file is the human-facing artifact and it was
+# claiming a fresh full scan — timestamp AND section counts — on ticks the keeper
+# itself refused to record as complete.
 surfacing_digest() {
-  local vault="$1" lines tmp target="$1/Librarian.md" kind label
+  local vault="$1" status="${2:-}" lines tmp target="$1/Librarian.md" kind label
   lines="$(cat)"
   tmp="$(mktemp "$vault/.Librarian-XXXXXX")" || return 1
   {
     printf '%s\n' '<!-- MACHINE-OWNED: regenerated each vaultkeeper scan. Edits do not persist. -->'
     printf '# Librarian\n\nlast_scan: %s\n' "$(now_epoch)"
+    [ -n "$status" ] && printf 'scan_status: %s\n' "$status"
     for kind in GAP UNFILED ASK CLUSTER QUARANTINE; do
       if [ "$kind" = "GAP" ]; then label="Frontmatter gaps"
       elif [ "$kind" = "UNFILED" ]; then label="Unfiled (Inbox)"

--- a/scripts/lib/vault-scan.sh
+++ b/scripts/lib/vault-scan.sh
@@ -72,10 +72,12 @@ scan_open_asks() {
 # One find over the whole vault, grouped by (dir, token) at the end. The previous
 # shape walked directories and opened a nested process substitution per directory
 # — two live fds per iteration — which exhausted the fd table under launchd and
-# truncated the candidate set while still returning 0. It also lost 58% of its
-# output whenever stdout was a plain pipe, with nothing on stderr. Emitting flat
-# `dir<TAB>token` pairs through a single pipeline has one process substitution for
-# the entire scan, so neither failure has anywhere to happen.
+# truncated the candidate set while still returning 0. How much it dropped tracked
+# whatever fd headroom happened to exist at runtime: the same frozen 569-directory
+# vault came back with 503 clusters on an idle host and 211 under load, identical
+# through a pipe and through a file redirect, and with nothing on stderr in either
+# case. Emitting flat `dir<TAB>token` pairs through a single pipeline leaves one
+# process substitution for the whole scan, so there is no headroom to run out of.
 scan_clusters() {
   local vault="$1" threshold="$2" f dir base slug rel
   while IFS= read -r f; do

--- a/scripts/lib/vault-scan.sh
+++ b/scripts/lib/vault-scan.sh
@@ -69,31 +69,29 @@ scan_open_asks() {
 # >= threshold distinct files. No associative arrays (bash 3.2 on the macOS
 # keeper host) — count via sort|uniq -c. Tokens are unique-per-file (sort -u),
 # so uniq -c across files = number of distinct files sharing the token.
+# One find over the whole vault, grouped by (dir, token) at the end. The previous
+# shape walked directories and opened a nested process substitution per directory
+# — two live fds per iteration — which exhausted the fd table under launchd and
+# truncated the candidate set while still returning 0. It also lost 58% of its
+# output whenever stdout was a plain pipe, with nothing on stderr. Emitting flat
+# `dir<TAB>token` pairs through a single pipeline has one process substitution for
+# the entire scan, so neither failure has anywhere to happen.
 scan_clusters() {
-  local vault="$1" threshold="$2" dir base f tok cnt
-  while IFS= read -r dir; do
-    while read -r cnt tok; do
-      [ -z "$cnt" ] && continue
-      [ "$cnt" -ge "$threshold" ] \
-        && printf 'CLUSTER\t%s\t%s\t%s\n' "${dir#"$vault"/}" "$tok" "$cnt"
-    done < <(
-      while IFS= read -r f; do
-        base="$(basename "$f" .md)"
-        # Spaces are folded to the same separator before tokenizing: tokenize_slug
-        # splits on `-` only, and this vault has filenames with spaces. `sort -u`
-        # keeps the count "distinct files containing the token", not total
-        # occurrences.
-        printf '%s\n' "$base" | tr ' ' '-' | while IFS= read -r slug; do
-          tokenize_slug "$slug"
-        done | sort -u
-      done < <(find "$dir" -maxdepth 1 -type f -name '*.md') \
-        | sort | uniq -c
-    )
-  done < <(find "$vault" -type d \
-            ! -path '*/.obsidian' ! -path '*/.obsidian/*' \
-            ! -path '*/.trash'    ! -path '*/.trash/*' \
-            ! -path '*/.git'      ! -path '*/.git/*' \
-            ! -path '*/.vaultkeeper-quarantine' ! -path '*/.vaultkeeper-quarantine/*' \
-            ! -path '*/.vaultkeeper'            ! -path '*/.vaultkeeper/*')
+  local vault="$1" threshold="$2" f dir base slug rel
+  while IFS= read -r f; do
+    dir="${f%/*}"
+    base="${f##*/}"; base="${base%.md}"
+    # Spaces are folded to the same separator before tokenizing: tokenize_slug
+    # splits on `-` only, and this vault has filenames with spaces. `sort -u`
+    # keeps the count "distinct files containing the token", not total occurrences.
+    slug="${base// /-}"
+    rel="${dir#"$vault"/}"
+    tokenize_slug "$slug" | sort -u | while IFS= read -r tok; do
+      [ -n "$tok" ] && printf '%s\t%s\n' "$rel" "$tok"
+    done
+  done < <(_scan_find_md "$vault") \
+  | sort | uniq -c \
+  | sed 's/^ *\([0-9][0-9]*\) /\1'"$(printf '\t')"'/' \
+  | awk -F'\t' -v t="$threshold" '$1+0 >= t+0 { printf "CLUSTER\t%s\t%s\t%s\n", $2, $3, $1 }'
   return 0
 }

--- a/scripts/vaultkeeper-tick.sh
+++ b/scripts/vaultkeeper-tick.sh
@@ -42,7 +42,20 @@ CONFLICTS="$(keeper_quarantine_conflicts "$VAULT" || true)"
 # maintainer's host, each one logging `Too many open files` immediately above
 # `scan complete`. A scan whose scanners complained is not a scan we can
 # describe as done; see the SCAN_ERR gate below keeper_record_scan.
+SCAN_FAULT=""
 SCAN_ERR="$(mktemp "${TMPDIR:-/tmp}/kbscan-XXXXXX" 2>/dev/null)" || SCAN_ERR=""
+if [ -n "$SCAN_ERR" ]; then
+  # trap, not a bare rm below: a tick killed for overrunning its launchd window
+  # otherwise leaks one buffer every 15 minutes, and the fault goes with it.
+  trap 'rm -f "$SCAN_ERR"' EXIT
+else
+  # Fail closed. With no buffer the fault check can never fire, and failing open
+  # here restored the exact bug this gate removes — a partial scan recorded as
+  # complete, silently. mktemp is also among the first casualties of the fd and
+  # disk exhaustion the gate is watching for, so this is a correlated failure, not
+  # an independent one.
+  SCAN_FAULT="cannot create the scan-fault buffer (mktemp failed); scan not verifiable"
+fi
 CAND="$( {
   scan_frontmatter_gaps "$VAULT" "$REQUIRED"
   scan_unfiled "$VAULT"
@@ -50,13 +63,11 @@ CAND="$( {
   scan_clusters "$VAULT" 3
   if [ -n "$CONFLICTS" ]; then printf '%s\n' "$CONFLICTS"; fi
 } 2>"${SCAN_ERR:-/dev/stderr}" | sed '/^$/d' )"
-SCAN_FAULT=""
 if [ -n "$SCAN_ERR" ] && [ -s "$SCAN_ERR" ]; then
   SCAN_FAULT="$(tr -c '[:print:]' ' ' < "$SCAN_ERR")" || SCAN_FAULT="unreadable"
   SCAN_FAULT="${SCAN_FAULT:0:300}"
   printf '%s\n' "$SCAN_FAULT" >&2
 fi
-[ -n "$SCAN_ERR" ] && rm -f "$SCAN_ERR"
 
 # The order of these three is the whole point. Both survive a partial candidate set:
 # base_view_write takes only a path, and the digest is a full overwrite, so a

--- a/scripts/vaultkeeper-tick.sh
+++ b/scripts/vaultkeeper-tick.sh
@@ -69,10 +69,14 @@ if [ -n "$SCAN_ERR" ] && [ -s "$SCAN_ERR" ]; then
   printf '%s\n' "$SCAN_FAULT" >&2
 fi
 
-# The order of these three is the whole point. Both survive a partial candidate set:
-# base_view_write takes only a path, and the digest is a full overwrite, so a
-# permanently-faulting host still surfaces something — which beats surfacing nothing,
-# the tradeoff that keeps them above the gate. The digest is told to say so.
+# These two stay above the gate because both survive a partial candidate set:
+# base_view_write's content does not depend on CAND, and the digest is a full
+# overwrite that nothing reads back. A permanently-faulting host therefore still
+# surfaces something, which beats surfacing nothing — and the digest is told to say
+# which it is. Caveat: keeper_quarantine_conflicts (line 38) already moved any sync
+# conflict irreversibly and emits its row once, so on a faulted tick that row never
+# reaches Pending.md and no later tick can re-emit it. The file is safely in
+# .vaultkeeper-quarantine either way; the missing checklist line is filed separately.
 base_view_write "$VAULT/_vaultkeeper.base"
 printf '%s\n' "$CAND" | surfacing_digest "$VAULT" "${SCAN_FAULT:+INCOMPLETE}"
 

--- a/scripts/vaultkeeper-tick.sh
+++ b/scripts/vaultkeeper-tick.sh
@@ -36,16 +36,39 @@ if ! keeper_is_owner "$LEASE" "$HOST" "$PRIORITY" "$MAXAGE"; then
 fi
 
 CONFLICTS="$(keeper_quarantine_conflicts "$VAULT" || true)"
+# Capture the scanners' stderr instead of letting it fly past. Every scanner
+# returns 0 unconditionally, so a truncated scan was indistinguishable from a
+# complete one and got recorded as complete — for 710 consecutive ticks on the
+# maintainer's host, each one logging `Too many open files` immediately above
+# `scan complete`. A scan whose scanners complained is not a scan we can
+# describe as done; see the SCAN_ERR gate below keeper_record_scan.
+SCAN_ERR="$(mktemp "${TMPDIR:-/tmp}/kbscan-XXXXXX" 2>/dev/null)" || SCAN_ERR=""
 CAND="$( {
   scan_frontmatter_gaps "$VAULT" "$REQUIRED"
   scan_unfiled "$VAULT"
   scan_open_asks "$VAULT"
   scan_clusters "$VAULT" 3
   if [ -n "$CONFLICTS" ]; then printf '%s\n' "$CONFLICTS"; fi
-} | sed '/^$/d' )"
+} 2>"${SCAN_ERR:-/dev/stderr}" | sed '/^$/d' )"
+SCAN_FAULT=""
+if [ -n "$SCAN_ERR" ] && [ -s "$SCAN_ERR" ]; then
+  SCAN_FAULT="$(tr -c '[:print:]' ' ' < "$SCAN_ERR")" || SCAN_FAULT="unreadable"
+  SCAN_FAULT="${SCAN_FAULT:0:300}"
+  printf '%s\n' "$SCAN_FAULT" >&2
+fi
+[ -n "$SCAN_ERR" ] && rm -f "$SCAN_ERR"
 
 base_view_write "$VAULT/_vaultkeeper.base"
 printf '%s\n' "$CAND" | surfacing_digest "$VAULT"
 printf '%s\n' "$CAND" | surfacing_pending_transition "$VAULT"
+if [ -n "$SCAN_FAULT" ]; then
+  # Deliberately do NOT record the scan. last_scan drives the staleness banner in
+  # /obsidian:ask and the owner-election window; recording a partial scan tells
+  # both that the vault was fully examined. Leaving it unrecorded makes the
+  # banner report stale, which is the true state, and the next tick retries.
+  printf 'vaultkeeper: scan INCOMPLETE on %s — not recorded as complete (candidates may be short); scanners said: %s\n' \
+    "$HOST" "$SCAN_FAULT" >&2
+  exit 0
+fi
 keeper_record_scan "$VAULT"
 echo "vaultkeeper: scan complete ($HOST)"

--- a/scripts/vaultkeeper-tick.sh
+++ b/scripts/vaultkeeper-tick.sh
@@ -38,10 +38,10 @@ fi
 CONFLICTS="$(keeper_quarantine_conflicts "$VAULT" || true)"
 # Capture the scanners' stderr instead of letting it fly past. Every scanner
 # returns 0 unconditionally, so a truncated scan was indistinguishable from a
-# complete one and got recorded as complete — for 710 consecutive ticks on the
-# maintainer's host, each one logging `Too many open files` immediately above
-# `scan complete`. A scan whose scanners complained is not a scan we can
-# describe as done; see the SCAN_ERR gate below keeper_record_scan.
+# complete one and got recorded as complete — for every one of 700+ consecutive
+# ticks on the maintainer's host, each logging `Too many open files` immediately
+# above `scan complete`. A scan whose scanners complained is not a scan we can
+# describe as done; the gate below sits between the digest and the snapshot.
 SCAN_FAULT=""
 SCAN_ERR="$(mktemp "${TMPDIR:-/tmp}/kbscan-XXXXXX" 2>/dev/null)" || SCAN_ERR=""
 if [ -n "$SCAN_ERR" ]; then

--- a/scripts/vaultkeeper-tick.sh
+++ b/scripts/vaultkeeper-tick.sh
@@ -58,17 +58,28 @@ if [ -n "$SCAN_ERR" ] && [ -s "$SCAN_ERR" ]; then
 fi
 [ -n "$SCAN_ERR" ] && rm -f "$SCAN_ERR"
 
+# The order of these three is the whole point. Both survive a partial candidate set:
+# base_view_write takes only a path, and the digest is a full overwrite, so a
+# permanently-faulting host still surfaces something — which beats surfacing nothing,
+# the tradeoff that keeps them above the gate. The digest is told to say so.
 base_view_write "$VAULT/_vaultkeeper.base"
-printf '%s\n' "$CAND" | surfacing_digest "$VAULT"
-printf '%s\n' "$CAND" | surfacing_pending_transition "$VAULT"
+printf '%s\n' "$CAND" | surfacing_digest "$VAULT" "${SCAN_FAULT:+INCOMPLETE}"
+
 if [ -n "$SCAN_FAULT" ]; then
-  # Deliberately do NOT record the scan. last_scan drives the staleness banner in
-  # /obsidian:ask and the owner-election window; recording a partial scan tells
-  # both that the vault was fully examined. Leaving it unrecorded makes the
-  # banner report stale, which is the true state, and the next tick retries.
-  printf 'vaultkeeper: scan INCOMPLETE on %s — not recorded as complete (candidates may be short); scanners said: %s\n' \
+  # Stop before the snapshot. surfacing_pending_transition diffs against it and then
+  # overwrites it, so a truncated set makes the next healthy tick re-append
+  # everything this scan missed — 3 duplicated items over 4 fault/heal cycles when
+  # this check sat below it, in a file the user hand-edits and Syncthing replicates.
+  # keeper_record_scan is withheld for the ordinary reason: last_scan's consumer is
+  # staleness_banner (scripts/ask-staleness.sh), and a partial scan recorded as
+  # complete tells it the vault was fully examined. Note the banner only fires once a
+  # PREVIOUS last_scan ages out — a host that has never recorded one stays silent, so
+  # a latched fault here is invisible rather than loud. That gap is filed separately.
+  printf 'vaultkeeper: scan INCOMPLETE on %s — snapshot and Pending.md left untouched; scanners said: %s\n' \
     "$HOST" "$SCAN_FAULT" >&2
   exit 0
 fi
+
+printf '%s\n' "$CAND" | surfacing_pending_transition "$VAULT"
 keeper_record_scan "$VAULT"
 echo "vaultkeeper: scan complete ($HOST)"

--- a/tests/vault-scan.sh
+++ b/tests/vault-scan.sh
@@ -168,4 +168,38 @@ for _flags in '' 'set -euo pipefail;'; do
     || fail "missing tokenizer was not named [flags: ${_flags:-none}]; got: $(cat "$TMP/vserr")"
 done
 
+# --- scan_clusters survives a low fd limit and a piped stdout (#42) ---
+# The per-directory `done < <(find "$dir" ...)` nested inside `< <(find "$vault"
+# -type d)` opened two process substitutions per directory. Under launchd's fd
+# limit that exhausts the table on a real vault: every tick on the maintainer's
+# host logged `cannot duplicate fd: Too many open files` and still reported
+# `scan complete`. The candidate set was silently 58-82% short.
+#
+# Two independent failure modes, both pinned here:
+#   1. fd pressure  — 88/503 clusters at ulimit 64, 211/503 at 128 and 256.
+#   2. piped stdout — a bare `scan_clusters | cmd` returned 211/503 even with
+#      no fd limit at all and NOTHING on stderr. Deterministic, and invisible.
+FD="$TMP/fdvault"
+for _i in $(seq 1 120); do
+  _d="$FD/Folder$_i"; mkdir -p "$_d"
+  for _j in 1 2 3; do printf -- '---\n---\n' > "$_d/topic$_i note $_j.md"; done
+done
+# 120 dirs x 3 files sharing 2 tokens each (topic<N>, note) = 240 clusters.
+FD_EXPECT=240
+for _lim in 64 256 ''; do
+  _pre=""; [ -n "$_lim" ] && _pre="ulimit -n $_lim;"
+  _out="$(bash -c "${_pre} . '${ROOT_DIR}/scripts/lib/frontmatter.sh'; . '${ROOT_DIR}/scripts/lib/vault-scan.sh'; scan_clusters '$FD' 3" 2>"$TMP/fderr")" \
+    || fail "scan_clusters failed at ulimit ${_lim:-default}"
+  _n="$(printf '%s\n' "$_out" | grep -c '^CLUSTER' || true)"
+  [ "$_n" = "$FD_EXPECT" ] \
+    || fail "ulimit ${_lim:-default}: got $_n clusters, want $FD_EXPECT (scan truncated silently)"
+  [ -s "$TMP/fderr" ] \
+    && fail "ulimit ${_lim:-default}: scan wrote to stderr: $(cat "$TMP/fderr")"
+done
+# Piped stdout must produce the same count as a file redirect. This is the arm
+# that fails with no fd limit and no error output.
+_piped="$(bash -c ". '${ROOT_DIR}/scripts/lib/frontmatter.sh'; . '${ROOT_DIR}/scripts/lib/vault-scan.sh'; scan_clusters '$FD' 3 | grep -c '^CLUSTER'" 2>/dev/null)"
+[ "$_piped" = "$FD_EXPECT" ] \
+  || fail "piped stdout: got $_piped clusters, want $FD_EXPECT (output lost to a pipe)"
+
 echo "PASS: vault-scan"

--- a/tests/vault-scan.sh
+++ b/tests/vault-scan.sh
@@ -168,38 +168,41 @@ for _flags in '' 'set -euo pipefail;'; do
     || fail "missing tokenizer was not named [flags: ${_flags:-none}]; got: $(cat "$TMP/vserr")"
 done
 
-# --- scan_clusters survives a low fd limit and a piped stdout (#42) ---
+# --- scan_clusters returns the whole vault under fd pressure (#42) ---
 # The per-directory `done < <(find "$dir" ...)` nested inside `< <(find "$vault"
-# -type d)` opened two process substitutions per directory. Under launchd's fd
-# limit that exhausts the table on a real vault: every tick on the maintainer's
-# host logged `cannot duplicate fd: Too many open files` and still reported
-# `scan complete`. The candidate set was silently 58-82% short.
+# -type d)` opened two process substitutions per directory, so the fd table ran out
+# on a real vault and the candidate set came back short — with rc=0. On the
+# maintainer's host every tick logged `cannot duplicate fd: Too many open files`
+# and then reported `scan complete`.
 #
-# Two independent failure modes, both pinned here:
-#   1. fd pressure  — 88/503 clusters at ulimit 64, 211/503 at 128 and 256.
-#   2. piped stdout — a bare `scan_clusters | cmd` returned 211/503 even with
-#      no fd limit at all and NOTHING on stderr. Deterministic, and invisible.
+# What the loss depends on is available fds at runtime, and nothing else: the SAME
+# frozen 569-directory vault returned 503 clusters on an idle host and 211 under
+# load, identical through a pipe and through a file redirect, 0 bytes on stderr
+# both times. An earlier version of this test also asserted a pipe-vs-redirect
+# difference; there isn't one, and that arm passed against the unfixed code. A
+# forced `ulimit` squeeze is the only way to make the failure deterministic, which
+# is why there is one limit here and not a sweep — 256 and the default limit both
+# passed against the bug, so they pinned nothing and only cost runtime.
 FD="$TMP/fdvault"
 for _i in $(seq 1 120); do
-  _d="$FD/Folder$_i"; mkdir -p "$_d"
+  # A space in the FOLDER name, not just the filename: the fix splits `uniq -c`
+  # output on a literal tab because this vault has folders like "Awesome Motive",
+  # and awk's default whitespace FS silently splits the folder into two fields.
+  # Without a space-bearing directory here, dropping `-F'\t'` passes the suite.
+  _d="$FD/Awesome Folder $_i"; mkdir -p "$_d"
   for _j in 1 2 3; do printf -- '---\n---\n' > "$_d/topic$_i note $_j.md"; done
 done
 # 120 dirs x 3 files sharing 2 tokens each (topic<N>, note) = 240 clusters.
 FD_EXPECT=240
-for _lim in 64 256 ''; do
-  _pre=""; [ -n "$_lim" ] && _pre="ulimit -n $_lim;"
-  _out="$(bash -c "${_pre} . '${ROOT_DIR}/scripts/lib/frontmatter.sh'; . '${ROOT_DIR}/scripts/lib/vault-scan.sh'; scan_clusters '$FD' 3" 2>"$TMP/fderr")" \
-    || fail "scan_clusters failed at ulimit ${_lim:-default}"
-  _n="$(printf '%s\n' "$_out" | grep -c '^CLUSTER' || true)"
-  [ "$_n" = "$FD_EXPECT" ] \
-    || fail "ulimit ${_lim:-default}: got $_n clusters, want $FD_EXPECT (scan truncated silently)"
-  [ -s "$TMP/fderr" ] \
-    && fail "ulimit ${_lim:-default}: scan wrote to stderr: $(cat "$TMP/fderr")"
-done
-# Piped stdout must produce the same count as a file redirect. This is the arm
-# that fails with no fd limit and no error output.
-_piped="$(bash -c ". '${ROOT_DIR}/scripts/lib/frontmatter.sh'; . '${ROOT_DIR}/scripts/lib/vault-scan.sh'; scan_clusters '$FD' 3 | grep -c '^CLUSTER'" 2>/dev/null)"
-[ "$_piped" = "$FD_EXPECT" ] \
-  || fail "piped stdout: got $_piped clusters, want $FD_EXPECT (output lost to a pipe)"
+_out="$(bash -c "ulimit -n 64; . '${ROOT_DIR}/scripts/lib/frontmatter.sh'; . '${ROOT_DIR}/scripts/lib/vault-scan.sh'; scan_clusters '$FD' 3" 2>"$TMP/fderr")" \
+  || fail "scan_clusters failed at ulimit 64"
+_n="$(printf '%s\n' "$_out" | grep -c '^CLUSTER' || true)"
+[ "$_n" = "$FD_EXPECT" ] \
+  || fail "ulimit 64: got $_n clusters, want $FD_EXPECT (scan truncated silently)"
+[ -s "$TMP/fderr" ] \
+  && fail "ulimit 64: scan wrote to stderr: $(cat "$TMP/fderr")"
+# The folder name must survive intact — this is what pins the tab-split.
+printf '%s\n' "$_out" | grep -qF "CLUSTER"$'\t'"Awesome Folder 7"$'\t'"note"$'\t'"3" \
+  || fail "space-bearing folder name was mangled: $(printf '%s\n' "$_out" | grep 'Awesome' | head -2)"
 
 echo "PASS: vault-scan"

--- a/tests/vaultkeeper-tick.sh
+++ b/tests/vaultkeeper-tick.sh
@@ -40,4 +40,38 @@ rm -f "$V/Librarian.md"
 run_tick "mbp"
 [ ! -f "$V/Librarian.md" ] || fail "non-owner must not write Librarian.md"
 
+# --- a scan whose scanners complained is not recorded as complete (#42) ---
+# 710 consecutive ticks on the maintainer's host logged `Too many open files`
+# from vault-scan.sh and then `scan complete`, so last_scan advanced on a
+# truncated candidate set. last_scan drives /obsidian:ask's staleness banner and
+# the owner-election window; recording a partial scan tells both the vault was
+# fully examined. The fd bug is fixed in vault-scan.sh, but the gate has to exist
+# independently — any future scanner fault must reach the same conclusion.
+SV="$TMP/faultvault"; mkdir -p "$SV/Inbox"
+printf -- '---\ntags: [x]\n---\nbody\n' > "$SV/n.md"
+FCFG="$TMP/fault.local.md"
+sed "s|^vault_path: .*|vault_path: $SV|" "$CFG" > "$FCFG"
+# Shadow one scanner with a version that writes to stderr and still returns 0 —
+# exactly the shape every scanner has today.
+FLIB="$TMP/faultlib"; mkdir -p "$FLIB"
+cp "${ROOT_DIR}"/scripts/lib/*.sh "$FLIB/"
+cat >> "$FLIB/vault-scan.sh" <<'EOF'
+scan_open_asks() { printf 'vault-scan.sh: SIMULATED-SCANNER-FAULT\n' >&2; return 0; }
+EOF
+FSCRIPTS="$TMP/faultscripts"; mkdir -p "$FSCRIPTS"
+cp "${ROOT_DIR}"/scripts/*.sh "$FSCRIPTS/" 2>/dev/null || true
+cp -R "$FLIB" "$FSCRIPTS/lib"
+FOUT="$TMP/fault.out"
+OBSIDIAN_LOCAL_MD="$FCFG" VAULTKEEPER_HOST="ml-1" \
+  bash "$FSCRIPTS/vaultkeeper-tick.sh" >"$FOUT" 2>&1 \
+  || fail "a scanner fault must not abort the tick; got: $(cat "$FOUT")"
+grep -q 'SIMULATED-SCANNER-FAULT' "$FOUT" \
+  || fail "the scanner's own words were dropped; got: $(cat "$FOUT")"
+grep -q 'scan INCOMPLETE' "$FOUT" \
+  || fail "a faulted scan was not named incomplete; got: $(cat "$FOUT")"
+grep -q 'scan complete' "$FOUT" \
+  && fail "a faulted scan reported itself complete; got: $(cat "$FOUT")"
+[ -f "$(keeper_last_scan_file "$SV")" ] \
+  && fail "a faulted scan recorded last_scan, so the staleness banner will lie"
+
 echo "PASS: vaultkeeper-tick"

--- a/tests/vaultkeeper-tick.sh
+++ b/tests/vaultkeeper-tick.sh
@@ -109,4 +109,31 @@ if [ -f "$CV/Pending.md" ]; then
     || fail "fault/heal cycles duplicated $_dups Pending.md item(s): $(grep '^- \[ \]' "$CV/Pending.md" | sort | uniq -d | head -3)"
 fi
 
+# --- a gate that cannot arm must not wave the tick through (#42, panel) ---
+# `SCAN_ERR="$(mktemp …)" || SCAN_ERR=""` failed open: with no buffer the fault
+# check could never fire, so the tick recorded a partial scan as complete — the
+# exact behavior this gate exists to remove. And mktemp is among the first things
+# to fail under the fd/disk exhaustion the gate is watching for, so the guard went
+# missing precisely when it was needed.
+MV="$TMP/mktempvault"; mkdir -p "$MV/Inbox"
+printf -- '---\ntags: [x]\n---\nbody\n' > "$MV/n.md"
+MCFG="$TMP/mktemp.local.md"; sed "s|^vault_path: .*|vault_path: $MV|" "$CFG" > "$MCFG"
+mkdir -p "$TMP/mbin"
+cat > "$TMP/mbin/mktemp" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in *kbscan*) exit 1 ;; esac
+exec /usr/bin/mktemp "$@"
+EOF
+chmod +x "$TMP/mbin/mktemp"
+MOUT="$TMP/mktemp.out"
+PATH="$TMP/mbin:$PATH" OBSIDIAN_LOCAL_MD="$MCFG" VAULTKEEPER_HOST="ml-1" \
+  bash "${ROOT_DIR}/scripts/vaultkeeper-tick.sh" >"$MOUT" 2>&1 \
+  || fail "a failed mktemp must not abort the tick; got: $(cat "$MOUT")"
+grep -q 'scan INCOMPLETE' "$MOUT" \
+  || fail "gate could not arm and the tick did not say so; got: $(cat "$MOUT")"
+grep -q 'scan complete' "$MOUT" \
+  && fail "a tick with no fault buffer reported itself complete: $(cat "$MOUT")"
+[ -f "$(keeper_last_scan_file "$MV")" ] \
+  && fail "a tick with no fault buffer recorded last_scan"
+
 echo "PASS: vaultkeeper-tick"

--- a/tests/vaultkeeper-tick.sh
+++ b/tests/vaultkeeper-tick.sh
@@ -74,4 +74,39 @@ grep -q 'scan complete' "$FOUT" \
 [ -f "$(keeper_last_scan_file "$SV")" ] \
   && fail "a faulted scan recorded last_scan, so the staleness banner will lie"
 
+# --- a faulted tick must not touch the snapshot or Pending.md (#42, panel) ---
+# The first cut of the scan-fault gate sat BELOW surfacing_pending_transition, so a
+# faulted tick overwrote the snapshot with the truncated candidate set and the next
+# healthy tick re-appended everything the short scan had missed. Measured at 3
+# duplicated items over 4 fault/heal cycles — in a file the user hand-edits and
+# Syncthing replicates. The digest still runs on a partial set (a permanently
+# faulting host surfacing nothing is worse than one surfacing a short list), so it
+# has to say so: `scan_status: INCOMPLETE`.
+CV="$TMP/cyclevault"; mkdir -p "$CV/Inbox"
+for _n in 1 2 3; do printf -- '---\ntags: [x]\n---\nbody has [ask:q%s] here\n' "$_n" > "$CV/note$_n.md"; done
+CCFG="$TMP/cycle.local.md"; sed "s|^vault_path: .*|vault_path: $CV|" "$CFG" > "$CCFG"
+# A scanner that faults on stderr and emits nothing — the shape every scanner has.
+FLIB2="$TMP/cyclelib"; mkdir -p "$FLIB2"; cp "${ROOT_DIR}"/scripts/lib/*.sh "$FLIB2/"
+cat >> "$FLIB2/vault-scan.sh" <<'EOF'
+scan_open_asks() { printf 'vault-scan.sh: CYCLE-FAULT\n' >&2; return 0; }
+EOF
+FS2="$TMP/cyclescripts"; mkdir -p "$FS2"; cp "${ROOT_DIR}"/scripts/*.sh "$FS2/" 2>/dev/null || true
+cp -R "$FLIB2" "$FS2/lib"
+HEALTHY="$TMP/healthyscripts"; mkdir -p "$HEALTHY"; cp "${ROOT_DIR}"/scripts/*.sh "$HEALTHY/" 2>/dev/null || true
+cp -R "${ROOT_DIR}/scripts/lib" "$HEALTHY/lib"
+run_cycle() { OBSIDIAN_LOCAL_MD="$CCFG" VAULTKEEPER_HOST="ml-1" bash "$1/vaultkeeper-tick.sh" >"$TMP/cyc.out" 2>&1 || fail "tick aborted: $(cat "$TMP/cyc.out")"; }
+for _c in 1 2 3 4; do
+  run_cycle "$HEALTHY"
+  run_cycle "$FS2"
+done
+[ -f "$CV/Librarian.md" ] \
+  || fail "faulted tick left no Librarian.md — a degraded host must still surface something"
+grep -q 'scan_status: INCOMPLETE' "$CV/Librarian.md" \
+  || fail "digest written from a faulted scan does not say so: $(head -5 "$CV/Librarian.md")"
+if [ -f "$CV/Pending.md" ]; then
+  _dups="$(grep '^- \[ \]' "$CV/Pending.md" | sort | uniq -d | wc -l | tr -d ' ')"
+  [ "$_dups" = "0" ] \
+    || fail "fault/heal cycles duplicated $_dups Pending.md item(s): $(grep '^- \[ \]' "$CV/Pending.md" | sort | uniq -d | head -3)"
+fi
+
 echo "PASS: vaultkeeper-tick"

--- a/tests/vaultkeeper-tick.sh
+++ b/tests/vaultkeeper-tick.sh
@@ -41,12 +41,13 @@ run_tick "mbp"
 [ ! -f "$V/Librarian.md" ] || fail "non-owner must not write Librarian.md"
 
 # --- a scan whose scanners complained is not recorded as complete (#42) ---
-# 710 consecutive ticks on the maintainer's host logged `Too many open files`
+# 700+ consecutive ticks on the maintainer's host logged `Too many open files`
 # from vault-scan.sh and then `scan complete`, so last_scan advanced on a
-# truncated candidate set. last_scan drives /obsidian:ask's staleness banner and
-# the owner-election window; recording a partial scan tells both the vault was
-# fully examined. The fd bug is fixed in vault-scan.sh, but the gate has to exist
-# independently — any future scanner fault must reach the same conclusion.
+# truncated candidate set. last_scan's only consumer is /obsidian:ask's staleness
+# banner (via scripts/ask-staleness.sh) — NOT owner election, which reads
+# claim-file mtimes and never looks at last_scan. The fd bug is fixed in
+# vault-scan.sh, but the gate has to exist independently — any future scanner
+# fault must reach the same conclusion.
 SV="$TMP/faultvault"; mkdir -p "$SV/Inbox"
 printf -- '---\ntags: [x]\n---\nbody\n' > "$SV/n.md"
 FCFG="$TMP/fault.local.md"


### PR DESCRIPTION
Closes #42

## Description (Issue Fixed & New Behavior)

`scan_clusters` walked `find "$vault" -type d` and, for each directory, opened a nested process substitution around `find "$dir" -maxdepth 1`. Two live fds per iteration, 569 directories on my vault, and launchd hands the tick a much smaller fd table than an interactive shell. Result: every tick logged

```
vault-scan.sh: redirection error: cannot duplicate fd: Too many open files
vaultkeeper: scan complete (MBP-2026)
```

710 of 710 ticks in `~/.config/llm-tools-hooks/obsidian-vaultkeeper.log`. The function returned 0 throughout, so the truncated candidate set was recorded as a completed scan.

Measured on a frozen copy of the real vault (2720 notes), using the production call shape:

| fd limit | clusters found | fd errors |
|---|---|---|
| `ulimit -n 64` | 88 of 503 | 1 |
| `ulimit -n 128` | 211 of 503 | 1 |
| `ulimit -n 256` | 211 of 503 | 1 |
| after this PR, all of the above | **503 of 503** | **0** |

So the keeper has been clustering on 17–42% of its candidates.

**Correction to an earlier version of this description.** It claimed a second, pipe-specific failure mode independent of the fd limit. That was wrong, and so was every competing theory the review panel proposed (one reviewer measured the file redirect as the lossy target; a panelist concluded it was purely fd-gated at flat fixture sizes; I briefly concluded it was directory depth). What actually holds: **the amount lost tracks whatever fd headroom exists at runtime.** The same frozen 569-directory vault returned 503 clusters on an idle host and 211 under load, matching exactly through a pipe and through a file redirect, with zero bytes on stderr both times. There is no target asymmetry, which is why no fixture size makes a pipe-vs-redirect assertion bite — that test arm has been deleted rather than grown.

`scan_clusters` now emits flat `dir<TAB>token` pairs through a single pipeline, so there is one process substitution for the entire scan instead of two per directory. The output *line set* is identical to the old implementation's known-good result on the frozen vault — zero lines gained or lost in either direction, verified with `comm` on 1138 lines. Not byte-identical: emission order changed from `find` order to globally sorted, so `Librarian.md`'s cluster section reorders (cosmetic, arguably an improvement). Reusing `_scan_find_md` also genuinely widens the exclusion set — `Librarian.md`, `Pending.md` and `*.base` no longer cluster — which is intended and is why equality held only by coincidence of which tokens those filenames share.

Second commit adds the invariant half. Every scanner ends in `return 0`, so the tick could not tell a partial scan from a complete one. The scanners' stderr is now captured; if it is non-empty the tick quotes it, says `scan INCOMPLETE`, and returns **without** recording `last_scan`. That matters because `last_scan` feeds `/obsidian:ask`'s staleness banner — recording a partial scan tells it the vault was fully examined. (An earlier version of this description also claimed it drives the owner-election window. It does not; election reads claim-file mtimes. Corrected in `053a627`.) Exit status stays 0; a partial scan must not take the Stop hook down.

Two smaller things in the rewrite: the count is grouped with `sort | uniq -c` and split on **tab**, not whitespace (default-FS `awk` broke on folders like `Awesome Motive`, which the first draft did until a fixture with spaces caught it); and clustering now reuses `_scan_find_md`, so `Librarian.md`, `Pending.md` and `*.base` are excluded the way they already were from every other scanner.

Superseded by `9a19bb7`: the Pending transition no longer runs on a partial set — it was the write causing duplicate growth. The digest still does, deliberately, because a permanently-degraded host surfacing nothing is worse than one surfacing a short list; it now stamps `scan_status: INCOMPLETE` so the artifact says which it is.


## Review panel corrections (commits 3-6)

An 8-agent review panel ran on this PR; 6 agents completed. Four findings were blocking and all four were mine.

**`9a19bb7` — the gate was below the writes it guarded.** `surfacing_pending_transition` diffs the candidate set against the snapshot and then overwrites it, so the original gate placement let a faulted tick rewrite persistent state to the truncated set; the next healthy tick then re-appended everything the short scan missed. Three agents independently measured the duplicate growth in `Pending.md` — a file the user hand-edits and Syncthing replicates. That oscillation was *introduced* by my gate: the pre-PR truncation was stable, so it never flapped. Fixed as a split rather than a move — `base_view_write` and the digest stay above (a permanently-faulting host that surfaces nothing is worse than one surfacing a short list, and a plain move was verified to leave a cold-start host with no `Librarian.md` at all), and the digest now stamps `scan_status: INCOMPLETE` because it was previously writing a fresh `last_scan` *and* `## Open [ask] items (0)` with three ASK notes present.

**`048359e` — the gate failed open.** `mktemp` failure left no buffer, so the fault check could never fire and a partial scan was recorded as complete — the exact behavior this PR removes, restored silently, under precisely the exhaustion the gate watches for. Now an unavailable buffer is itself a fault. Cleanup moved to a `trap`; the previous bare `rm` did not survive a tick killed for overrunning its launchd window, so the earlier claim of cleanup "on every path" was false.

**`b522ab6` — a test arm that passed against the bug.** The piped-stdout arm returned 240 of 240 on the reverted implementation while its own comment called it "the arm that fails." Deleted. Also closed real missing coverage: no fixture had a space in a *directory* name, so `awk -F'\t'` — load-bearing, because this vault has folders like `Awesome Motive` — survived deletion with the suite green. The fd sweep is down to the one limit that discriminates.

**`053a627` — three false comments**, including one that named `last_scan` as driving the owner-election window. It has no such consumer, and that claim was the gate's stated justification.

The panel's remaining findings are filed as #51 (the fault predicate keys on stderr, so it latches on noise and misses quiet faults), #52 (cold-start banner silence), #53 (quarantine stderr outside the capture), #54 (fault-buffer dedup before truncation), #55 (threshold coercion), #56 (vault-root absolute-path leak), and #57 (end-to-end tick test under a low fd limit).

## Testing Procedure

1. Check out this branch and run `bash tests/run-all.sh` — expect `ALL PASS` (bash 3.2.57 verified).
2. Revert `scripts/lib/vault-scan.sh` to master's version and run `bash tests/vault-scan.sh`. Expect `FAIL: ulimit 64: got 102 clusters, want 240 (scan truncated silently)`. The test builds its own 120-directory fixture (3 files each, 2 shared tokens = exactly 240 clusters) and asserts that count at `ulimit -n 64` — the only limit that discriminates; 256 and the default both passed against the bug and were dropped in `b522ab6`, along with a piped-vs-redirected arm that also passed against it.
3. Delete the `if [ -n "$SCAN_FAULT" ]` block from `scripts/vaultkeeper-tick.sh` and run `bash tests/vaultkeeper-tick.sh`. Expect `FAIL: a faulted scan was not named incomplete`. That arm shadows one scanner with a version that writes to stderr and returns 0 — the exact shape every scanner has today — then asserts the tick stays 0, quotes the scanner, says INCOMPLETE, never says complete, and leaves `last_scan` absent.
4. To see the original symptom on real data: `bash -c "ulimit -n 128; . scripts/lib/vault-scan.sh; scan_clusters <your-vault> 3 | wc -l"` on master vs this branch.

## Additional Notes / HelpScout Tickets

Measuring against the live vault is useless — Syncthing and the keeper itself mutate it mid-run, and three consecutive runs gave 211, 336 and 503. Every number above comes from a frozen copy or a synthetic fixture. I burned several measurement rounds on that before noticing, and one intermediate claim ("production is losing lines") was wrong as a result; the frozen-fixture numbers are the ones that hold.

Related: #43 (temp-swap invariant, the Pending-churn half), #44, #45, #46.




---

Two corrections to the commits themselves, for the record. `048359e`'s message says it "retires the `${SCAN_ERR:-/dev/stderr}` fallback" — it does not; the fallback is still there and is now only reachable once a fault is already recorded, so it is inert rather than removed. And the gate split left `keeper_quarantine_conflicts` on the wrong side: its `QUARANTINE` row is a one-shot side effect of an irreversible `mv`, so a faulted tick drops that row from `Pending.md` permanently. The conflict file is safely quarantined either way. Filed as #58 rather than bodged in, because deferring quarantine past the gate would empty the digest's quarantine section.
