### PR TITLE
Make a never-completed scan visible to the staleness banner

### DIFF
--- a/scripts/lib/keeper-state.sh
+++ b/scripts/lib/keeper-state.sh
@@ -43,11 +43,30 @@ keeper_last_scan_file() { printf '%s/last_scan\n' "$(keeper_cache_dir "$1")"; }
 keeper_record_scan()    { local f; f="$(keeper_last_scan_file "$1")"; mkdir -p "$(dirname "$f")"; now_epoch > "$f"; }
 keeper_last_scan()      { local f; f="$(keeper_last_scan_file "$1")"; [ -f "$f" ] && cat "$f" || true; }
 
+# An attempt is recorded by the elected owner before it scans, whether or not that
+# scan goes on to complete. It is what separates "no last_scan because nothing has
+# ever tried" (fresh install, or a host that defers to the owner — silence is right)
+# from "no last_scan because every attempt faulted" (the scan-fault gate withholding
+# it, which is exactly the state worth shouting about).
+keeper_last_attempt_file() { printf '%s/last_attempt\n' "$(keeper_cache_dir "$1")"; }
+keeper_record_attempt()    { local f; f="$(keeper_last_attempt_file "$1")"; mkdir -p "$(dirname "$f")"; now_epoch > "$f"; }
+keeper_last_attempt()      { local f; f="$(keeper_last_attempt_file "$1")"; [ -f "$f" ] && cat "$f" || true; }
+
 staleness_banner() {
-  local vault="$1" interval="$2" last now
+  local vault="$1" interval="$2" last attempted now
   last="$(keeper_last_scan "$vault")"
-  [ -z "$last" ] && return 0
   now="$(now_epoch)"
+  if [ -z "$last" ]; then
+    attempted="$(keeper_last_attempt "$vault")"
+    # No attempt on disk: nothing has tried to scan this vault from this host yet.
+    [ -z "$attempted" ] && return 0
+    # Attempted and still no completed scan. No aging grace here on purpose — one
+    # faulted tick already means the index has never been fully built, and the
+    # in-flight window between recording the attempt and recording the scan is
+    # the couple of seconds a healthy tick takes.
+    printf '⚠ index has never completed a scan (last attempt %ss ago)\n' "$(( now - attempted ))"
+    return 0
+  fi
   if [ "$(( now - last ))" -gt "$(( interval * 2 ))" ]; then
     printf '⚠ index last maintained %ss ago\n' "$(( now - last ))"
   fi

--- a/scripts/vaultkeeper-tick.sh
+++ b/scripts/vaultkeeper-tick.sh
@@ -35,6 +35,13 @@ if ! keeper_is_owner "$LEASE" "$HOST" "$PRIORITY" "$MAXAGE"; then
   exit 0
 fi
 
+# Record the attempt below the ownership gate, so only the host that actually scans
+# claims one. staleness_banner needs it to read a missing last_scan correctly: with
+# no attempt it means nothing has tried yet (fresh install, or a host deferring to
+# the owner) and silence is right; with an attempt it means every try faulted, which
+# is the state the gate below withholds last_scan to signal.
+keeper_record_attempt "$VAULT"
+
 CONFLICTS="$(keeper_quarantine_conflicts "$VAULT" || true)"
 # Capture the scanners' stderr instead of letting it fly past. Every scanner
 # returns 0 unconditionally, so a truncated scan was indistinguishable from a
@@ -87,9 +94,10 @@ if [ -n "$SCAN_FAULT" ]; then
   # this check sat below it, in a file the user hand-edits and Syncthing replicates.
   # keeper_record_scan is withheld for the ordinary reason: last_scan's consumer is
   # staleness_banner (scripts/ask-staleness.sh), and a partial scan recorded as
-  # complete tells it the vault was fully examined. Note the banner only fires once a
-  # PREVIOUS last_scan ages out — a host that has never recorded one stays silent, so
-  # a latched fault here is invisible rather than loud. That gap is filed separately.
+  # complete tells it the vault was fully examined. Withholding it now actually
+  # reaches that consumer: the attempt recorded above the scan lets the banner tell a
+  # host whose every tick faulted from one that has never tried, so a fault latched
+  # from the first tick reads as "never completed a scan" instead of as silence.
   printf 'vaultkeeper: scan INCOMPLETE on %s — snapshot and Pending.md left untouched; scanners said: %s\n' \
     "$HOST" "$SCAN_FAULT" >&2
   exit 0

--- a/tests/keeper-state.sh
+++ b/tests/keeper-state.sh
@@ -42,4 +42,24 @@ keeper_record_scan "$VAULT"
 printf '1000\n' > "$(keeper_cache_dir "$VAULT")/last_scan"
 [ -n "$(staleness_banner "$VAULT" 900)" ] || fail "stale scan should warn"
 
+# --- a host that has ATTEMPTED a scan but never completed one is not healthy (#52) ---
+# The scan-fault gate withholds last_scan on purpose, so a host whose scans fault
+# from the very first tick never records one. The banner's `[ -z "$last" ] && return 0`
+# then made that host indistinguishable from one scanned a second ago — the fault
+# latched silently. `keeper_last_scan` absent is two different states, and only one
+# of them (never attempted: fresh install, or a non-owner host that defers before
+# scanning) warrants silence.
+AV="$TMP/attempted"; mkdir -p "$AV"
+keeper_state_init "$AV" >/dev/null
+[ -z "$(keeper_last_attempt "$AV")" ] || fail "last_attempt should be empty before any tick"
+[ -z "$(staleness_banner "$AV" 900)" ] || fail "never-attempted host must stay silent"
+keeper_record_attempt "$AV"
+[ -n "$(keeper_last_attempt "$AV")" ] || fail "last_attempt not recorded"
+BANNER="$(staleness_banner "$AV" 900)"
+[ -n "$BANNER" ] || fail "attempted-but-never-completed host must warn, got silence"
+case "$BANNER" in *"never completed"*) : ;; *) fail "banner must say the scan never completed: $BANNER" ;; esac
+# A completed scan wins over the attempt: recording one must silence the never-completed line.
+keeper_record_scan "$AV"
+[ -z "$(staleness_banner "$AV" 900)" ] || fail "fresh completed scan should not warn even with an attempt on disk"
+
 echo "PASS: keeper-state"

--- a/tests/vaultkeeper-tick.sh
+++ b/tests/vaultkeeper-tick.sh
@@ -74,6 +74,16 @@ grep -q 'scan complete' "$FOUT" \
   && fail "a faulted scan reported itself complete; got: $(cat "$FOUT")"
 [ -f "$(keeper_last_scan_file "$SV")" ] \
   && fail "a faulted scan recorded last_scan, so the staleness banner will lie"
+# ...and withholding last_scan has to actually reach the consumer (#52). Before the
+# attempt file existed, this host — faulting from its very first tick, so with no
+# prior last_scan to age out — got silence from staleness_banner, identical to a
+# vault scanned a second ago. The gate was honest and the reader never heard it.
+[ -f "$(keeper_last_attempt_file "$SV")" ] \
+  || fail "a faulted tick recorded no attempt, so the banner cannot tell it from a fresh install"
+FBANNER="$(staleness_banner "$SV" 900)"
+[ -n "$FBANNER" ] \
+  || fail "a host whose only scans faulted still looks healthy to the banner"
+case "$FBANNER" in *"never completed"*) : ;; *) fail "banner did not name the real state: $FBANNER" ;; esac
 
 # --- a faulted tick must not touch the snapshot or Pending.md (#42, panel) ---
 # The first cut of the scan-fault gate sat BELOW surfacing_pending_transition, so a


### PR DESCRIPTION
Closes #52

## Description

Follow-up to #49. That PR made the tick withhold `last_scan` when the scanners fault, so `/obsidian:ask` would report the index as stale rather than claim a scan it didn't finish. The withholding was correct; the consumer couldn't hear it.

`staleness_banner` returned early on an absent `last_scan` (`keeper-state.sh`, `[ -z "$last" ] && return 0`). On a host whose scans fault from the *first* tick there is no previous `last_scan` to age out, so the banner printed nothing — indistinguishable from a vault scanned a second ago. A fault latched from tick one was silent.

An absent `last_scan` is two different states, and only one of them earns silence:

- **nothing has tried yet** — fresh install, or a host that defers to the elected owner and never scans. Silence is right.
- **every attempt faulted** — exactly what the #49 gate withholds `last_scan` to signal. This is the loud case.

So the tick now records an attempt (`keeper_record_attempt`) below the ownership gate and before scanning, and the banner uses it to tell the two apart. With an attempt and no completed scan it prints `⚠ index has never completed a scan (last attempt Ns ago)`. No aging grace on that branch on purpose — one faulted tick already means the index was never fully built, and the in-flight window between recording the attempt and recording the scan is the couple of seconds a healthy tick takes.

Recording below the ownership gate matters: doing it above would have every non-owner host claim an attempt it never makes, and then permanently report "never completed a scan" for a vault it isn't responsible for scanning.

Also updates the gate comment in `vaultkeeper-tick.sh`, which documented this gap as unfiled.

## Testing Procedure

1. Check out this branch.
2. `bash tests/keeper-state.sh` and `bash tests/vaultkeeper-tick.sh` — both pass.
3. Confirm the assertions bind, one mutation at a time:
   - Restore the early return: change `if [ -z "$last" ]; then` to `if [ -z "$last" ]; then return 0;` in `scripts/lib/keeper-state.sh`. `keeper-state.sh` fails with `attempted-but-never-completed host must warn, got silence`; `vaultkeeper-tick.sh` fails with `a host whose only scans faulted still looks healthy to the banner`.
   - Delete the `keeper_record_attempt "$VAULT"` line from `scripts/vaultkeeper-tick.sh`. `vaultkeeper-tick.sh` fails with `a faulted tick recorded no attempt, so the banner cannot tell it from a fresh install`.
4. Confirm the fresh-install case stays quiet — `tests/keeper-state.sh:37` (`no banner when last_scan absent`) is unchanged and still passes, as does the never-attempted assertion on the new fixture vault.
5. Full suite: `for t in tests/*.sh; do bash "$t" >/dev/null || echo "FAIL $t"; done` — 29/29, no output.

## Notes

Both #49 findings that touched `Librarian.md` and `Pending.md` are already fixed on master (`scan_status: INCOMPLETE` and moving `surfacing_pending_transition` below the gate). This PR is the third one, which #49 knowingly deferred to #52.

The digest still writes a fresh `last_scan:` on a faulted tick alongside `scan_status: INCOMPLETE`. Left as-is — the field means "when the scan ran", and the status line carries whether it finished.

Open and unrelated to this change: #58 (a faulted tick drops the QUARANTINE row permanently), #53, #51, #54.