### PR TITLE
Gate commit-capture on a PreToolUse HEAD snapshot instead of text shapes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.16.7",
+  "version": "1.17.0",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Long Claude sessions and the commits they produce hold context that's gone the m
 
 - A **Stop hook** runs at session end; if the session is significant, a background `claude --print` summarizer writes a structured note to your vault.
 - Session capture infers `session_intent`, `capture_action`, and `research_state_change` with confidence scores and evidence bullets, so routing can distinguish execution, research, planning, operations, reflection, scratch work, and claim/evidence changes that should land in the Research Substrate.
-- A **PostToolUse hook** on `Bash` detects successful `git commit` calls and appends goal / investigation / decision / loose-ends bullets to a per-repo daily file.
+- A **PreToolUse/PostToolUse hook pair** on `Bash` notices when a `git commit` actually moved `HEAD` and appends goal / investigation / decision / loose-ends bullets to a per-repo daily file.
 - **Slash commands** (skills) cover the manual paths: save, find, recall, daily, new, bookmark, setup.
 - **Routing** is driven by `obsidian.local.md` — a vault path and a keyword-based domain taxonomy you edit directly.
 
@@ -114,9 +114,12 @@ The keeper writes only to the Obsidian vault (`vault_path` from `obsidian.local.
 |---|---|---|
 | `SessionStart` | `scripts/config-doctor.sh` | If the plugin is installed but unconfigured on this host (no `obsidian.local.md`) while a synced vault is detectable, surfaces an advisory so the agent can offer `/obsidian:setup`. Silent once configured, and silent on hosts with no vault. Advisory only — a hook can't prompt. |
 | `Stop` | `scripts/session-save.sh` | Auto-saves significant sessions via background `claude --print` summarizer. Skips trivial sessions. |
-| `PostToolUse` (Bash) | `scripts/commit-capture.sh` | After a successful `git commit`, appends a context block to `<vault>/Projects/Development/<org>_<repo>/<YYYY-MM-DD>.md`. Per-repo overrides supported (e.g. `altamira2/mtf-builder` → flat `<vault>/Altamira/<date>-mtf-builder-commits.md`). |
+| `PreToolUse` (Bash) | `scripts/commit-capture-pre.sh` | For a Bash call that is about to run `git commit`, records the repo's current `HEAD`. Writes nothing else, and always exits 0 — a PreToolUse hook that fails would block the command. |
+| `PostToolUse` (Bash) | `scripts/commit-capture.sh` | If `HEAD` moved during the call, appends a context block to `<vault>/Projects/Development/<org>_<repo>/<YYYY-MM-DD>.md`. Per-repo overrides supported (e.g. `altamira2/mtf-builder` → flat `<vault>/Altamira/<date>-mtf-builder-commits.md`). |
 
-The PostToolUse hook is gated — it inspects the Bash command first and exits silently for non-commit calls, so it doesn't interrupt normal tool flow.
+Both hooks are gated — they inspect the Bash command first and exit silently for non-commit calls, so they don't interrupt normal tool flow.
+
+**The two halves are one mechanism: register both or neither.** Whether a commit landed is decided by comparing `HEAD` before the call against `HEAD` after, which is the only signal that actually distinguishes a commit from a `git commit` that was rejected, aborted, short-circuited by `false &&`, or had nothing to commit. With only the PostToolUse half wired up there is no "before", and the hook says so on stderr rather than guessing from the command text.
 
 ## Examples
 
@@ -188,8 +191,9 @@ Per-repo commit-capture overrides go in the same file under a `## Commit Capture
 .claude-plugin/plugin.json    Plugin manifest
 commands/*.md                 Slash command entry points
 skills/*/SKILL.md             Skill logic (save, find, recall, setup, …)
-hooks/hooks.json              Stop + PostToolUse hook registration
+hooks/hooks.json              Stop + Pre/PostToolUse hook registration
 scripts/                      Hook executables (commit-capture, session-save, …)
+scripts/lib/commit-capture-parse.sh Payload decoding + repo resolution shared by the commit-capture hook pair
 scripts/lib/resolve-config.sh Version-independent config-path resolver
 scripts/lib/allowlist-validate.sh Frontmatter/path allowlist validation shared by writers
 scripts/lib/dedup-scan.sh     Shared dedup-against-existing-notes scan

--- a/README.md
+++ b/README.md
@@ -114,12 +114,14 @@ The keeper writes only to the Obsidian vault (`vault_path` from `obsidian.local.
 |---|---|---|
 | `SessionStart` | `scripts/config-doctor.sh` | If the plugin is installed but unconfigured on this host (no `obsidian.local.md`) while a synced vault is detectable, surfaces an advisory so the agent can offer `/obsidian:setup`. Silent once configured, and silent on hosts with no vault. Advisory only — a hook can't prompt. |
 | `Stop` | `scripts/session-save.sh` | Auto-saves significant sessions via background `claude --print` summarizer. Skips trivial sessions. |
-| `PreToolUse` (Bash) | `scripts/commit-capture-pre.sh` | For a Bash call that is about to run `git commit`, records the repo's current `HEAD`. Writes nothing else, and always exits 0 — a PreToolUse hook that fails would block the command. |
-| `PostToolUse` (Bash) | `scripts/commit-capture.sh` | If `HEAD` moved during the call, appends a context block to `<vault>/Projects/Development/<org>_<repo>/<YYYY-MM-DD>.md`. Per-repo overrides supported (e.g. `altamira2/mtf-builder` → flat `<vault>/Altamira/<date>-mtf-builder-commits.md`). |
+| `PreToolUse` (Bash) | `scripts/commit-capture-pre.sh` | For a Bash call that is about to run `git commit`, records the target repo's current `HEAD` (and the repo the command named, which may not exist yet). Writes nothing else, and always exits 0 — a PreToolUse hook that fails would block the command. |
+| `PostToolUse` (Bash) | `scripts/commit-capture.sh` | If `HEAD` moved during the call and git says the move was a commit of ours, appends a context block to `<vault>/Projects/Development/<org>_<repo>/<YYYY-MM-DD>.md`. Per-repo overrides supported (e.g. `altamira2/mtf-builder` → flat `<vault>/Altamira/<date>-mtf-builder-commits.md`). |
 
 Both hooks are gated — they inspect the Bash command first and exit silently for non-commit calls, so they don't interrupt normal tool flow.
 
-**The two halves are one mechanism: register both or neither.** Whether a commit landed is decided by comparing `HEAD` before the call against `HEAD` after, which is the only signal that actually distinguishes a commit from a `git commit` that was rejected, aborted, short-circuited by `false &&`, or had nothing to commit. With only the PostToolUse half wired up there is no "before", and the hook says so on stderr rather than guessing from the command text.
+**The two halves are one mechanism: register both or neither.** Whether a commit landed is decided by comparing `HEAD` before the call against `HEAD` after — the only signal that distinguishes a commit from a `git commit` that was rejected, aborted, short-circuited by `false &&`, or had nothing to commit. A tip that moved is necessary but not sufficient, so the post-hook also asks git *what* the move was: the old tip (or its parent, for an amend) has to be reachable from the new one, and the new commit's committer has to be you — a `git pull` that fast-forwards in front of a failed commit leaves someone else's commit at the tip.
+
+With only the PostToolUse half wired up there is no "before". The hook says so, on stdout, alongside every other reason a commit went uncaptured — a hook that exits 0 has its stdout read, and nothing documented reads its stderr, so a diagnostic written there would be indistinguishable from silence. Only a line beginning `obsidian-commit-capture: hash=` is a record.
 
 ## Examples
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -22,6 +22,18 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/commit-capture-pre.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",

--- a/scripts/commit-capture-pre.sh
+++ b/scripts/commit-capture-pre.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# commit-capture-pre.sh
+# PreToolUse command hook. Records HEAD for any Bash call that is about to invoke
+# `git commit`, so the PostToolUse hook can require that HEAD actually moved
+# instead of inferring a commit from the command text and the age of the tip.
+#
+# Why the snapshot exists: nothing in a PostToolUse payload links HEAD to the
+# invocation being observed. A `git commit` that failed leaves the previous
+# commit at the tip, and if that commit's capture was ever dropped, the failed
+# call captures its predecessor and stamps it with the hook's clock rather than
+# the commit's. `false && git commit` reproduced it end to end. HEAD_before vs
+# HEAD_after observes the thing we actually care about.
+#
+# This hook must never fail the tool call it precedes: a PreToolUse hook exiting
+# 2 blocks the Bash call, and any other non-zero surfaces an error to the user.
+# Every step is best-effort and the script exits 0 unconditionally, silently, on
+# both stdout and stderr.
+
+set -uo pipefail
+
+INPUT=$(cat)
+
+case "$INPUT" in
+  *'"command"'*commit*) ;;
+  *) exit 0 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)" || exit 0
+LIB="${SCRIPT_DIR}/lib/commit-capture-parse.sh"
+[ -f "$LIB" ] || exit 0
+# shellcheck source=lib/commit-capture-parse.sh
+. "$LIB" || exit 0
+
+COMMAND_LINE="$(cc_json_value "$INPUT" '"command"')"
+PAYLOAD_CWD="$(cc_json_value "$INPUT" '"cwd"')"
+
+cc_invokes_commit "$COMMAND_LINE" || exit 0
+
+# The repo may not exist yet — `mkdir x && cd x && git init && git commit` is a
+# real shape. Record that we looked and could not resolve one, which is different
+# from not having run at all: the post-hook has no prior HEAD to compare against
+# and falls back to requiring a freshly-dated tip.
+SHA="unresolved"
+ROOT=""
+REPO_DIR="$(cc_find_repo_dir "$PAYLOAD_CWD")" || REPO_DIR=""
+if [ -n "$REPO_DIR" ]; then
+  ROOT=$(git -C "$REPO_DIR" rev-parse --show-toplevel 2>/dev/null) || ROOT="$REPO_DIR"
+  # An unborn HEAD is not a failure: the next commit is the repo's first, and
+  # `none` still differs from whatever sha that produces.
+  SHA=$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null) || SHA="none"
+  case "$SHA" in
+    *[!0-9a-f]*|'') SHA="none" ;;
+  esac
+fi
+
+SNAP_DIR="$(cc_state_dir)/pre-commit-head"
+mkdir -p "$SNAP_DIR" 2>/dev/null || exit 0
+
+# A snapshot is consumed by the post-hook, which deletes it. One is left behind
+# whenever the tool call never completes (denied, interrupted, session killed),
+# so sweep anything older than a day. Only runs on commit-shaped calls, so this
+# is not a per-Bash-call cost.
+find "$SNAP_DIR" -type f -mtime +1 -delete 2>/dev/null || true
+
+KEY="$(cc_snapshot_key "$INPUT")"
+# Newline-free values only: root comes from rev-parse, sha from a hex check.
+{ printf 'sha=%s\nroot=%s\n' "$SHA" "$ROOT" > "${SNAP_DIR}/${KEY}"; } 2>/dev/null || true
+
+exit 0

--- a/scripts/commit-capture-pre.sh
+++ b/scripts/commit-capture-pre.sh
@@ -36,10 +36,28 @@ PAYLOAD_CWD="$(cc_json_value "$INPUT" '"cwd"')"
 
 cc_invokes_commit "$COMMAND_LINE" || exit 0
 
-# The repo may not exist yet — `mkdir x && cd x && git init && git commit` is a
-# real shape. Record that we looked and could not resolve one, which is different
-# from not having run at all: the post-hook has no prior HEAD to compare against
-# and falls back to requiring a freshly-dated tip.
+# The repo the command names may not exist yet — `git worktree add ../wt && cd ../wt
+# && git commit` and `mkdir sub && cd sub && git init && git commit` are both real
+# shapes, and the first is this project's own documented workflow. Record the named
+# directory regardless of whether it resolves *now*: without it, resolution fell
+# through to the surrounding repo, the post-hook resolved the new one, the two roots
+# disagreed, and the real commit was discarded as belonging to another repository.
+INTENT=""
+for cand in "$CC_GIT_C_DIR" "$CC_CD_TARGET"; do
+  [ -n "$cand" ] || continue
+  INTENT="$cand"
+  break
+done
+# Absolutise it so the post-hook does not have to reproduce this hook's cwd, and so
+# a relative `cd` cannot resolve against the wrong directory later.
+case "$INTENT" in
+  '') ;;
+  '~') INTENT="$HOME" ;;
+  '~/'*) INTENT="$HOME/${INTENT#\~/}" ;;
+  /*) ;;
+  *) [ -n "$PAYLOAD_CWD" ] && INTENT="$PAYLOAD_CWD/$INTENT" ;;
+esac
+
 SHA="unresolved"
 ROOT=""
 REPO_DIR="$(cc_find_repo_dir "$PAYLOAD_CWD")" || REPO_DIR=""
@@ -51,6 +69,12 @@ if [ -n "$REPO_DIR" ]; then
   case "$SHA" in
     *[!0-9a-f]*|'') SHA="none" ;;
   esac
+elif [ -z "$INTENT" ]; then
+  # Nothing resolved and the command named nothing, so there is no repository this
+  # snapshot could be *about*. Writing one anyway produced a sha that matches no
+  # HEAD and a root that matches every repo — a wildcard the post-hook could only
+  # resolve with the same recent-tip guess the gate exists to replace.
+  exit 0
 fi
 
 SNAP_DIR="$(cc_state_dir)/pre-commit-head"
@@ -63,7 +87,10 @@ mkdir -p "$SNAP_DIR" 2>/dev/null || exit 0
 find "$SNAP_DIR" -type f -mtime +1 -delete 2>/dev/null || true
 
 KEY="$(cc_snapshot_key "$INPUT")"
-# Newline-free values only: root comes from rev-parse, sha from a hex check.
-{ printf 'sha=%s\nroot=%s\n' "$SHA" "$ROOT" > "${SNAP_DIR}/${KEY}"; } 2>/dev/null || true
+# One `key=value` per line, and every value is newline-free: sha passes a hex check,
+# root comes from rev-parse, and a newline cannot survive the payload decode into a
+# single shell token. The post-hook reads the keys it knows and ignores the rest, so
+# adding a field does not strand an in-flight snapshot from an older version.
+{ printf 'sha=%s\nroot=%s\nintent=%s\n' "$SHA" "$ROOT" "$INTENT" > "${SNAP_DIR}/${KEY}"; } 2>/dev/null || true
 
 exit 0

--- a/scripts/commit-capture.sh
+++ b/scripts/commit-capture.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 # commit-capture.sh
-# PostToolUse command hook. Detects git commits from Bash tool output,
-# extracts metadata, and outputs it inline. Non-commit Bash calls exit silently.
+# PostToolUse command hook. Detects git commits from Bash tool calls, extracts
+# metadata, and outputs it inline. Non-commit Bash calls exit silently.
+#
+# "A commit happened" is decided by comparing HEAD against the snapshot its
+# PreToolUse sibling (commit-capture-pre.sh) took before the call ran. Reading
+# success out of the command text and the tool output could not do that job: the
+# guard list had to grow a phrase for every way git can fail, `--dry-run` had to
+# be told apart from a commit message that mentions the flag, `false && git
+# commit` still read as success, and a failed commit inherited its predecessor's
+# tip. None of that survives a HEAD comparison, so none of it is here any more.
 
 set -uo pipefail
 
@@ -14,273 +22,82 @@ case "$INPUT" in
   *) exit 0 ;;
 esac
 
-# The payload is JSON: a quote inside the command arrives as \" and a newline as
-# the two characters \n. Truncating a value at the first `"` therefore cut the
-# command short at its first quoted argument, silently dropping
-# `cd "<worktree>" && git commit` — this project's own documented workflow — and
-# `git add "a b.txt" && git commit`. Decode the string instead of slicing it.
-# Walking the string a character at a time cost ~11s on a 4 KB command, which is
-# not something a PostToolUse hook may spend. Substitute the two escapes that can
-# be confused with the closing quote for placeholders, cut at the first quote
-# that is now genuinely unescaped, then restore — all bulk expansions.
-# \uXXXX is left as written: it can never be a delimiter or a shell separator.
-json_value() {
-  local s="$1" key="$2"
-  s="${s#*"$key"}"
-  [ "$s" != "$1" ] || { printf '%s' ''; return 0; }
-  s="${s#*\"}"
-  s="${s//\\\\/$'\001'}"
-  s="${s//\\\"/$'\002'}"
-  s="${s%%\"*}"
-  s="${s//\\n/$'\n'}"
-  s="${s//\\t/$'\t'}"
-  s="${s//\\r/$'\r'}"
-  s="${s//$'\002'/\"}"
-  s="${s//$'\001'/\\}"
-  printf '%s' "$s"
-}
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB="${SCRIPT_DIR}/lib/commit-capture-parse.sh"
+if [ ! -f "$LIB" ]; then
+  printf 'obsidian-commit-capture: not captured — missing %s (reinstall the plugin)\n' "$LIB" >&2
+  exit 0
+fi
+# shellcheck source=lib/commit-capture-parse.sh
+. "$LIB"
 
-COMMAND_LINE="$(json_value "$INPUT" '"command"')"
-PAYLOAD_CWD="$(json_value "$INPUT" '"cwd"')"
-# Failure text must be judged on what the tool reported, never on the command or
-# the commit message. Matching the whole payload discarded a successful commit
-# whose subject contained `fatal:`, `error:`, or `--dry-run`.
-RESPONSE=""
-case "$INPUT" in
-  *'"tool_response"'*) RESPONSE="${INPUT#*'"tool_response"'}" ;;
-esac
+COMMAND_LINE="$(cc_json_value "$INPUT" '"command"')"
+PAYLOAD_CWD="$(cc_json_value "$INPUT" '"cwd"')"
 
-# Pull the first shell token off a string, honouring "…" and '…' so a path with
-# spaces survives. Sets TOKEN and REST.
-TOKEN=""
-REST=""
-take_token() {
-  local s="$1"
-  s="${s#"${s%%[![:space:]]*}"}"
-  case "$s" in
-    '"'*) s="${s#\"}"; TOKEN="${s%%\"*}"; REST="${s#"$TOKEN"}"; REST="${REST#\"}" ;;
-    "'"*) s="${s#\'}"; TOKEN="${s%%\'*}"; REST="${s#"$TOKEN"}"; REST="${REST#\'}" ;;
-    *)    TOKEN="${s%%[[:space:]]*}"; REST="${s#"$TOKEN"}" ;;
-  esac
-  REST="${REST#"${REST%%[![:space:]]*}"}"
-}
-
-# `git commit` must be an actual command word, not a substring. Matching the
-# substring captured `grep -rn "git commit" docs/`, `echo "run git commit"`, and
-# `git log --grep="git commit"` — each of which fires the hook and, with a recent
-# HEAD, re-captures whatever commit happened to be at the tip.
-# Split the command on shell separators and require some segment to *invoke* git
-# with the `commit` subcommand. A newline is a separator too: it arrives decoded
-# by now, and `git add -A` on one line with `git commit` on the next is the most
-# common shape there is.
-#
-# Heredoc bodies are not commands. This only became reachable once newlines were
-# decoded: `cat <<EOF` / `git commit -q` / `EOF` used to survive as one segment and
-# be rejected, and now the body line would match the gate on its own. The opening
-# line is kept, because `git commit -F - <<EOF` is a real invocation.
-strip_heredoc_bodies() {
-  local s="$1" out="" line trimmed delim="" tag
-  while IFS= read -r line; do
-    if [ -n "$delim" ]; then
-      trimmed="${line#"${line%%[![:space:]]*}"}"
-      [ "$trimmed" = "$delim" ] && delim=""
-      continue
-    fi
-    out="${out}${line}"$'\n'
-    case "$line" in
-      *'<<<'*) ;;                                   # herestring: no body follows
-      *'<<'*)
-        tag="${line#*<<}"
-        tag="${tag#-}"
-        tag="${tag#"${tag%%[![:space:]]*}"}"
-        tag="${tag%%[[:space:]]*}"
-        tag="${tag%%[;&|)]*}"
-        tag="${tag//\"/}"
-        tag="${tag//\'/}"
-        [ -n "$tag" ] && delim="$tag"
-        ;;
-    esac
-  done <<EOF
-$s
-EOF
-  printf '%s' "$out"
-}
-
-INVOKES_COMMIT=0
-GIT_C_DIR=""
-CD_TARGET=""
-SEGMENTS="$(strip_heredoc_bodies "$COMMAND_LINE")"
-SEGMENTS="${SEGMENTS//&&/$'\n'}"
-SEGMENTS="${SEGMENTS//||/$'\n'}"
-SEGMENTS="${SEGMENTS//;/$'\n'}"
-SEGMENTS="${SEGMENTS//|/$'\n'}"
-while IFS= read -r seg; do
-  seg="${seg#"${seg%%[![:space:]]*}"}"          # ltrim
-  # Shell keywords and grouping tokens sit in front of the real command word, so
-  # `if true; then git commit; fi` and `for f in a; do git commit; done` used to
-  # miss entirely.
-  while :; do
-    case "$seg" in
-      'then '*|'do '*|'else '*|'elif '*|'time '*|'exec '*|'! '*|'{ '*)
-        seg="${seg#* }" ;;
-      '('*|'{'*) seg="${seg#?}" ;;
-      *) break ;;
-    esac
-    seg="${seg#"${seg%%[![:space:]]*}"}"
-  done
-  # Leading VAR=value assignments (GIT_AUTHOR_DATE=… git commit …).
-  while :; do
-    case "$seg" in
-      [A-Za-z_]*=*)
-        assign="${seg%%=*}"
-        case "$assign" in
-          *[!A-Za-z0-9_]*) break ;;
-        esac
-        case "$seg" in
-          *' '*) seg="${seg#* }"; seg="${seg#"${seg%%[![:space:]]*}"}" ;;
-          *) break ;;
-        esac
-        ;;
-      *) break ;;
-    esac
-  done
-  take_token "$seg"
-  word="$TOKEN"
-  args="$REST"
-  # Match the basename so /usr/bin/git counts, and remember a `cd` target: it is
-  # where git actually ran.
-  case "${word##*/}" in
-    cd)
-      while :; do
-        case "$args" in
-          -*) take_token "$args"; args="$REST" ;;
-          *) break ;;
-        esac
-      done
-      take_token "$args"
-      [ -n "$TOKEN" ] && [ -z "$CD_TARGET" ] && CD_TARGET="$TOKEN"
-      continue
-      ;;
-    git) ;;
-    *) continue ;;
-  esac
-  [ -n "$args" ] || continue
-  # Skip git's global flags. `-C <dir>` is recorded, not just skipped: the gate
-  # used to parse it while resolution ignored it, so the two layers disagreed
-  # about which repository the commit landed in.
-  while :; do
-    case "$args" in
-      -C' '*|-c' '*|--git-dir' '*|--work-tree' '*|--namespace' '*|--exec-path' '*)
-        flag="${args%%[[:space:]]*}"
-        args="${args#"$flag"}"
-        args="${args#"${args%%[![:space:]]*}"}"
-        take_token "$args"
-        [ "$flag" = "-C" ] && [ -z "$GIT_C_DIR" ] && GIT_C_DIR="$TOKEN"
-        args="$REST"
-        ;;
-      -*) take_token "$args"; args="$REST" ;;
-      *) break ;;
-    esac
-    [ -n "$args" ] || break
-  done
-  case "$args" in
-    commit|commit' '*|commit$'\t'*) INVOKES_COMMIT=1; break ;;
-  esac
-done <<EOF
-$SEGMENTS
-EOF
-[ "$INVOKES_COMMIT" -eq 1 ] || exit 0
-
-# --dry-run is a flag, so look for it outside quoted text: a commit whose message
-# mentions the flag (`-m "add --dry-run flag"`) is still a real commit.
-strip_quoted() {
-  local s="$1" q="$2" out="" pre
-  while :; do
-    case "$s" in
-      *"$q"*)
-        pre="${s%%"$q"*}"
-        s="${s#*"$q"}"
-        case "$s" in
-          *"$q"*) s="${s#*"$q"}" ;;
-          *) s="" ;;                    # unbalanced: treat the tail as quoted
-        esac
-        out="${out}${pre} "
-        ;;
-      *) out="${out}${s}"; break ;;
-    esac
-  done
-  printf '%s' "$out"
-}
-UNQUOTED="$(strip_quoted "$COMMAND_LINE" '"')"
-UNQUOTED="$(strip_quoted "$UNQUOTED" "'")"
-case "$UNQUOTED" in
-  *--dry-run*)
-    exit 0
-    ;;
-esac
-
-# Failure text. The old list matched three phrases and `"error:` (which only
-# fires when stderr *starts* with it), so a rejected pre-commit hook and
-# `fatal: cannot do a partial commit during a merge` both read as success.
-case "$RESPONSE" in
-  *'nothing to commit'*|*'nothing added'*|*'no changes added'*|*'Aborting'*  |*'error:'*|*'fatal:'*|*'exited with code'*|*'hook failed'*|*'Untracked files'*)
-    exit 0
-    ;;
-esac
+cc_invokes_commit "$COMMAND_LINE" || exit 0
 
 # Which repo? The commit may have been made in a worktree via
-# `cd <worktree> && git commit`, which is this project's documented workflow.
-# Running git in the hook's own cwd read the wrong HEAD — dropping the capture
-# when the session repo was idle, or capturing the wrong commit when it wasn't.
-# A relative `cd` has to be resolved against the payload's cwd, not the hook's:
-# with a same-named directory beside the hook it captured a different
-# repository's commit outright, and filed the note under that repo's name.
-resolve_repo_dir() {
-  local d="$1"
-  [ -n "$d" ] || return 1
-  case "$d" in
-    '~') d="$HOME" ;;
-    '~/'*) d="$HOME/${d#\~/}" ;;
-  esac
-  case "$d" in
-    /*) ;;
-    *)
-      [ -n "$PAYLOAD_CWD" ] || return 1
-      d="$PAYLOAD_CWD/$d"
-      ;;
-  esac
-  [ -d "$d" ] || return 1
-  git -C "$d" rev-parse --show-toplevel >/dev/null 2>&1 || return 1
-  printf '%s' "$d"
-}
-
-REPO_DIR=""
-for cand in "$GIT_C_DIR" "$CD_TARGET" "$PAYLOAD_CWD" "$PWD"; do
-  [ -n "$cand" ] || continue
-  REPO_DIR="$(resolve_repo_dir "$cand")" && break
-  REPO_DIR=""
-done
-[ -n "$REPO_DIR" ] || exit 0
+# `cd <worktree> && git commit`, which is this project's documented workflow, so
+# the hook's own cwd is the last candidate rather than the first.
+REPO_DIR="$(cc_find_repo_dir "$PAYLOAD_CWD")" || exit 0
 GIT() { git -C "$REPO_DIR" "$@"; }
-
-# Resolved once, above the dedup gate, because the gate has to key on the
-# repository rather than on whatever cwd string this invocation happened to
-# carry — `$R`, `$R/sub` and `$R/` are one repo and produced three captures.
 REPO_ROOT=$(GIT rev-parse --show-toplevel 2>/dev/null) || REPO_ROOT=""
 [ -n "$REPO_ROOT" ] || REPO_ROOT="$REPO_DIR"
 
-# Confirm a commit actually landed, and that it is one we have not already
-# captured. The old gate required the "[branch hash]" summary line, which
-# `git commit -q` does not print, so every quiet commit was silently skipped.
-# Asking git instead needs two parts: the sha must be new (otherwise any later
-# Bash call that merely mentions `git commit` re-captures the same commit, and a
-# failed commit re-captures its predecessor), and it must be recent (otherwise a
-# first-ever mention captures unrelated history).
+# --- Did a commit actually land? ---
+
+SNAP_FILE="$(cc_state_dir)/pre-commit-head/$(cc_snapshot_key "$INPUT")"
+HEAD_BEFORE=""
+SNAP_ROOT=""
+if [ -f "$SNAP_FILE" ]; then
+  while IFS= read -r line; do
+    case "$line" in
+      sha=*) HEAD_BEFORE="${line#sha=}" ;;
+      root=*) SNAP_ROOT="${line#root=}" ;;
+    esac
+  done < "$SNAP_FILE"
+  # Consumed: one snapshot answers for exactly one invocation, so a second
+  # PostToolUse for the same call cannot re-capture the commit.
+  rm -f "$SNAP_FILE" 2>/dev/null || true
+fi
+
+# A snapshot taken against a different repository says nothing about this one.
+# Without a tool_use_id in the payload the key is only session-scoped, so two
+# concurrent commits in one session can cross — hence the recorded root. There is
+# no safe way to reuse the other repo's sha: it is unequal to this HEAD whether or
+# not anything was committed here, which is exactly the "recent tip, assume a
+# commit" inference this gate exists to remove. Discard it and say so.
+if [ -n "$SNAP_ROOT" ] && [ "$SNAP_ROOT" != "$REPO_ROOT" ]; then
+  HEAD_BEFORE=""
+fi
+
+# No usable snapshot means the PreToolUse hook did not run for this call — a
+# partial install, a hand-wired hook config carrying only the PostToolUse half, or
+# a session that predates the pre-hook. Say so instead of dropping the capture
+# silently; the message names the fix.
+if [ -z "$HEAD_BEFORE" ]; then
+  printf 'obsidian-commit-capture: not captured — no PreToolUse HEAD snapshot for this call (register scripts/commit-capture-pre.sh as a PreToolUse Bash hook, then restart the session)\n' >&2
+  exit 0
+fi
+
 FULL_SHA=$(GIT rev-parse HEAD 2>/dev/null) || exit 0
 case "$FULL_SHA" in
   *[!0-9a-f]*|'') exit 0 ;;
 esac
 
+# The whole gate: the tip moved during this call. A commit that was rejected,
+# aborted, dry-run, short-circuited by `false &&`, or found nothing to commit
+# leaves HEAD exactly where the snapshot found it.
+if [ "$HEAD_BEFORE" = "$FULL_SHA" ]; then
+  exit 0
+fi
+
+# HEAD can also move without a commit of ours landing: `git pull && git commit`
+# where the commit failed leaves the pulled tip, and so does a `git checkout` in
+# front of a failed commit. Requiring a freshly-dated tip rejects both, because
+# what arrived over the wire or was already on another branch was committed
+# earlier. This is a corroborating check, not the gate — on its own it was what
+# let a failed commit inherit its predecessor.
 COMMIT_RECENT_WINDOW="${OBSIDIAN_COMMIT_RECENT_WINDOW:-120}"
 HEAD_CT=$(GIT log -1 --format=%ct 2>/dev/null) || exit 0
 case "$HEAD_CT" in
@@ -289,20 +106,9 @@ esac
 NOW_CT=$(date +%s)
 AGE=$(( NOW_CT - HEAD_CT ))
 # A HEAD dated in the future is not evidence a commit just happened — clock skew
-# or a script-set GIT_COMMITTER_DATE would otherwise make every mention qualify
-# until real time caught up. Allow a few seconds for jitter.
+# or a script-set GIT_COMMITTER_DATE would otherwise qualify until real time
+# caught up. Allow a few seconds for jitter.
 if [ "$AGE" -lt -5 ] || [ "$AGE" -gt "$COMMIT_RECENT_WINDOW" ]; then
-  exit 0
-fi
-
-STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/claude-obsidian"
-# Keyed on a bounded digest of the repo root. Slugging the raw path both split
-# one repo across several keys and, in a deep worktree, exceeded NAME_MAX — the
-# open failed, the error went to the hook's stderr, and dedup stayed off.
-ROOT_KEY=$(printf '%s' "$REPO_ROOT" | cksum 2>/dev/null | tr -cd '0-9') || ROOT_KEY=""
-[ -n "$ROOT_KEY" ] || ROOT_KEY="unkeyed"
-SHA_FILE="${STATE_DIR}/last-capture-${ROOT_KEY}"
-if [ -f "$SHA_FILE" ] && [ "$(cat "$SHA_FILE" 2>/dev/null)" = "$FULL_SHA" ]; then
   exit 0
 fi
 
@@ -429,11 +235,10 @@ done
 # picks up the new value.
 
 VAULT_PATH=""
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CONFIG_FILE=""
 # Sourced unguarded, a partial install produced two shell errors, an empty
-# vault_path — which the skill skips silently, by contract — and a captured
-# marker already on disk, making the miss permanently unretryable.
+# vault_path — which the skill skips silently, by contract — and (before the
+# HEAD-snapshot gate) a marker on disk that made the miss unretryable.
 if [ -f "${SCRIPT_DIR}/lib/resolve-config.sh" ]; then
   . "${SCRIPT_DIR}/lib/resolve-config.sh"
   CONFIG_FILE="$(resolve_obsidian_config "${CLAUDE_PLUGIN_ROOT:-$(dirname "$SCRIPT_DIR")}")" || CONFIG_FILE=""
@@ -471,8 +276,7 @@ fi
 # --- Output metadata inline for the obsidian:commit-capture skill ---
 
 # With no vault_path the skill has nothing to write to and skips silently, so
-# emitting the record would burn the capture. Say so on stderr and leave no
-# marker, which keeps the next invocation able to retry.
+# emitting the record would burn the capture. Say so on stderr instead.
 if [ -z "$VAULT_PATH" ]; then
   printf 'obsidian-commit-capture: %s not captured — vault_path unresolved (run /obsidian:setup)\n' "$HASH" >&2
   exit 0
@@ -485,9 +289,3 @@ fi
 # every parseable field precedes anything a commit author can influence.
 printf 'obsidian-commit-capture: hash=%s | branch=%s | files=%s | org_repo=%s | repo_name=%s | ticket=%s | date=%s | time=%s | vault_path=%s | msg=%s\n' \
   "$HASH" "$BRANCH" "$FILES" "$ORG_REPO" "$REPO_NAME" "$TICKET" "$TODAY" "$NOW" "$VAULT_PATH" "$MSG"
-
-# Marker last, and brace-grouped so a failed open cannot spray the hook's stderr.
-# It is still best-effort: dedup degrading to a duplicate note is better than a
-# non-zero exit from a PostToolUse hook.
-mkdir -p "$STATE_DIR" 2>/dev/null || true
-{ printf '%s\n' "$FULL_SHA" > "$SHA_FILE"; } 2>/dev/null || true

--- a/scripts/commit-capture.sh
+++ b/scripts/commit-capture.sh
@@ -22,14 +22,27 @@ case "$INPUT" in
   *) exit 0 ;;
 esac
 
+# Diagnostics go to stdout, not stderr. A hook that exits 0 has its stdout read
+# (that is how the record below reaches the skill at all); exit-0 stderr has no
+# documented surface, so a "not captured" line written there is indistinguishable
+# from dropping the capture in silence. The skill knows that only a line starting
+# `obsidian-commit-capture: hash=` is a record.
+say() { printf 'obsidian-commit-capture: %s\n' "$1"; }
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LIB="${SCRIPT_DIR}/lib/commit-capture-parse.sh"
 if [ ! -f "$LIB" ]; then
-  printf 'obsidian-commit-capture: not captured — missing %s (reinstall the plugin)\n' "$LIB" >&2
+  say "not captured — missing ${LIB} (reinstall the plugin)"
   exit 0
 fi
+# Guarded, like the pre-hook: a truncated lib (a partial plugin update) otherwise
+# leaves every function undefined, and the gate below would swallow the resulting
+# command-not-found as an ordinary non-commit call.
 # shellcheck source=lib/commit-capture-parse.sh
-. "$LIB"
+if ! . "$LIB"; then
+  say "not captured — ${LIB} failed to load (reinstall the plugin)"
+  exit 0
+fi
 
 COMMAND_LINE="$(cc_json_value "$INPUT" '"command"')"
 PAYLOAD_CWD="$(cc_json_value "$INPUT" '"cwd"')"
@@ -49,11 +62,13 @@ REPO_ROOT=$(GIT rev-parse --show-toplevel 2>/dev/null) || REPO_ROOT=""
 SNAP_FILE="$(cc_state_dir)/pre-commit-head/$(cc_snapshot_key "$INPUT")"
 HEAD_BEFORE=""
 SNAP_ROOT=""
+SNAP_INTENT=""
 if [ -f "$SNAP_FILE" ]; then
   while IFS= read -r line; do
     case "$line" in
       sha=*) HEAD_BEFORE="${line#sha=}" ;;
       root=*) SNAP_ROOT="${line#root=}" ;;
+      intent=*) SNAP_INTENT="${line#intent=}" ;;
     esac
   done < "$SNAP_FILE"
   # Consumed: one snapshot answers for exactly one invocation, so a second
@@ -61,43 +76,101 @@ if [ -f "$SNAP_FILE" ]; then
   rm -f "$SNAP_FILE" 2>/dev/null || true
 fi
 
-# A snapshot taken against a different repository says nothing about this one.
-# Without a tool_use_id in the payload the key is only session-scoped, so two
-# concurrent commits in one session can cross — hence the recorded root. There is
-# no safe way to reuse the other repo's sha: it is unequal to this HEAD whether or
-# not anything was committed here, which is exactly the "recent tip, assume a
-# commit" inference this gate exists to remove. Discard it and say so.
-if [ -n "$SNAP_ROOT" ] && [ "$SNAP_ROOT" != "$REPO_ROOT" ]; then
-  HEAD_BEFORE=""
+# Which of the three states is this snapshot in?
+#
+#   trusted   — it recorded THIS repo's HEAD, so HEAD_BEFORE is a real before-image.
+#   blind     — it is about this repo (the command named it) but had no HEAD to read:
+#               the repo did not exist yet at pre-time. `git worktree add ../wt && cd
+#               ../wt && git commit` and `mkdir sub && cd sub && git init && git
+#               commit` are both this shape, and both are common. There is no
+#               before-image, so the fallback below has to decide.
+#   foreign   — it is about some other repo. Its sha is unequal to this HEAD whether
+#               or not anything was committed here, which is exactly the "unequal
+#               tip, assume a commit" inference this gate removes. Discard it.
+#
+# `intent` is the repo the command *named*, recorded even when it did not resolve at
+# pre-time. Without it a `cd <not-yet-a-repo>` snapshot fell back to the surrounding
+# repo, the roots then disagreed, and the real commit was discarded as foreign.
+SNAP_STATE="none"
+if [ -n "$HEAD_BEFORE" ]; then
+  if [ -n "$SNAP_ROOT" ] && [ "$SNAP_ROOT" = "$REPO_ROOT" ]; then
+    SNAP_STATE="trusted"
+  elif [ -n "$SNAP_INTENT" ]; then
+    # The intent now resolves (the call created it). Compare repo roots, not path
+    # strings: `../wt`, a symlinked /tmp, and the toplevel are the same repo.
+    INTENT_DIR="$(cc_resolve_repo_dir "$SNAP_INTENT" "$PAYLOAD_CWD")" || INTENT_DIR=""
+    if [ -n "$INTENT_DIR" ]; then
+      INTENT_ROOT=$(git -C "$INTENT_DIR" rev-parse --show-toplevel 2>/dev/null) || INTENT_ROOT=""
+      [ "$INTENT_ROOT" = "$REPO_ROOT" ] && SNAP_STATE="blind"
+    fi
+  fi
 fi
 
-# No usable snapshot means the PreToolUse hook did not run for this call — a
-# partial install, a hand-wired hook config carrying only the PostToolUse half, or
-# a session that predates the pre-hook. Say so instead of dropping the capture
-# silently; the message names the fix.
-if [ -z "$HEAD_BEFORE" ]; then
-  printf 'obsidian-commit-capture: not captured — no PreToolUse HEAD snapshot for this call (register scripts/commit-capture-pre.sh as a PreToolUse Bash hook, then restart the session)\n' >&2
-  exit 0
-fi
+case "$SNAP_STATE" in
+  none)
+    # Either the PreToolUse hook did not run for this call — a partial install, a
+    # hand-wired config carrying only the PostToolUse half, a session predating the
+    # pre-hook, or a state dir it could not write — or the snapshot it left belongs
+    # to another repository. Both are reported: dropping a commit in silence is the
+    # failure this whole mechanism exists to prevent.
+    if [ -n "$HEAD_BEFORE" ]; then
+      say "not captured — the PreToolUse snapshot for this call is about ${SNAP_ROOT:-another repository}, not ${REPO_ROOT}"
+    else
+      say "not captured — no PreToolUse HEAD snapshot for this call (register scripts/commit-capture-pre.sh as a PreToolUse Bash hook and restart the session; if it is registered, check that ${XDG_STATE_HOME:-$HOME/.local/state}/claude-obsidian is writable)"
+    fi
+    exit 0
+    ;;
+esac
 
 FULL_SHA=$(GIT rev-parse HEAD 2>/dev/null) || exit 0
 case "$FULL_SHA" in
   *[!0-9a-f]*|'') exit 0 ;;
 esac
 
-# The whole gate: the tip moved during this call. A commit that was rejected,
-# aborted, dry-run, short-circuited by `false &&`, or found nothing to commit
-# leaves HEAD exactly where the snapshot found it.
+# The gate: the tip moved during this call. A commit that was rejected, aborted,
+# dry-run, short-circuited by `false &&`, or found nothing to commit leaves HEAD
+# exactly where the snapshot found it.
 if [ "$HEAD_BEFORE" = "$FULL_SHA" ]; then
   exit 0
 fi
 
-# HEAD can also move without a commit of ours landing: `git pull && git commit`
-# where the commit failed leaves the pulled tip, and so does a `git checkout` in
-# front of a failed commit. Requiring a freshly-dated tip rejects both, because
-# what arrived over the wire or was already on another branch was committed
-# earlier. This is a corroborating check, not the gate — on its own it was what
-# let a failed commit inherit its predecessor.
+# HEAD moving is necessary but not sufficient — other operations move it too. Ask
+# git what the move was rather than guessing from the clock:
+#
+#   - `git pull && git commit` where the commit failed leaves the *pulled* tip.
+#     It is a fast-forward, so ancestry accepts it; the committer is not us, which
+#     is what rejects it.
+#   - `git checkout other && git commit` where the commit failed leaves another
+#     branch's tip, which is not a descendant of where we were.
+#   - `git reset --hard HEAD~1` leaves HEAD at the previous commit's parent.
+#
+# The wall clock used to stand in for all of this, and it was both too weak (a
+# teammate's commit pulled within the window read as ours) and too strong (it
+# discarded a commit the gate had positively observed whenever the Bash call kept
+# working for two minutes afterwards — `git commit && npm test` lost the note, with
+# no output on any stream). It is kept only for the blind case below, where there is
+# no before-image to reason from.
+if [ "$SNAP_STATE" = "trusted" ] && [ "$HEAD_BEFORE" != "none" ]; then
+  # An amend or a reset-then-commit makes the old tip a sibling, not an ancestor,
+  # so its parent is what has to be reachable.
+  if GIT merge-base --is-ancestor "$HEAD_BEFORE" "$FULL_SHA" >/dev/null 2>&1; then
+    :
+  elif GIT merge-base --is-ancestor "${HEAD_BEFORE}^" "$FULL_SHA" >/dev/null 2>&1; then
+    # …but landing exactly ON that parent is an undo, not a commit.
+    BEFORE_PARENT=$(GIT rev-parse "${HEAD_BEFORE}^" 2>/dev/null) || BEFORE_PARENT=""
+    [ "$BEFORE_PARENT" != "$FULL_SHA" ] || exit 0
+  else
+    exit 0
+  fi
+  # Whoever ran `git commit` is the committer, always — author can be overridden,
+  # committer cannot. A commit that arrived over the wire carries someone else's.
+  LOCAL_EMAIL=$(GIT config user.email 2>/dev/null) || LOCAL_EMAIL=""
+  if [ -n "$LOCAL_EMAIL" ]; then
+    HEAD_EMAIL=$(GIT log -1 --format=%ce 2>/dev/null) || HEAD_EMAIL=""
+    [ -z "$HEAD_EMAIL" ] || [ "$HEAD_EMAIL" = "$LOCAL_EMAIL" ] || exit 0
+  fi
+fi
+
 COMMIT_RECENT_WINDOW="${OBSIDIAN_COMMIT_RECENT_WINDOW:-120}"
 HEAD_CT=$(GIT log -1 --format=%ct 2>/dev/null) || exit 0
 case "$HEAD_CT" in
@@ -105,27 +178,57 @@ case "$HEAD_CT" in
 esac
 NOW_CT=$(date +%s)
 AGE=$(( NOW_CT - HEAD_CT ))
-# A HEAD dated in the future is not evidence a commit just happened — clock skew
-# or a script-set GIT_COMMITTER_DATE would otherwise qualify until real time
-# caught up. Allow a few seconds for jitter.
-if [ "$AGE" -lt -5 ] || [ "$AGE" -gt "$COMMIT_RECENT_WINDOW" ]; then
+# A HEAD dated in the future is not evidence a commit just happened — clock skew or
+# a script-set GIT_COMMITTER_DATE would otherwise qualify until real time caught up.
+# Allow a few seconds for jitter. The upper bound applies only to the blind case:
+# with no before-image, freshness is the only thing separating this repo's brand-new
+# first commit from history that was already there.
+if [ "$AGE" -lt -5 ]; then
+  exit 0
+fi
+if [ "$SNAP_STATE" = "blind" ] && [ "$AGE" -gt "$COMMIT_RECENT_WINDOW" ]; then
   exit 0
 fi
 
 # --- Extract git metadata ---
 
 HASH=$(GIT rev-parse --short HEAD 2>/dev/null) || exit 0
+
+# The record below is ` | `-delimited and the skill parses it by field name, turning
+# org_repo into a path under the vault and vault_path into a --vault argument. Any
+# field a commit author controls can therefore inject its own `org_repo=` /
+# `vault_path=` ahead of the real one, and a reader taking the first match resolves
+# the attacker's. `msg` was moved last and stripped for this reason — but a *path* is
+# author-controlled too (`|` is legal in a filename and in a refname), and `files=`
+# and `branch=` both precede the fields they could spoof. Strip all three.
+scrub_field() {
+  local s="$1"
+  s="${s//|/ }"
+  s="${s//$'\r'/ }"
+  s="${s//$'\n'/ }"
+  printf '%s' "$s"
+}
+
 MSG=$(GIT log -1 --pretty=format:'%s' 2>/dev/null) || MSG=""
-# The record below is ` | `-delimited and the skill parses it by field name,
-# turning org_repo into a path under the vault and vault_path into a --vault
-# argument. A subject containing ` | org_repo=…` injected its own fields ahead of
-# the real ones, so the delimiter cannot survive in free-form text.
-MSG="${MSG//|/ }"
-MSG="${MSG//$'\r'/ }"
-MSG="${MSG//$'\n'/ }"
+MSG="$(scrub_field "$MSG")"
 BRANCH=$(GIT rev-parse --abbrev-ref HEAD 2>/dev/null) || BRANCH="unknown"
+BRANCH="$(scrub_field "$BRANCH")"
 FILES_RAW=$(GIT diff --name-only HEAD~1..HEAD 2>/dev/null) || FILES_RAW=""
 FILES=$(printf '%s' "$FILES_RAW" | tr '\n' ',' | sed 's/,$//')
+FILES="$(scrub_field "$FILES")"
+
+# One snapshot answers for one invocation, so a call that made several commits emits
+# one record — for the tip. Name the others: a silent partial capture reads exactly
+# like a complete one.
+if [ "$SNAP_STATE" = "trusted" ] && [ "$HEAD_BEFORE" != "none" ]; then
+  EXTRA=$(GIT rev-list --count "${HEAD_BEFORE}..${FULL_SHA}" 2>/dev/null) || EXTRA=""
+  case "$EXTRA" in
+    ''|*[!0-9]*) ;;
+    *) if [ "$EXTRA" -gt 1 ]; then
+         say "partial — this call made ${EXTRA} commits; only ${HASH} is captured, skipped: $(GIT log --format=%h "${HEAD_BEFORE}..${FULL_SHA}^" 2>/dev/null | tr '\n' ' ')"
+       fi ;;
+  esac
+fi
 REMOTE=$(GIT remote get-url origin 2>/dev/null) || REMOTE="local"
 REPO_NAME=${REPO_ROOT##*/}
 : "${REPO_NAME:=unknown}"
@@ -278,7 +381,7 @@ fi
 # With no vault_path the skill has nothing to write to and skips silently, so
 # emitting the record would burn the capture. Say so on stderr instead.
 if [ -z "$VAULT_PATH" ]; then
-  printf 'obsidian-commit-capture: %s not captured — vault_path unresolved (run /obsidian:setup)\n' "$HASH" >&2
+  say "not captured — ${HASH}: vault_path unresolved (run /obsidian:setup)"
   exit 0
 fi
 

--- a/scripts/lib/commit-capture-parse.sh
+++ b/scripts/lib/commit-capture-parse.sh
@@ -211,6 +211,11 @@ cc_resolve_repo_dir() {
 # Running git in the hook's own cwd read the wrong HEAD — dropping the capture
 # when the session repo was idle, or capturing the wrong commit when it wasn't.
 # Prints the repo dir, or returns 1 when no candidate is a git repository.
+#
+# CALL ORDER: `cc_invokes_commit` must run first. It is what sets CC_GIT_C_DIR and
+# CC_CD_TARGET, the two highest-priority candidates read below; calling this alone
+# silently degrades to the payload cwd, which is a different repository whenever the
+# command changed directory.
 cc_find_repo_dir() {
   local payload_cwd="$1" cand resolved
   for cand in "$CC_GIT_C_DIR" "$CC_CD_TARGET" "$payload_cwd" "$PWD"; do
@@ -226,6 +231,21 @@ cc_state_dir() {
   printf '%s' "${XDG_STATE_HOME:-$HOME/.local/state}/claude-obsidian"
 }
 
+# Keyed on a bounded digest rather than a slug of the raw value: slugging split
+# one repo across several keys and, in a deep worktree, exceeded NAME_MAX.
+# The fallback keeps the value's own bytes (filtered to a filename-safe set, then
+# truncated) rather than a constant — a constant would quietly collapse every
+# invocation onto one key, which is the crossing failure the digest prevents.
+cc_digest() {
+  local d
+  d=$(printf '%s' "$1" | cksum 2>/dev/null | tr -cd '0-9') || d=""
+  if [ -z "$d" ]; then
+    d=$(printf '%s' "$1" | tr -cd 'A-Za-z0-9_-')
+    d="nocksum-${d:0:64}"
+  fi
+  printf '%s' "$d"
+}
+
 # Snapshot key. A Bash call carries a tool_use_id, which names *this* invocation
 # and so survives two commits running concurrently in one session. When the
 # payload has no such field, fall back to the session — the pair still lines up
@@ -239,13 +259,4 @@ cc_snapshot_key() {
   id="$(cc_json_value "$payload" '"tool_use_id"')"
   [ -n "$id" ] || id="session:$(cc_json_value "$payload" '"session_id"')"
   cc_digest "$id"
-}
-
-# Keyed on a bounded digest rather than a slug of the raw value: slugging split
-# one repo across several keys and, in a deep worktree, exceeded NAME_MAX.
-cc_digest() {
-  local d
-  d=$(printf '%s' "$1" | cksum 2>/dev/null | tr -cd '0-9') || d=""
-  [ -n "$d" ] || d="unkeyed"
-  printf '%s' "$d"
 }

--- a/scripts/lib/commit-capture-parse.sh
+++ b/scripts/lib/commit-capture-parse.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# commit-capture-parse.sh
+# Payload decoding, command inspection, and repo resolution shared by the
+# commit-capture PreToolUse and PostToolUse hooks.
+#
+# The two hooks must agree, exactly, on three answers: does this command invoke
+# `git commit`, which repository would it run in, and what key names the
+# snapshot. When the pre-hook says "no" and the post-hook says "yes", the
+# post-hook sees a missing snapshot and drops a real commit; when they disagree
+# about the repo, the snapshot compares two different HEADs. Neither divergence
+# is observable in either hook alone, so the answers live here and both source
+# them rather than each carrying its own copy.
+
+# The payload is JSON: a quote inside the command arrives as \" and a newline as
+# the two characters \n. Truncating a value at the first `"` therefore cut the
+# command short at its first quoted argument, silently dropping
+# `cd "<worktree>" && git commit` — this project's own documented workflow — and
+# `git add "a b.txt" && git commit`. Decode the string instead of slicing it.
+# Walking the string a character at a time cost ~11s on a 4 KB command, which is
+# not something a hook on every Bash call may spend. Substitute the two escapes
+# that can be confused with the closing quote for placeholders, cut at the first
+# quote that is now genuinely unescaped, then restore — all bulk expansions.
+# \uXXXX is left as written: it can never be a delimiter or a shell separator.
+cc_json_value() {
+  local s="$1" key="$2"
+  s="${s#*"$key"}"
+  [ "$s" != "$1" ] || { printf '%s' ''; return 0; }
+  s="${s#*\"}"
+  s="${s//\\\\/$'\001'}"
+  s="${s//\\\"/$'\002'}"
+  s="${s%%\"*}"
+  s="${s//\\n/$'\n'}"
+  s="${s//\\t/$'\t'}"
+  s="${s//\\r/$'\r'}"
+  s="${s//$'\002'/\"}"
+  s="${s//$'\001'/\\}"
+  printf '%s' "$s"
+}
+
+# Pull the first shell token off a string, honouring "…" and '…' so a path with
+# spaces survives. Sets CC_TOKEN and CC_REST.
+CC_TOKEN=""
+CC_REST=""
+cc_take_token() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  case "$s" in
+    '"'*) s="${s#\"}"; CC_TOKEN="${s%%\"*}"; CC_REST="${s#"$CC_TOKEN"}"; CC_REST="${CC_REST#\"}" ;;
+    "'"*) s="${s#\'}"; CC_TOKEN="${s%%\'*}"; CC_REST="${s#"$CC_TOKEN"}"; CC_REST="${CC_REST#\'}" ;;
+    *)    CC_TOKEN="${s%%[[:space:]]*}"; CC_REST="${s#"$CC_TOKEN"}" ;;
+  esac
+  CC_REST="${CC_REST#"${CC_REST%%[![:space:]]*}"}"
+}
+
+# Heredoc bodies are not commands. This only became reachable once newlines were
+# decoded: `cat <<EOF` / `git commit -q` / `EOF` used to survive as one segment and
+# be rejected, and now the body line would match the gate on its own. The opening
+# line is kept, because `git commit -F - <<EOF` is a real invocation.
+cc_strip_heredoc_bodies() {
+  local s="$1" out="" line trimmed delim="" tag
+  while IFS= read -r line; do
+    if [ -n "$delim" ]; then
+      trimmed="${line#"${line%%[![:space:]]*}"}"
+      [ "$trimmed" = "$delim" ] && delim=""
+      continue
+    fi
+    out="${out}${line}"$'\n'
+    case "$line" in
+      *'<<<'*) ;;                                   # herestring: no body follows
+      *'<<'*)
+        tag="${line#*<<}"
+        tag="${tag#-}"
+        tag="${tag#"${tag%%[![:space:]]*}"}"
+        tag="${tag%%[[:space:]]*}"
+        tag="${tag%%[;&|)]*}"
+        tag="${tag//\"/}"
+        tag="${tag//\'/}"
+        [ -n "$tag" ] && delim="$tag"
+        ;;
+    esac
+  done <<EOF
+$s
+EOF
+  printf '%s' "$out"
+}
+
+# `git commit` must be an actual command word, not a substring. Matching the
+# substring captured `grep -rn "git commit" docs/`, `echo "run git commit"`, and
+# `git log --grep="git commit"` — each of which fires the hook on a Bash call
+# that committed nothing.
+# Split the command on shell separators and require some segment to *invoke* git
+# with the `commit` subcommand. A newline is a separator too: it arrives decoded
+# by now, and `git add -A` on one line with `git commit` on the next is the most
+# common shape there is.
+#
+# Returns 0 when some segment invokes `git commit`, 1 otherwise. Sets
+# CC_GIT_C_DIR and CC_CD_TARGET to where git would have run.
+CC_GIT_C_DIR=""
+CC_CD_TARGET=""
+cc_invokes_commit() {
+  local segments seg word args assign flag found=0
+  CC_GIT_C_DIR=""
+  CC_CD_TARGET=""
+  segments="$(cc_strip_heredoc_bodies "$1")"
+  segments="${segments//&&/$'\n'}"
+  segments="${segments//||/$'\n'}"
+  segments="${segments//;/$'\n'}"
+  segments="${segments//|/$'\n'}"
+  while IFS= read -r seg; do
+    seg="${seg#"${seg%%[![:space:]]*}"}"          # ltrim
+    # Shell keywords and grouping tokens sit in front of the real command word, so
+    # `if true; then git commit; fi` and `for f in a; do git commit; done` used to
+    # miss entirely.
+    while :; do
+      case "$seg" in
+        'then '*|'do '*|'else '*|'elif '*|'time '*|'exec '*|'! '*|'{ '*)
+          seg="${seg#* }" ;;
+        '('*|'{'*) seg="${seg#?}" ;;
+        *) break ;;
+      esac
+      seg="${seg#"${seg%%[![:space:]]*}"}"
+    done
+    # Leading VAR=value assignments (GIT_AUTHOR_DATE=… git commit …).
+    while :; do
+      case "$seg" in
+        [A-Za-z_]*=*)
+          assign="${seg%%=*}"
+          case "$assign" in
+            *[!A-Za-z0-9_]*) break ;;
+          esac
+          case "$seg" in
+            *' '*) seg="${seg#* }"; seg="${seg#"${seg%%[![:space:]]*}"}" ;;
+            *) break ;;
+          esac
+          ;;
+        *) break ;;
+      esac
+    done
+    cc_take_token "$seg"
+    word="$CC_TOKEN"
+    args="$CC_REST"
+    # Match the basename so /usr/bin/git counts, and remember a `cd` target: it is
+    # where git actually ran.
+    case "${word##*/}" in
+      cd)
+        while :; do
+          case "$args" in
+            -*) cc_take_token "$args"; args="$CC_REST" ;;
+            *) break ;;
+          esac
+        done
+        cc_take_token "$args"
+        [ -n "$CC_TOKEN" ] && [ -z "$CC_CD_TARGET" ] && CC_CD_TARGET="$CC_TOKEN"
+        continue
+        ;;
+      git) ;;
+      *) continue ;;
+    esac
+    [ -n "$args" ] || continue
+    # Skip git's global flags. `-C <dir>` is recorded, not just skipped: the gate
+    # used to parse it while resolution ignored it, so the two layers disagreed
+    # about which repository the commit landed in.
+    while :; do
+      case "$args" in
+        -C' '*|-c' '*|--git-dir' '*|--work-tree' '*|--namespace' '*|--exec-path' '*)
+          flag="${args%%[[:space:]]*}"
+          args="${args#"$flag"}"
+          args="${args#"${args%%[![:space:]]*}"}"
+          cc_take_token "$args"
+          [ "$flag" = "-C" ] && [ -z "$CC_GIT_C_DIR" ] && CC_GIT_C_DIR="$CC_TOKEN"
+          args="$CC_REST"
+          ;;
+        -*) cc_take_token "$args"; args="$CC_REST" ;;
+        *) break ;;
+      esac
+      [ -n "$args" ] || break
+    done
+    case "$args" in
+      commit|commit' '*|commit$'\t'*) found=1; break ;;
+    esac
+  done <<EOF
+$segments
+EOF
+  [ "$found" -eq 1 ]
+}
+
+# A relative `cd` has to be resolved against the payload's cwd, not the hook's:
+# with a same-named directory beside the hook it captured a different
+# repository's commit outright, and filed the note under that repo's name.
+cc_resolve_repo_dir() {
+  local d="$1" payload_cwd="$2"
+  [ -n "$d" ] || return 1
+  case "$d" in
+    '~') d="$HOME" ;;
+    '~/'*) d="$HOME/${d#\~/}" ;;
+  esac
+  case "$d" in
+    /*) ;;
+    *)
+      [ -n "$payload_cwd" ] || return 1
+      d="$payload_cwd/$d"
+      ;;
+  esac
+  [ -d "$d" ] || return 1
+  git -C "$d" rev-parse --show-toplevel >/dev/null 2>&1 || return 1
+  printf '%s' "$d"
+}
+
+# Which repo? The commit may have been made in a worktree via
+# `cd <worktree> && git commit`, which is this project's documented workflow.
+# Running git in the hook's own cwd read the wrong HEAD — dropping the capture
+# when the session repo was idle, or capturing the wrong commit when it wasn't.
+# Prints the repo dir, or returns 1 when no candidate is a git repository.
+cc_find_repo_dir() {
+  local payload_cwd="$1" cand resolved
+  for cand in "$CC_GIT_C_DIR" "$CC_CD_TARGET" "$payload_cwd" "$PWD"; do
+    [ -n "$cand" ] || continue
+    resolved="$(cc_resolve_repo_dir "$cand" "$payload_cwd")" || continue
+    printf '%s' "$resolved"
+    return 0
+  done
+  return 1
+}
+
+cc_state_dir() {
+  printf '%s' "${XDG_STATE_HOME:-$HOME/.local/state}/claude-obsidian"
+}
+
+# Snapshot key. A Bash call carries a tool_use_id, which names *this* invocation
+# and so survives two commits running concurrently in one session. When the
+# payload has no such field, fall back to the session — the pair still lines up
+# for the one-at-a-time case, and the snapshot records its repo root so the
+# post-hook can tell when it got somebody else's.
+# Both are reduced to a bounded, filename-safe digest: an id with a `/` in it
+# would write outside the directory, and a long one exceeds NAME_MAX, where the
+# open fails and the whole gate silently stops working.
+cc_snapshot_key() {
+  local payload="$1" id
+  id="$(cc_json_value "$payload" '"tool_use_id"')"
+  [ -n "$id" ] || id="session:$(cc_json_value "$payload" '"session_id"')"
+  cc_digest "$id"
+}
+
+# Keyed on a bounded digest rather than a slug of the raw value: slugging split
+# one repo across several keys and, in a deep worktree, exceeded NAME_MAX.
+cc_digest() {
+  local d
+  d=$(printf '%s' "$1" | cksum 2>/dev/null | tr -cd '0-9') || d=""
+  [ -n "$d" ] || d="unkeyed"
+  printf '%s' "$d"
+}

--- a/skills/commit-capture/SKILL.md
+++ b/skills/commit-capture/SKILL.md
@@ -12,7 +12,10 @@ The value here is not commit metadata — git already has that. The value is the
 
 Detection and metadata extraction are handled by two shell hooks (zero AI cost): `scripts/commit-capture-pre.sh` records `HEAD` before a `git commit` runs, and `scripts/commit-capture.sh` captures only if `HEAD` moved. This skill is invoked when the post-hook outputs a line starting with `obsidian-commit-capture:` — all metadata is inline, no file read needed.
 
-A line beginning `obsidian-commit-capture: not captured —` is a diagnostic on stderr, not a record. Do not treat it as metadata and do not write a note for it; surface the reason if the user asks why a commit went uncaptured.
+**Only a line beginning `obsidian-commit-capture: hash=` is a record.** The hook uses the same channel for diagnostics, because a hook that exits 0 has its stdout read and nothing documented reads its stderr — a "not captured" line written there would be indistinguishable from dropping the capture in silence. Two other prefixes exist:
+
+- `obsidian-commit-capture: not captured — …` — nothing was captured, and the rest of the line says why. Do not write a note. Surface the reason if the user asks why a commit went uncaptured, or if it names a fix (an unregistered hook, an unwritable state dir, a missing `vault_path`).
+- `obsidian-commit-capture: partial — …` — a record follows, but the call made more commits than the one captured, and the line lists the shas that were skipped. Write the note for the record; mention the skipped shas only if the user is reconciling history.
 
 The actual write goes through the **keeper CLI** (`scripts/keeper append`) — the
 keeper's deterministic write primitive. The CLI creates the file on absence,

--- a/skills/commit-capture/SKILL.md
+++ b/skills/commit-capture/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: commit-capture
 description: Captures conversation context around git commits to Obsidian vault. Fires automatically via PostToolUse hook.
-version: 2.2.0
+version: 2.3.0
 ---
 
 # Commit Capture
@@ -10,7 +10,9 @@ The value here is not commit metadata — git already has that. The value is the
 
 ## Architecture
 
-Detection and metadata extraction are handled by `scripts/commit-capture.sh` (shell script, zero AI cost). This skill is invoked when the hook outputs a line starting with `obsidian-commit-capture:` — all metadata is inline, no file read needed.
+Detection and metadata extraction are handled by two shell hooks (zero AI cost): `scripts/commit-capture-pre.sh` records `HEAD` before a `git commit` runs, and `scripts/commit-capture.sh` captures only if `HEAD` moved. This skill is invoked when the post-hook outputs a line starting with `obsidian-commit-capture:` — all metadata is inline, no file read needed.
+
+A line beginning `obsidian-commit-capture: not captured —` is a diagnostic on stderr, not a record. Do not treat it as metadata and do not write a note for it; surface the reason if the user asks why a commit went uncaptured.
 
 The actual write goes through the **keeper CLI** (`scripts/keeper append`) — the
 keeper's deterministic write primitive. The CLI creates the file on absence,

--- a/tests/commit-capture-detection.sh
+++ b/tests/commit-capture-detection.sh
@@ -52,6 +52,13 @@ case "\$*" in
   "remote get-url origin") echo "${remote}" ;;
   "rev-parse --show-toplevel") echo "/tmp/mtf-builder" ;;
   "rev-parse HEAD") echo 0123456789abcdef0123456789abcdef01234567 ;;
+  # The post-hook asks git what the HEAD move was: is the snapshot's sha an
+  # ancestor, and did we commit it. Answer yes to both — these cases are about
+  # what happens once the gate has opened.
+  "merge-base --is-ancestor "*) exit 0 ;;
+  "config user.email") echo tester@example.com ;;
+  "log -1 --format=%ce") echo tester@example.com ;;
+  "rev-list --count "*) echo 1 ;;
   *) echo "unexpected git argv: \$*" >&2; exit 99 ;;
 esac
 STUB
@@ -62,7 +69,8 @@ STATE_HOME="$(mktemp -d "${TMPDIR:-/tmp}/cc-det-state-XXXXXX")"
 
 # The post-hook captures only when a PreToolUse snapshot shows HEAD moved. These
 # cases are about what happens once it has: the snapshot sha is one no HEAD can
-# equal, and the root is left empty so it is not compared.
+# equal, and the root is the one the stub reports — a sha/root pair the real
+# pre-hook could actually have written, so the fixture stays representable.
 seed_snapshot() {
   local payload="$1" key
   key="$(
@@ -70,7 +78,22 @@ seed_snapshot() {
     cc_snapshot_key "$payload"
   )"
   mkdir -p "${STATE_HOME:?}/claude-obsidian/pre-commit-head"
-  printf 'sha=%s\nroot=\n' "1111111111111111111111111111111111111111" \
+  printf 'sha=%s\nroot=/tmp/mtf-builder\nintent=\n' "1111111111111111111111111111111111111111" \
+    > "${STATE_HOME}/claude-obsidian/pre-commit-head/${key}"
+}
+
+# The other snapshot shape: the pre-hook found no repo to read (the call created it),
+# so there is no before-image and freshness is the only signal left. `intent` is a
+# directory that exists, which the stub resolves to the same toplevel the post-hook
+# sees — that is what marks the snapshot as being about *this* repo.
+seed_blind_snapshot() {
+  local payload="$1" key
+  key="$(
+    . "${ROOT_DIR}/scripts/lib/commit-capture-parse.sh"
+    cc_snapshot_key "$payload"
+  )"
+  mkdir -p "${STATE_HOME:?}/claude-obsidian/pre-commit-head"
+  printf 'sha=unresolved\nroot=\nintent=%s\n' "$PWD" \
     > "${STATE_HOME}/claude-obsidian/pre-commit-head/${key}"
 }
 
@@ -78,6 +101,13 @@ run_hook() {
   local payload="$1"
   rm -rf "${STATE_HOME:?}/claude-obsidian"
   seed_snapshot "$payload"
+  printf '%s' "$payload" | PATH="${GIT_BIN_DIR}:$PATH" XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>/dev/null || true
+}
+
+run_hook_blind() {
+  local payload="$1"
+  rm -rf "${STATE_HOME:?}/claude-obsidian"
+  seed_blind_snapshot "$payload"
   printf '%s' "$payload" | PATH="${GIT_BIN_DIR}:$PATH" XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>/dev/null || true
 }
 
@@ -109,26 +139,34 @@ case "$OUT" in
   *) fail "non-quiet commit stopped being captured"$'\n'"got: ${OUT:-<empty>}" ;;
 esac
 
-# --- 3. a stale HEAD is NOT captured -----------------------------------------
-# HEAD can move without a commit of ours landing — a `git pull` or `git checkout`
-# in front of a failed commit leaves a tip that was committed earlier. The
-# freshness check is what rejects those.
+# --- 3. with no before-image, a stale HEAD is NOT captured -------------------
+# When the repo did not exist at pre-time there is nothing to compare against, so
+# freshness is the only thing separating a brand-new first commit from history that
+# was already there. (With a real before-image the clock is not consulted: it used
+# to discard commits whose Bash call simply kept running — see the head-gate suite.)
 make_git_stub 4000 "git@github.com:nhangen/test.git"
-OUT="$(run_hook "$QUIET")"
-[ -z "$OUT" ] || fail "stale HEAD was captured; the recency window is not enforced"$'\n'"got: $OUT"
+OUT="$(run_hook_blind "$QUIET")"
+[ -z "$OUT" ] || fail "stale HEAD was captured on the blind path; the recency window is not enforced"$'\n'"got: $OUT"
 
 # --- 4. non-commit Bash calls stay silent ------------------------------------
 make_git_stub 0 "git@github.com:nhangen/test.git"
 OUT="$(run_hook '{"tool_input":{"command":"git status"},"tool_response":{"stdout":"nothing"}}')"
 [ -z "$OUT" ] || fail "non-commit command produced output: $OUT"
 
-# --- 5. recency boundary -----------------------------------------------------
+# --- 5. recency boundary (blind path) ----------------------------------------
 make_git_stub 60 "git@github.com:nhangen/test.git"
-OUT="$(printf '%s' "$QUIET" | { rm -rf "${STATE_HOME:?}/claude-obsidian"; seed_snapshot "$QUIET"; PATH="${GIT_BIN_DIR}:$PATH" XDG_STATE_HOME="$STATE_HOME" OBSIDIAN_COMMIT_RECENT_WINDOW=60 bash "$SCRIPT" 2>/dev/null; } || true)"
+OUT="$(printf '%s' "$QUIET" | { rm -rf "${STATE_HOME:?}/claude-obsidian"; seed_blind_snapshot "$QUIET"; PATH="${GIT_BIN_DIR}:$PATH" XDG_STATE_HOME="$STATE_HOME" OBSIDIAN_COMMIT_RECENT_WINDOW=60 bash "$SCRIPT" 2>/dev/null; } || true)"
 case "$OUT" in *hash=*) : ;; *) fail "AGE == window must capture"$'\n'"got: ${OUT:-<empty>}" ;; esac
 make_git_stub 61 "git@github.com:nhangen/test.git"
-OUT="$(printf '%s' "$QUIET" | { rm -rf "${STATE_HOME:?}/claude-obsidian"; seed_snapshot "$QUIET"; PATH="${GIT_BIN_DIR}:$PATH" XDG_STATE_HOME="$STATE_HOME" OBSIDIAN_COMMIT_RECENT_WINDOW=60 bash "$SCRIPT" 2>/dev/null; } || true)"
+OUT="$(printf '%s' "$QUIET" | { rm -rf "${STATE_HOME:?}/claude-obsidian"; seed_blind_snapshot "$QUIET"; PATH="${GIT_BIN_DIR}:$PATH" XDG_STATE_HOME="$STATE_HOME" OBSIDIAN_COMMIT_RECENT_WINDOW=60 bash "$SCRIPT" 2>/dev/null; } || true)"
 [ -z "$OUT" ] || fail "AGE == window+1 must skip"$'\n'"got: $OUT"
+
+# A trusted before-image is NOT subject to the clock: the same 4000s-old tip that
+# case 3 rejects is captured here, because the snapshot proves the tip moved during
+# this call. This is the `git commit && <slow thing>` loss.
+make_git_stub 4000 "git@github.com:nhangen/test.git"
+OUT="$(run_hook "$QUIET")"
+case "$OUT" in *hash=*) : ;; *) fail "the clock still vetoes a commit the snapshot observed"$'\n'"got: ${OUT:-<empty>}" ;; esac
 
 # --- 6. a FUTURE HEAD is not evidence of a fresh commit ---------------------
 make_git_stub -4000 "git@github.com:nhangen/test.git"

--- a/tests/commit-capture-detection.sh
+++ b/tests/commit-capture-detection.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Exercises scripts/commit-capture.sh's commit-detection gate and its
-# org/repo derivation.
+# Exercises scripts/commit-capture.sh's freshness check and its org/repo
+# derivation, with git stubbed so HEAD's age and the remote URL are controlled
+# exactly.
 #
 # Two regressions, both silent:
 #   1. The gate required the "[branch hash]" summary line in the tool output.
@@ -9,6 +10,10 @@
 #   2. The derivation matched SSH and github.com only, so an HTTPS GitLab remote
 #      fell through to local/<repo>. The same repo was captured under three
 #      different org_repo values and its notes landed in three folders.
+#
+# Whether a commit landed is decided by the PreToolUse HEAD snapshot, which has
+# its own suite (commit-capture-head-gate.sh). Here the snapshot is always a sha
+# no HEAD can equal, so these cases isolate what happens *after* the gate opens.
 #
 # Reverting either fix must fail this suite.
 
@@ -54,115 +59,91 @@ STUB
 }
 
 STATE_HOME="$(mktemp -d "${TMPDIR:-/tmp}/cc-det-state-XXXXXX")"
+
+# The post-hook captures only when a PreToolUse snapshot shows HEAD moved. These
+# cases are about what happens once it has: the snapshot sha is one no HEAD can
+# equal, and the root is left empty so it is not compared.
+seed_snapshot() {
+  local payload="$1" key
+  key="$(
+    . "${ROOT_DIR}/scripts/lib/commit-capture-parse.sh"
+    cc_snapshot_key "$payload"
+  )"
+  mkdir -p "${STATE_HOME:?}/claude-obsidian/pre-commit-head"
+  printf 'sha=%s\nroot=\n' "1111111111111111111111111111111111111111" \
+    > "${STATE_HOME}/claude-obsidian/pre-commit-head/${key}"
+}
+
 run_hook() {
+  local payload="$1"
   rm -rf "${STATE_HOME:?}/claude-obsidian"
-  PATH="${GIT_BIN_DIR}:$PATH" XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>/dev/null || true
+  seed_snapshot "$payload"
+  printf '%s' "$payload" | PATH="${GIT_BIN_DIR}:$PATH" XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>/dev/null || true
 }
-# Same, but keeping state between calls, to exercise the sha dedup.
-run_hook_keep_state() {
-  PATH="${GIT_BIN_DIR}:$PATH" XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>/dev/null || true
-}
+
 # Negative cases must be silent AND clean-exit, not silent-because-crashed.
 run_hook_strict() {
-  local err rc
+  local payload="$1" err rc
   err="$(mktemp)"
-  PATH="${GIT_BIN_DIR}:$PATH" XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>"$err"
+  printf '%s' "$payload" | PATH="${GIT_BIN_DIR}:$PATH" XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>"$err"
   rc=$?
   [ "$rc" -eq 0 ] || { rm -f "$err"; fail "hook exited $rc (expected 0)"; }
   [ -s "$err" ] && { local e; e="$(cat "$err")"; rm -f "$err"; fail "hook wrote to stderr: $e"; }
   rm -f "$err"
 }
 
+QUIET='{"tool_input":{"command":"cd /repo && git commit -q -F -"},"tool_response":{"stdout":""}}'
+
 # --- 1. a QUIET commit is captured (no "[branch hash]" line anywhere) ---------
 make_git_stub 0 "git@github.com:nhangen/test.git"
-OUT="$(printf '%s' '{"tool_input":{"command":"cd /repo && git commit -q -F -"},"tool_response":{"stdout":""}}' | run_hook)"
+OUT="$(run_hook "$QUIET")"
 case "$OUT" in
   *hash=abc1234*) : ;;
   *) fail "quiet commit not captured (this is the -q regression)"$'\n'"got: ${OUT:-<empty>}" ;;
 esac
 
 # --- 2. a non-quiet commit still works ---------------------------------------
-OUT="$(printf '%s' '{"tool_input":{"command":"git commit -F -"},"tool_response":{"stdout":"[dev abc1234] test commit\n 1 file changed"}}' | run_hook)"
+OUT="$(run_hook '{"tool_input":{"command":"git commit -F -"},"tool_response":{"stdout":"[dev abc1234] test commit\n 1 file changed"}}')"
 case "$OUT" in
   *hash=abc1234*) : ;;
   *) fail "non-quiet commit stopped being captured"$'\n'"got: ${OUT:-<empty>}" ;;
 esac
 
 # --- 3. a stale HEAD is NOT captured -----------------------------------------
-# A `git commit` that failed leaves an older HEAD; capturing it would attribute
-# the previous commit to this call.
+# HEAD can move without a commit of ours landing — a `git pull` or `git checkout`
+# in front of a failed commit leaves a tip that was committed earlier. The
+# freshness check is what rejects those.
 make_git_stub 4000 "git@github.com:nhangen/test.git"
-OUT="$(printf '%s' '{"tool_input":{"command":"git commit -q -F -"},"tool_response":{"stdout":""}}' | run_hook)"
+OUT="$(run_hook "$QUIET")"
 [ -z "$OUT" ] || fail "stale HEAD was captured; the recency window is not enforced"$'\n'"got: $OUT"
 
 # --- 4. non-commit Bash calls stay silent ------------------------------------
 make_git_stub 0 "git@github.com:nhangen/test.git"
-OUT="$(printf '%s' '{"tool_input":{"command":"git status"},"tool_response":{"stdout":"nothing"}}' | run_hook)"
+OUT="$(run_hook '{"tool_input":{"command":"git status"},"tool_response":{"stdout":"nothing"}}')"
 [ -z "$OUT" ] || fail "non-commit command produced output: $OUT"
 
-OUT="$(printf '%s' '{"tool_input":{"command":"git commit --dry-run"},"tool_response":{"stdout":""}}' | run_hook)"
-[ -z "$OUT" ] || fail "--dry-run was captured: $OUT"
-
-OUT="$(printf '%s' '{"tool_input":{"command":"git commit -q"},"tool_response":{"stdout":"nothing to commit, working tree clean"}}' | run_hook)"
-[ -z "$OUT" ] || fail "'nothing to commit' was captured: $OUT"
-
-
-# --- 6. a FAILING commit right after a real one must not re-capture ----------
-# The gate infers from git rather than confirming from output, so the guards and
-# the sha check together have to reject these. A recent HEAD is present in all
-# three; only the sha check / failure text stops them.
-make_git_stub 0 "git@github.com:nhangen/test.git"
-for payload in \
-  '{"tool_input":{"command":"git commit -q -F -"},"tool_response":{"stdout":"","stderr":"husky - pre-commit hook exited with code 1"}}' \
-  '{"tool_input":{"command":"git commit -q"},"tool_response":{"stdout":"","stderr":"fatal: cannot do a partial commit during a merge."}}' \
-  '{"tool_input":{"command":"git commit -q -a"},"tool_response":{"stdout":"","stderr":"error: gpg failed to sign the data"}}' ; do
-  OUT="$(printf '%s' "$payload" | run_hook)"
-  [ -z "$OUT" ] || fail "failed commit was captured"$'\n'"payload: $payload"$'\n'"got: $OUT"
-done
-
-# --- 7. merely MENTIONING git commit must not capture ------------------------
-for payload in \
-  '{"tool_input":{"command":"grep -rn \"git commit\" docs/"},"tool_response":{"stdout":"docs/x.md: run git commit"}}' \
-  '{"tool_input":{"command":"echo \"run git commit later\""},"tool_response":{"stdout":"run git commit later"}}' \
-  '{"tool_input":{"command":"git log --grep=\"git commit\""},"tool_response":{"stdout":"commit abc"}}' ; do
-  OUT="$(printf '%s' "$payload" | run_hook)"
-  [ -z "$OUT" ] || fail "a mention of git commit was captured"$'\n'"payload: $payload"$'\n'"got: $OUT"
-done
-
-# --- 8. the same commit is captured once, not twice --------------------------
-make_git_stub 0 "git@github.com:nhangen/test.git"
-rm -rf "${STATE_HOME:?}/claude-obsidian"
-FIRST="$(printf '%s' '{"tool_input":{"command":"git commit -q -F -"},"tool_response":{"stdout":""}}' | run_hook_keep_state)"
-case "$FIRST" in *hash=*) : ;; *) fail "first capture missing"$'\n'"got: ${FIRST:-<empty>}" ;; esac
-# A second REAL commit invocation on the same sha — e.g. `git commit --amend`
-# that changed nothing, or the hook firing twice for one Bash call. Only the sha
-# check can reject this; the command-word gate cannot.
-SECOND="$(printf '%s' '{"tool_input":{"command":"git commit -q --amend --no-edit"},"tool_response":{"stdout":""}}' | run_hook_keep_state)"
-[ -z "$SECOND" ] || fail "same sha captured twice (sha dedup not enforced)"$'\n'"got: $SECOND"
-
-# --- 9. recency boundary -----------------------------------------------------
-PAYLOAD='{"tool_input":{"command":"git commit -q -F -"},"tool_response":{"stdout":""}}'
+# --- 5. recency boundary -----------------------------------------------------
 make_git_stub 60 "git@github.com:nhangen/test.git"
-OUT="$(printf '%s' "$PAYLOAD" | OBSIDIAN_COMMIT_RECENT_WINDOW=60 run_hook)"
+OUT="$(printf '%s' "$QUIET" | { rm -rf "${STATE_HOME:?}/claude-obsidian"; seed_snapshot "$QUIET"; PATH="${GIT_BIN_DIR}:$PATH" XDG_STATE_HOME="$STATE_HOME" OBSIDIAN_COMMIT_RECENT_WINDOW=60 bash "$SCRIPT" 2>/dev/null; } || true)"
 case "$OUT" in *hash=*) : ;; *) fail "AGE == window must capture"$'\n'"got: ${OUT:-<empty>}" ;; esac
 make_git_stub 61 "git@github.com:nhangen/test.git"
-OUT="$(printf '%s' "$PAYLOAD" | OBSIDIAN_COMMIT_RECENT_WINDOW=60 run_hook)"
+OUT="$(printf '%s' "$QUIET" | { rm -rf "${STATE_HOME:?}/claude-obsidian"; seed_snapshot "$QUIET"; PATH="${GIT_BIN_DIR}:$PATH" XDG_STATE_HOME="$STATE_HOME" OBSIDIAN_COMMIT_RECENT_WINDOW=60 bash "$SCRIPT" 2>/dev/null; } || true)"
 [ -z "$OUT" ] || fail "AGE == window+1 must skip"$'\n'"got: $OUT"
 
-# --- 10. a FUTURE HEAD is not evidence of a fresh commit --------------------
+# --- 6. a FUTURE HEAD is not evidence of a fresh commit ---------------------
 make_git_stub -4000 "git@github.com:nhangen/test.git"
-OUT="$(printf '%s' "$PAYLOAD" | run_hook)"
+OUT="$(run_hook "$QUIET")"
 [ -z "$OUT" ] || fail "future-dated HEAD was captured (clock-skew clamp regression)"$'\n'"got: $OUT"
 
-# --- 11. negative cases exit 0 and write nothing to stderr ------------------
+# --- 7. negative cases exit 0 and write nothing to stderr -------------------
 make_git_stub 0 "git@github.com:nhangen/test.git"
-printf '%s' '{"tool_input":{"command":"git status"},"tool_response":{"stdout":"x"}}' | run_hook_strict
+run_hook_strict '{"tool_input":{"command":"git status"},"tool_response":{"stdout":"x"}}'
 
-# --- 5. org/repo derivation across remote forms ------------------------------
+# --- 8. org/repo derivation across remote forms ------------------------------
 check_org_repo() {
   local remote="$1" expect="$2" out
   make_git_stub 0 "$remote"
-  out="$(printf '%s' '{"tool_input":{"command":"git commit -q -F -"},"tool_response":{"stdout":""}}' | run_hook)"
+  out="$(run_hook "$QUIET")"
   case "$out" in
     *"org_repo=${expect} "*|*"org_repo=${expect}") : ;;
     *) fail "remote ${remote} -> expected org_repo=${expect}"$'\n'"got: ${out:-<empty>}" ;;

--- a/tests/commit-capture-head-gate.sh
+++ b/tests/commit-capture-head-gate.sh
@@ -24,6 +24,7 @@ fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 cleanup() {
   [ -n "$WORK" ] && rm -rf "$WORK"
   [ -n "$STATE_HOME" ] && rm -rf "$STATE_HOME"
+  [ -n "${ISOLATED_XDG:-}" ] && rm -rf "$ISOLATED_XDG"
   return 0
 }
 trap cleanup EXIT
@@ -31,6 +32,17 @@ trap cleanup EXIT
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/cc-gate-XXXXXX")"
 STATE_HOME="$(mktemp -d "${TMPDIR:-/tmp}/cc-gate-state-XXXXXX")"
 SNAP_DIR="${STATE_HOME}/claude-obsidian/pre-commit-head"
+
+# The hook resolves its config through $OBSIDIAN_LOCAL_MD, then the XDG path, then
+# the plugin dir. Left alone, every positive assertion here would depend on the
+# developer having a real vault configured — the suite passed on this machine and
+# failed on a fresh clone. Point config resolution at the plugin's own example and
+# a scratch XDG home, the same isolation commit-capture-vault-path.sh uses.
+ISOLATED_XDG="$(mktemp -d "${TMPDIR:-/tmp}/cc-gate-xdg-XXXXXX")"
+export XDG_CONFIG_HOME="$ISOLATED_XDG"
+mkdir -p "${ISOLATED_XDG}/claude-obsidian"
+printf -- '---\nvault_path: %s/vault\n---\n' "$WORK" > "${ISOLATED_XDG}/claude-obsidian/obsidian.local.md"
+unset OBSIDIAN_LOCAL_MD
 
 mkrepo() {
   local dir="$1" remote="${2:-git@github.com:nhangen/gate.git}"
@@ -119,23 +131,26 @@ for cmd in \
 done
 
 # --- 3. failure phrases no longer suppress a real capture -------------------
-# A commit subject or tool output containing `fatal:`, `error:`, or
-# `Untracked files:` used to be read as a failed commit and dropped.
+# The retired guard read the tool *response*, and a subject supplied via `-F -`
+# never reaches the payload at all — so a row whose only guard word is in the
+# subject cannot fail however the hook behaves. Put the word where the old code
+# looked: in the response, or in the command via `-m`.
 for pair in \
-  'fix: swallow fatal: on rebase|' \
-  'chore: nothing to commit yet|' \
-  'feat: add --dry-run flag|Untracked files:' \
-  'fix: error: prefix|nothing to commit, working tree clean' ; do
-  subject="${pair%%|*}"
+  'git commit -q -m "fix: swallow fatal: on rebase"|' \
+  'git commit -q -m "chore: explain nothing to commit"|' \
+  'git commit -q -F -|Untracked files:' \
+  'git commit -q -F -|nothing to commit, working tree clean' \
+  'git commit -q -F -|fatal: cannot do a partial commit during a merge' ; do
+  cmd="${pair%%|*}"
   resp="${pair#*|}"
   reset_state
-  P="$(payload 'git commit -q -F -' "$REPO" call-3 "$resp")"
+  P="$(payload "$cmd" "$REPO" call-3 "$resp")"
   run_pre "$P"
-  commit_in "$REPO" "$subject"
+  commit_in "$REPO" "work $RANDOM"
   run_post_verbose "$P"
   case "$POST_OUT" in
     *hash=*) : ;;
-    *) fail "a real commit was dropped over failure text (subject: $subject / response: $resp)"$'\n'"got: ${POST_OUT:-<empty>}" ;;
+    *) fail "a real commit was dropped over failure text (command: $cmd / response: $resp)"$'\n'"got: ${POST_OUT:-<empty>}" ;;
   esac
 done
 
@@ -146,10 +161,12 @@ reset_state
 P="$(payload 'git commit -q -m x' "$REPO" call-4)"
 commit_in "$REPO" "unsnapshotted work"
 run_post_verbose "$P"
-[ -z "$POST_OUT" ] || fail "captured with no snapshot; the gate is not being enforced"$'\n'"got: $POST_OUT"
-case "$POST_ERR" in
+case "$POST_OUT" in
+  *hash=*) fail "captured with no snapshot; the gate is not being enforced"$'\n'"got: $POST_OUT" ;;
+esac
+case "$POST_OUT" in
   *PreToolUse*) : ;;
-  *) fail "a missing snapshot was not reported on stderr"$'\n'"got: ${POST_ERR:-<empty>}" ;;
+  *) fail "a missing snapshot was not reported"$'\n'"got: ${POST_OUT:-<empty>}" ;;
 esac
 
 # --- 5. a snapshot answers for one invocation only --------------------------
@@ -160,7 +177,9 @@ commit_in "$REPO" "once only"
 run_post_verbose "$P"
 case "$POST_OUT" in *hash=*) : ;; *) fail "first capture missing"$'\n'"got: ${POST_OUT:-<empty>}" ;; esac
 run_post_verbose "$P"
-[ -z "$POST_OUT" ] || fail "the same commit was captured twice (snapshot not consumed)"$'\n'"got: $POST_OUT"
+case "$POST_OUT" in
+  *hash=*) fail "the same commit was captured twice (snapshot not consumed)"$'\n'"got: $POST_OUT" ;;
+esac
 
 # --- 6. the first commit in a repo with no history is captured --------------
 # HEAD is unborn before the call, so there is no sha to compare — `none` still
@@ -209,10 +228,14 @@ OTHER_P="$(payload 'git commit -q -m x' "$REPO")"
 run_pre "$OTHER_P"                       # snapshot belongs to $REPO
 MINE_P="$(payload 'git commit -q -m x' "$SIBLING")"
 run_post_verbose "$MINE_P"               # same session key, different repo
-[ -z "$POST_OUT" ] || fail "a snapshot from another repository was accepted as evidence"$'\n'"got: $POST_OUT"
-case "$POST_ERR" in
-  *PreToolUse*) : ;;
-  *) fail "discarding a foreign snapshot was not reported on stderr"$'\n'"got: ${POST_ERR:-<empty>}" ;;
+case "$POST_OUT" in
+  *hash=*) fail "a snapshot from another repository was accepted as evidence"$'\n'"got: $POST_OUT" ;;
+esac
+# The two rejections have to be distinguishable: "register the hook" is misleading
+# advice when the hook ran and the snapshot simply belongs to another repo.
+case "$POST_OUT" in
+  *'is about'*) : ;;
+  *) fail "discarding a foreign snapshot was not reported, or reused the missing-snapshot message"$'\n'"got: ${POST_OUT:-<empty>}" ;;
 esac
 
 # --- 9. the pre-hook is silent, exits 0, and only snapshots commit calls -----
@@ -233,9 +256,21 @@ done
 # Malformed and hostile payloads must not fail the tool call either.
 for bad in '' 'not json at all' '{"tool_input":{"command":"git commit -q -m x"}}' \
            '{"cwd":"/nonexistent/nope","tool_input":{"command":"cd /nonexistent/nope && git commit"}}' ; do
-  printf '%s' "$bad" | XDG_STATE_HOME="$STATE_HOME" bash "$PRE" >/dev/null 2>&1 \
+  # From $WORK, like every other case: run from the checkout and the `$PWD`
+  # fallback resolves the plugin repo, so the payload under test is not the thing
+  # being exercised.
+  ( cd "$WORK" && printf '%s' "$bad" | XDG_STATE_HOME="$STATE_HOME" bash "$PRE" >/dev/null 2>&1 ) \
     || fail "pre-hook exited non-zero on payload: ${bad:-<empty>}"
 done
+
+# --- 9b. a snapshot about no repository at all is not written ----------------
+# `sha=unresolved` with no root and no named directory matched every repo and no
+# HEAD: the post-hook could only fall back to "the tip looks recent, assume a
+# commit", which is the inference this gate replaces. There is nothing to record.
+reset_state
+run_pre "$(payload 'git commit -q -m x' "$WORK" call-9b)"
+[ ! -d "$SNAP_DIR" ] || [ -z "$(ls -A "$SNAP_DIR" 2>/dev/null)" ] \
+  || fail "a snapshot was written for a call with no resolvable and no named repository"$'\n'"got: $(cat "$SNAP_DIR"/* 2>/dev/null)"
 
 # --- 10. abandoned snapshots are swept -------------------------------------
 # One is left behind whenever the tool call never completes (denied, interrupted,
@@ -272,7 +307,9 @@ run_post_verbose "$PB"
 # writes outside the snapshot directory and a long one exceeds NAME_MAX — where
 # the open fails and the whole gate silently stops working.
 reset_state
-ESCAPE_MARK="$WORK/escaped-write"
+# `../../` from the snapshot dir lands in $STATE_HOME, not $WORK — the assertion has
+# to watch the directory the escape can actually reach, or it can never fire.
+ESCAPE_MARK="$STATE_HOME/escaped-write"
 LONG_ID="$(printf 'i%.0s' $(seq 1 400))"
 for id in "../../$(basename "$ESCAPE_MARK")" "$LONG_ID" ; do
   reset_state
@@ -288,6 +325,188 @@ for id in "../../$(basename "$ESCAPE_MARK")" "$LONG_ID" ; do
     *) fail "a commit was dropped because the snapshot key came from a hostile id"$'\n'"got: ${POST_OUT:-<empty>}"$'\n'"stderr: $POST_ERR" ;;
   esac
 done
+
+# --- 13. a repo that did not exist at pre-time is still captured -------------
+# `git worktree add ../wt && cd ../wt && git commit` is this project's documented
+# workflow, and `mkdir sub && cd sub && git init && git commit` is the same shape.
+# The pre-hook cannot read a HEAD that isn't there yet, and resolution falls through
+# to the SURROUNDING repo — so matching on the resolved root alone discarded the real
+# commit as belonging to another repository. master captured both of these.
+reset_state
+OUTER="$WORK/outer"
+mkrepo "$OUTER" "git@github.com:nhangen/outer.git"
+commit_in "$OUTER" "outer seed"
+P="$(payload "git worktree add ../outer-wt -b feat && cd ../outer-wt && git commit -q -m x" "$OUTER" call-13a)"
+run_pre "$P"
+git -C "$OUTER" worktree add -q "$WORK/outer-wt" -b feat
+commit_in "$WORK/outer-wt" "worktree commit"
+run_post_verbose "$P"
+case "$POST_OUT" in
+  *hash=*) : ;;
+  *) fail "a commit in a worktree created during the call was dropped"$'\n'"got: ${POST_OUT:-<empty>}"$'\n'"stderr: $POST_ERR"$'\n'"stdout-err: $POST_OUT" ;;
+esac
+
+reset_state
+P="$(payload "mkdir -p sub && cd sub && git init -q && git commit -q -m x" "$OUTER" call-13b)"
+run_pre "$P"
+mkrepo "$OUTER/sub" "git@github.com:nhangen/inner.git"
+commit_in "$OUTER/sub" "inner first commit"
+run_post_verbose "$P"
+case "$POST_OUT" in
+  *"org_repo=nhangen/inner"*) : ;;
+  *) fail "a repo initialised inside another during the call was dropped or misattributed"$'\n'"got: ${POST_OUT:-<empty>}" ;;
+esac
+
+# --- 14. a commit that arrived over the wire is not ours ---------------------
+# `git pull && git commit` where the commit fails leaves the PULLED tip. It is a
+# fast-forward, so the tip moved and ancestry accepts it; only the committer
+# identity separates it from a commit we made. The old wall-clock check passed it
+# whenever the teammate's commit was less than two minutes old.
+reset_state
+UP="$WORK/upstream.git"
+git init -q --bare "$UP"
+THEIRS="$WORK/theirs"
+mkrepo "$THEIRS" "$UP"
+git -C "$THEIRS" config user.email teammate@example.com
+git -C "$THEIRS" config user.name Teammate
+# A shared base first: without it the teammate's commit is the root commit, the
+# clone already has it, the pull moves nothing, and the case proves nothing about
+# the committer check because the HEAD gate rejects it first.
+commit_in "$THEIRS" "shared base"
+git -C "$THEIRS" push -q origin HEAD:refs/heads/main
+
+MINE="$WORK/mine"
+git clone -q "$UP" "$MINE"
+git -C "$MINE" config core.hooksPath /dev/null
+git -C "$MINE" config commit.gpgsign false
+git -C "$MINE" config user.email me@example.com
+git -C "$MINE" config user.name Me
+
+commit_in "$THEIRS" "teammate work"
+git -C "$THEIRS" push -q origin HEAD:refs/heads/main
+
+BEFORE_PULL="$(git -C "$MINE" rev-parse HEAD)"
+P="$(payload 'git pull && git commit -q -m mine' "$MINE" call-14)"
+run_pre "$P"
+git -C "$MINE" pull -q --ff-only origin main
+git -C "$MINE" remote set-url origin "git@github.com:nhangen/mine.git"
+[ "$(git -C "$MINE" rev-parse HEAD)" != "$BEFORE_PULL" ] \
+  || fail "case 14 fixture did not fast-forward; the case cannot exercise the committer check"
+run_post_verbose "$P"
+case "$POST_OUT" in
+  *"msg=teammate work"*) fail "a pulled commit was captured as ours — the exact failure #60 names"$'\n'"got: $POST_OUT" ;;
+  *hash=*) fail "something was captured for a call that committed nothing"$'\n'"got: $POST_OUT" ;;
+esac
+
+# --- 15. a slow call does not lose the commit it made -----------------------
+# PostToolUse fires when the whole Bash call finishes, not when `git commit`
+# returns. `git commit && npm test` outlived the 120s recency window and the note
+# was discarded — a commit the gate had positively observed, dropped in silence.
+reset_state
+P="$(payload 'git commit -q -m x && sleep 300' "$REPO" call-15)"
+run_pre "$P"
+commit_in "$REPO" "committed then a long test run"
+# The tip has to be OLDER than the window for this to mean anything — with a
+# one-second window and a commit made in the same second, the old code passed too.
+sleep 2
+POST_OUT=""
+POST_ERR=""
+err="$(mktemp)"
+POST_OUT="$( cd "$WORK" && printf '%s' "$P" | XDG_STATE_HOME="$STATE_HOME" OBSIDIAN_COMMIT_RECENT_WINDOW=1 bash "$POST" 2>"$err" )" || fail "post-hook exited non-zero"
+POST_ERR="$(cat "$err")"; rm -f "$err"
+case "$POST_OUT" in
+  *hash=*) : ;;
+  *) fail "the wall clock discarded a commit the HEAD gate observed"$'\n'"got: ${POST_OUT:-<empty>}" ;;
+esac
+
+# --- 16. an undo is not a commit --------------------------------------------
+# `git reset --hard HEAD~1` moves HEAD without committing, and it lands exactly on
+# the previous tip's parent — which ancestry alone accepts.
+reset_state
+P="$(payload 'git reset --hard HEAD~1 && git commit -q -m x' "$REPO" call-16)"
+run_pre "$P"
+git -C "$REPO" reset -q --hard HEAD~1
+run_post_verbose "$P"
+[ -z "$POST_OUT" ] || fail "a reset was captured as a commit"$'\n'"got: $POST_OUT"
+
+# --- 17. every "not captured" line is on the channel the skill reads --------
+# stdout is what a hook exiting 0 surfaces, and what the record itself uses. On
+# stderr these diagnostics were indistinguishable from silence.
+reset_state
+P="$(payload 'git commit -q -m x' "$REPO" call-17)"
+commit_in "$REPO" "unsnapshotted"
+run_post_verbose "$P"
+case "$POST_OUT" in
+  *'not captured'*) : ;;
+  *) fail "the no-snapshot diagnostic is not on stdout"$'\n'"stdout: ${POST_OUT:-<empty>}"$'\n'"stderr: ${POST_ERR:-<empty>}" ;;
+esac
+[ -z "$POST_ERR" ] || fail "diagnostics still going to stderr: $POST_ERR"
+case "$POST_OUT" in
+  *'hash='*) fail "a diagnostic was emitted in record form; the skill would file a note for it"$'\n'"got: $POST_OUT" ;;
+esac
+
+# --- 18. a call that made several commits says so ---------------------------
+reset_state
+P="$(payload 'git commit -q -m one && git commit -q -m two' "$REPO" call-18)"
+run_pre "$P"
+commit_in "$REPO" "commit one"
+commit_in "$REPO" "commit two"
+run_post_verbose "$P"
+case "$POST_OUT" in
+  *'partial —'*) : ;;
+  *) fail "two commits in one call captured one and said nothing about the other"$'\n'"got: ${POST_OUT:-<empty>}" ;;
+esac
+case "$POST_OUT" in
+  *'msg=commit two'*) : ;;
+  *) fail "the tip commit was not the one captured"$'\n'"got: $POST_OUT" ;;
+esac
+
+# --- 19. a path or branch cannot inject a field ahead of a real one ---------
+# `|` is legal in a filename and in a refname, and files=/branch= both precede
+# org_repo= and vault_path= in a record the skill parses first-match.
+reset_state
+INJ="$WORK/inject-path"
+mkrepo "$INJ" "git@github.com:nhangen/injpath.git"
+commit_in "$INJ" "seed"
+# No `/` — that would make it a nested path rather than one filename, which is why
+# an earlier attempt at this case could not create the fixture at all. A single
+# component is enough: the record is delimiter-separated, not path-separated.
+BAD_FILE='a | org_repo=EVIL | vault_path=EVILVAULT | b.txt'
+if : > "$INJ/$BAD_FILE" 2>/dev/null; then
+  git -C "$INJ" add -A
+  git -C "$INJ" commit -q -m "add a piped path"
+  P="$(payload 'git commit -q -m x' "$INJ" call-19)"
+  # Snapshot the tip's parent so the commit above reads as landing during the call.
+  mkdir -p "$SNAP_DIR"
+  printf 'sha=%s\nroot=%s\nintent=\n' "$(git -C "$INJ" rev-parse HEAD~1)" "$(git -C "$INJ" rev-parse --show-toplevel)" \
+    > "${SNAP_DIR}/$( . "${ROOT_DIR}/scripts/lib/commit-capture-parse.sh"; cc_snapshot_key "$P" )"
+  run_post_verbose "$P"
+  case "$POST_OUT" in
+    *hash=*) : ;;
+    *) fail "the injection fixture was not captured at all"$'\n'"got: ${POST_OUT:-<empty>}" ;;
+  esac
+  # The invariant is that the FIRST occurrence of each field is the real one, so a
+  # reader taking the first match cannot be steered. The injected text may survive
+  # as text — it just cannot survive as a *field*, which means its delimiters are
+  # gone.
+  first_field() {
+    printf '%s' "$1" | tr '|' '\n' | while IFS= read -r seg; do
+      seg="${seg#"${seg%%[![:space:]]*}"}"
+      case "$seg" in
+        "$2="*) printf '%s' "${seg#"$2"=}"; return 0 ;;
+      esac
+    done
+  }
+  GOT="$(first_field "$POST_OUT" org_repo)"
+  [ "${GOT% }" = "nhangen/injpath" ] || fail "a path steered the first org_repo field: '$GOT'"$'\n'"got: $POST_OUT"
+  GOT="$(first_field "$POST_OUT" vault_path)"
+  case "${GOT% }" in
+    EVILVAULT) fail "a path steered the first vault_path field"$'\n'"got: $POST_OUT" ;;
+    '') fail "no vault_path field in the record"$'\n'"got: $POST_OUT" ;;
+  esac
+else
+  printf 'skip commit-capture-head-gate.sh case 19: filesystem refused a path containing |\n' >&2
+fi
 
 # --- wiring: both halves are registered on Bash ------------------------------
 # The pair is one mechanism. Shipping the post-hook without the pre-hook turns

--- a/tests/commit-capture-head-gate.sh
+++ b/tests/commit-capture-head-gate.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+# Exercises the PreToolUse/PostToolUse pair that decides whether a commit landed.
+#
+# The old post-hook inferred it from the command text plus a tip that was recent
+# and not yet seen. Nothing tied HEAD to the invocation being observed, so after
+# any dropped capture a *failed* commit picked up its predecessor and filed it
+# with the hook's clock instead of the commit's. `false && git commit` reproduced
+# that end to end during the PR #48 review.
+#
+# The pair below observes the thing that matters: HEAD before the call, HEAD
+# after. Real git repositories throughout — a stub cannot make a commit land.
+#
+# Every case was verified to fail against the text-guard version.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POST="${ROOT_DIR}/scripts/commit-capture.sh"
+PRE="${ROOT_DIR}/scripts/commit-capture-pre.sh"
+
+WORK=""
+STATE_HOME=""
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+cleanup() {
+  [ -n "$WORK" ] && rm -rf "$WORK"
+  [ -n "$STATE_HOME" ] && rm -rf "$STATE_HOME"
+  return 0
+}
+trap cleanup EXIT
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/cc-gate-XXXXXX")"
+STATE_HOME="$(mktemp -d "${TMPDIR:-/tmp}/cc-gate-state-XXXXXX")"
+SNAP_DIR="${STATE_HOME}/claude-obsidian/pre-commit-head"
+
+mkrepo() {
+  local dir="$1" remote="${2:-git@github.com:nhangen/gate.git}"
+  mkdir -p "$dir"
+  git -C "$dir" init -q
+  # Fixtures must not run the developer's global hooks (an identity gate lives
+  # there and would block every seed commit).
+  git -C "$dir" config core.hooksPath /dev/null
+  git -C "$dir" config commit.gpgsign false
+  git -C "$dir" config user.email t@example.com
+  git -C "$dir" config user.name Tester
+  git -C "$dir" remote add origin "$remote"
+}
+
+commit_in() {
+  local dir="$1" subject="$2" file
+  file="f$RANDOM.txt"
+  : > "$dir/$file"
+  git -C "$dir" add "$file"
+  git -C "$dir" commit -q -m "$subject"
+}
+
+# $1 = command, $2 = cwd, $3 = tool_use_id (optional), $4 = response text
+payload() {
+  local cmd="$1" cwd="${2:-}" id="${3:-}" resp="${4:-}" esc="$1"
+  esc="${esc//\\/\\\\}"
+  esc="${esc//\"/\\\"}"
+  esc="${esc//$'\n'/\\n}"
+  printf '{'
+  [ -n "$id" ] && printf '"tool_use_id":"%s",' "$id"
+  [ -n "$cwd" ] && printf '"cwd":"%s",' "$cwd"
+  printf '"session_id":"sess-1","tool_input":{"command":"%s"},"tool_response":{"stdout":"%s"}}' "$esc" "$resp"
+}
+
+# Both hooks run from a directory that is NOT a repository, so the last-resort
+# `$PWD` candidate never resolves and a case that means to exercise "no repo
+# here" cannot accidentally pick up the checkout the suite runs in.
+run_pre() {
+  local rc=0
+  ( cd "$WORK" && printf '%s' "$1" | XDG_STATE_HOME="$STATE_HOME" bash "$PRE" ) || rc=$?
+  [ "$rc" -eq 0 ] || fail "pre-hook exited $rc — a non-zero PreToolUse hook blocks the Bash call"
+}
+# Post with stderr captured; sets POST_OUT and POST_ERR.
+run_post_verbose() {
+  local err rc=0
+  err="$(mktemp)"
+  POST_OUT="$( cd "$WORK" && printf '%s' "$1" | XDG_STATE_HOME="$STATE_HOME" bash "$POST" 2>"$err" )" || rc=$?
+  POST_ERR="$(cat "$err")"
+  rm -f "$err"
+  [ "$rc" -eq 0 ] || fail "post-hook exited $rc (expected 0)"
+}
+
+reset_state() { rm -rf "${STATE_HOME:?}/claude-obsidian"; }
+
+REPO="$WORK/repo"
+mkrepo "$REPO" "https://gitlab.com/altamira2/mtf-builder.git"
+commit_in "$REPO" "seed commit"
+
+# --- 1. a commit that lands between pre and post is captured -----------------
+reset_state
+P="$(payload 'git commit -q -m x' "$REPO" call-1)"
+run_pre "$P"
+commit_in "$REPO" "real work"
+run_post_verbose "$P"
+case "$POST_OUT" in
+  *"org_repo=altamira2/mtf-builder"*) : ;;
+  *) fail "a commit that landed during the call was not captured"$'\n'"got: ${POST_OUT:-<empty>}"$'\n'"stderr: $POST_ERR" ;;
+esac
+[ -z "$POST_ERR" ] || fail "a successful capture wrote to stderr: $POST_ERR"
+
+# --- 2. HEAD unchanged means nothing landed, whatever the text says ----------
+# Each of these fired a real `git commit` that committed nothing, or none at all.
+# The text guards needed a phrase per failure mode; `false && git commit` had no
+# phrase at all and read as success.
+for cmd in \
+  'git commit -q -m x' \
+  'false && git commit -q -m x' \
+  'git commit --dry-run' \
+  'git commit -q -m "add --dry-run flag"' ; do
+  reset_state
+  P="$(payload "$cmd" "$REPO" call-2)"
+  run_pre "$P"
+  run_post_verbose "$P"
+  [ -z "$POST_OUT" ] || fail "HEAD did not move but the call was captured: $cmd"$'\n'"got: $POST_OUT"
+  [ -z "$POST_ERR" ] || fail "a legitimate no-capture wrote to stderr: $cmd"$'\n'"got: $POST_ERR"
+done
+
+# --- 3. failure phrases no longer suppress a real capture -------------------
+# A commit subject or tool output containing `fatal:`, `error:`, or
+# `Untracked files:` used to be read as a failed commit and dropped.
+for pair in \
+  'fix: swallow fatal: on rebase|' \
+  'chore: nothing to commit yet|' \
+  'feat: add --dry-run flag|Untracked files:' \
+  'fix: error: prefix|nothing to commit, working tree clean' ; do
+  subject="${pair%%|*}"
+  resp="${pair#*|}"
+  reset_state
+  P="$(payload 'git commit -q -F -' "$REPO" call-3 "$resp")"
+  run_pre "$P"
+  commit_in "$REPO" "$subject"
+  run_post_verbose "$P"
+  case "$POST_OUT" in
+    *hash=*) : ;;
+    *) fail "a real commit was dropped over failure text (subject: $subject / response: $resp)"$'\n'"got: ${POST_OUT:-<empty>}" ;;
+  esac
+done
+
+# --- 4. no snapshot is reported, not silently dropped -----------------------
+# A hand-wired hook config carrying only the PostToolUse half would otherwise
+# stop capturing with no visible cause.
+reset_state
+P="$(payload 'git commit -q -m x' "$REPO" call-4)"
+commit_in "$REPO" "unsnapshotted work"
+run_post_verbose "$P"
+[ -z "$POST_OUT" ] || fail "captured with no snapshot; the gate is not being enforced"$'\n'"got: $POST_OUT"
+case "$POST_ERR" in
+  *PreToolUse*) : ;;
+  *) fail "a missing snapshot was not reported on stderr"$'\n'"got: ${POST_ERR:-<empty>}" ;;
+esac
+
+# --- 5. a snapshot answers for one invocation only --------------------------
+reset_state
+P="$(payload 'git commit -q -m x' "$REPO" call-5)"
+run_pre "$P"
+commit_in "$REPO" "once only"
+run_post_verbose "$P"
+case "$POST_OUT" in *hash=*) : ;; *) fail "first capture missing"$'\n'"got: ${POST_OUT:-<empty>}" ;; esac
+run_post_verbose "$P"
+[ -z "$POST_OUT" ] || fail "the same commit was captured twice (snapshot not consumed)"$'\n'"got: $POST_OUT"
+
+# --- 6. the first commit in a repo with no history is captured --------------
+# HEAD is unborn before the call, so there is no sha to compare — `none` still
+# differs from whatever the commit produces.
+reset_state
+FRESH="$WORK/fresh"
+mkrepo "$FRESH" "git@github.com:nhangen/fresh.git"
+P="$(payload 'git commit -q -m first' "$FRESH" call-6)"
+run_pre "$P"
+grep -q '^sha=none$' "$SNAP_DIR"/* || fail "an unborn HEAD was not recorded as 'none'"$'\n'"got: $(cat "$SNAP_DIR"/*)"
+commit_in "$FRESH" "first commit"
+run_post_verbose "$P"
+case "$POST_OUT" in
+  *"org_repo=nhangen/fresh"*) : ;;
+  *) fail "a repo's first commit was not captured"$'\n'"got: ${POST_OUT:-<empty>}"$'\n'"stderr: $POST_ERR" ;;
+esac
+
+# --- 7. a repo that does not exist yet is recorded as unresolved ------------
+# `mkdir x && cd x && git init && git commit` is a real shape: the pre-hook has
+# no repo to read. The post-hook then has no prior HEAD and falls back to
+# requiring a freshly-dated tip, which a brand-new commit satisfies.
+reset_state
+LATE="$WORK/late"
+P="$(payload "mkdir -p $LATE && cd $LATE && git init -q && git commit -q -m x" "$WORK" call-7)"
+run_pre "$P"
+grep -q '^sha=unresolved$' "$SNAP_DIR"/* || fail "an unresolvable repo was not recorded as 'unresolved'"$'\n'"got: $(cat "$SNAP_DIR"/*)"
+mkrepo "$LATE" "git@github.com:nhangen/late.git"
+commit_in "$LATE" "late init"
+run_post_verbose "$P"
+case "$POST_OUT" in
+  *"org_repo=nhangen/late"*) : ;;
+  *) fail "a repo created during the call was not captured"$'\n'"got: ${POST_OUT:-<empty>}"$'\n'"stderr: $POST_ERR" ;;
+esac
+
+# --- 8. a snapshot from another repository is not evidence about this one ----
+# Without a tool_use_id the key is session-scoped, so two concurrent commits in
+# one session can cross. The other repo's sha is unequal to this HEAD whether or
+# not anything was committed here, so reusing it is the "recent tip, assume a
+# commit" inference this gate removes. This repo's tip is deliberately FRESH:
+# only the recorded root can reject it, the freshness check cannot.
+reset_state
+SIBLING="$WORK/sibling"
+mkrepo "$SIBLING" "git@github.com:nhangen/sibling.git"
+commit_in "$SIBLING" "fresh tip, committed before the call"
+OTHER_P="$(payload 'git commit -q -m x' "$REPO")"
+run_pre "$OTHER_P"                       # snapshot belongs to $REPO
+MINE_P="$(payload 'git commit -q -m x' "$SIBLING")"
+run_post_verbose "$MINE_P"               # same session key, different repo
+[ -z "$POST_OUT" ] || fail "a snapshot from another repository was accepted as evidence"$'\n'"got: $POST_OUT"
+case "$POST_ERR" in
+  *PreToolUse*) : ;;
+  *) fail "discarding a foreign snapshot was not reported on stderr"$'\n'"got: ${POST_ERR:-<empty>}" ;;
+esac
+
+# --- 9. the pre-hook is silent, exits 0, and only snapshots commit calls -----
+reset_state
+for cmd in 'git status' 'echo "git commit"' 'grep -rn commit .' ; do
+  P="$(payload "$cmd" "$REPO" "call-9")"
+  ERR="$(mktemp)"
+  RC=0
+  OUT="$( cd "$WORK" && printf '%s' "$P" | XDG_STATE_HOME="$STATE_HOME" bash "$PRE" 2>"$ERR" )" || RC=$?
+  E="$(cat "$ERR")"; rm -f "$ERR"
+  [ "$RC" -eq 0 ] || fail "pre-hook exited $RC on '$cmd' — a non-zero PreToolUse hook blocks the Bash call"
+  [ -z "$OUT" ] || fail "pre-hook wrote to stdout on '$cmd': $OUT"
+  [ -z "$E" ] || fail "pre-hook wrote to stderr on '$cmd': $E"
+  [ ! -d "$SNAP_DIR" ] || [ -z "$(ls -A "$SNAP_DIR" 2>/dev/null)" ] \
+    || fail "pre-hook snapshotted a call that does not invoke git commit: $cmd"
+done
+
+# Malformed and hostile payloads must not fail the tool call either.
+for bad in '' 'not json at all' '{"tool_input":{"command":"git commit -q -m x"}}' \
+           '{"cwd":"/nonexistent/nope","tool_input":{"command":"cd /nonexistent/nope && git commit"}}' ; do
+  printf '%s' "$bad" | XDG_STATE_HOME="$STATE_HOME" bash "$PRE" >/dev/null 2>&1 \
+    || fail "pre-hook exited non-zero on payload: ${bad:-<empty>}"
+done
+
+# --- 10. abandoned snapshots are swept -------------------------------------
+# One is left behind whenever the tool call never completes (denied, interrupted,
+# session killed). Nothing else deletes them.
+reset_state
+mkdir -p "$SNAP_DIR"
+printf 'sha=deadbeef\nroot=\n' > "${SNAP_DIR}/stale-key"
+touch -t 200001010000 "${SNAP_DIR}/stale-key"
+printf 'sha=deadbeef\nroot=\n' > "${SNAP_DIR}/fresh-key"
+run_pre "$(payload 'git commit -q -m x' "$REPO" call-10)"
+[ ! -f "${SNAP_DIR}/stale-key" ] || fail "an abandoned snapshot was not swept"
+[ -f "${SNAP_DIR}/fresh-key" ] || fail "the sweep deleted a current snapshot"
+
+# --- 11. concurrent calls do not cross when the payload carries an id -------
+reset_state
+A="$WORK/repo-a"; B="$WORK/repo-b"
+mkrepo "$A" "git@github.com:nhangen/aaa.git"; commit_in "$A" "a seed"
+mkrepo "$B" "git@github.com:nhangen/bbb.git"; commit_in "$B" "b seed"
+PA="$(payload 'git commit -q -m x' "$A" tool-a)"
+PB="$(payload 'git commit -q -m x' "$B" tool-b)"
+run_pre "$PA"
+run_pre "$PB"
+commit_in "$A" "only A commits"
+run_post_verbose "$PA"
+case "$POST_OUT" in
+  *"org_repo=nhangen/aaa"*) : ;;
+  *) fail "the repo that committed was not captured"$'\n'"got: ${POST_OUT:-<empty>}" ;;
+esac
+run_post_verbose "$PB"
+[ -z "$POST_OUT" ] || fail "the idle repo was captured off its sibling's commit"$'\n'"got: $POST_OUT"
+
+# --- 12. the key is a digest, so an id from the payload cannot steer the write --
+# tool_use_id arrives from outside. Used raw as a filename, one containing `/`
+# writes outside the snapshot directory and a long one exceeds NAME_MAX — where
+# the open fails and the whole gate silently stops working.
+reset_state
+ESCAPE_MARK="$WORK/escaped-write"
+LONG_ID="$(printf 'i%.0s' $(seq 1 400))"
+for id in "../../$(basename "$ESCAPE_MARK")" "$LONG_ID" ; do
+  reset_state
+  P="$(payload 'git commit -q -m x' "$REPO" "$id")"
+  run_pre "$P"
+  COUNT=$(find "$SNAP_DIR" -type f 2>/dev/null | wc -l | tr -d ' ')
+  [ "$COUNT" -eq 1 ] || fail "a hostile tool_use_id produced $COUNT snapshot files (want 1)"
+  [ ! -e "$ESCAPE_MARK" ] || fail "a tool_use_id containing '..' wrote outside the snapshot directory"
+  commit_in "$REPO" "hostile id $RANDOM"
+  run_post_verbose "$P"
+  case "$POST_OUT" in
+    *hash=*) : ;;
+    *) fail "a commit was dropped because the snapshot key came from a hostile id"$'\n'"got: ${POST_OUT:-<empty>}"$'\n'"stderr: $POST_ERR" ;;
+  esac
+done
+
+# --- wiring: both halves are registered on Bash ------------------------------
+# The pair is one mechanism. Shipping the post-hook without the pre-hook turns
+# every capture into a stderr diagnostic.
+HJ="${ROOT_DIR}/hooks/hooks.json"
+python3 -c "
+import json
+h = json.load(open('$HJ'))['hooks']
+for event, script in (('PreToolUse', 'commit-capture-pre.sh'), ('PostToolUse', 'commit-capture.sh')):
+    assert event in h, event + ' not registered'
+    groups = [g for g in h[event] if g.get('matcher') == 'Bash']
+    assert groups, event + ' has no Bash matcher'
+    cmds = [hk['command'] for g in groups for hk in g['hooks']]
+    assert any(script in c for c in cmds), (event, script, cmds)
+" || fail "hooks.json does not register both commit-capture halves on Bash"
+
+printf 'ok   commit-capture-head-gate.sh (PreToolUse HEAD snapshot decides capture)\n'

--- a/tests/commit-capture-parsing.sh
+++ b/tests/commit-capture-parsing.sh
@@ -46,19 +46,39 @@ mkrepo() {
   git -C "$dir" commit -q -m "$subject"
 }
 
-# The post-hook only captures when a PreToolUse snapshot says HEAD moved, so
-# every positive case needs one. `sha=` is a value no real HEAD can equal and
-# `root=` is left empty (unvalidated), which keeps these cases about payload
-# parsing and repo resolution rather than about the gate — the gate has its own
-# suite in commit-capture-head-gate.sh.
+# The post-hook only captures when a PreToolUse snapshot says HEAD moved *in this
+# repo*, so every positive case needs one naming the repo the hook will resolve.
+# Rather than hard-code that (these cases are precisely about which repo gets
+# resolved), ask the production functions — the same ones the real pre-hook uses.
+# `sha=` is a value no real HEAD can equal, which keeps these cases about payload
+# parsing and repo resolution; the gate itself has its own suite in
+# commit-capture-head-gate.sh.
+resolved_root_for() {
+  local from="$1" payload="$2"
+  (
+    cd "$from" || exit 0
+    . "${ROOT_DIR}/scripts/lib/commit-capture-parse.sh"
+    cmd="$(cc_json_value "$payload" '"command"')"
+    cwd="$(cc_json_value "$payload" '"cwd"')"
+    cc_invokes_commit "$cmd" || exit 0
+    d="$(cc_find_repo_dir "$cwd")" || exit 0
+    git -C "$d" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$d"
+  )
+}
+
 snapshot_for() {
-  local payload="$1" sha="${2:-0000000000000000000000000000000000000000}" root="${3:-}" key
+  local payload="$1" sha="${2:-}" root="${3:-}" key
+  # `none` is what the pre-hook records for an unborn HEAD, and it is what these
+  # fixtures actually are: a repo whose seed commit is its first. A fabricated sha
+  # would fail the post-hook's ancestry check — correctly, since no such object
+  # exists — and every case here would go quiet for the wrong reason.
+  [ -n "$sha" ] || sha=none
   key="$(
     . "${ROOT_DIR}/scripts/lib/commit-capture-parse.sh"
     cc_snapshot_key "$payload"
   )"
   mkdir -p "${STATE_HOME:?}/claude-obsidian/pre-commit-head"
-  printf 'sha=%s\nroot=%s\n' "$sha" "$root" \
+  printf 'sha=%s\nroot=%s\nintent=\n' "$sha" "$root" \
     > "${STATE_HOME}/claude-obsidian/pre-commit-head/${key}"
 }
 
@@ -67,7 +87,7 @@ snapshot_for() {
 run_from() {
   local from="$1" payload="$2"
   rm -rf "${STATE_HOME:?}/claude-obsidian"
-  snapshot_for "$payload"
+  snapshot_for "$payload" "" "$(resolved_root_for "$from" "$payload")"
   ( cd "$from" && printf '%s' "$payload" | XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>/dev/null ) || true
 }
 
@@ -273,12 +293,14 @@ esac
 mkdir -p "$REAL/sub"
 keep() { printf '%s' "$1" | XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>/dev/null || true; }
 rm -rf "${STATE_HOME:?}/claude-obsidian"
-snapshot_for "$(payload 'git commit -q -m x' "$REAL")"
+snapshot_for "$(payload 'git commit -q -m x' "$REAL")" "" "$(git -C "$REAL" rev-parse --show-toplevel)"
 FIRST="$(keep "$(payload 'git commit -q -m x' "$REAL")")"
 case "$FIRST" in *hash=*) : ;; *) fail "first capture missing"$'\n'"got: ${FIRST:-<empty>}" ;; esac
 for variant in "$REAL/sub" "$REAL/" "$REAL"; do
   AGAIN="$(keep "$(payload 'git commit -q -m x' "$variant")")"
-  [ -z "$AGAIN" ] || fail "same commit re-captured from cwd '$variant' (snapshot not consumed)"$'\n'"got: $AGAIN"
+  case "$AGAIN" in
+    *hash=*) fail "same commit re-captured from cwd '$variant' (snapshot not consumed)"$'\n'"got: $AGAIN" ;;
+  esac
 done
 
 # --- 6. the record is not injectable via the commit message -----------------
@@ -332,7 +354,7 @@ DEEP="$WORK/$(printf 'd%.0s' $(seq 1 60))/$(printf 'e%.0s' $(seq 1 60))/$(printf
 mkrepo "$DEEP" "git@github.com:nhangen/deep.git" "deep commit"
 DEEP_PAYLOAD="$(payload 'git commit -q -m x' "$DEEP")"
 rm -rf "${STATE_HOME:?}/claude-obsidian"
-snapshot_for "$DEEP_PAYLOAD"
+snapshot_for "$DEEP_PAYLOAD" "" "$(git -C "$DEEP" rev-parse --show-toplevel)"
 ERR="$(mktemp)"
 OUT="$( cd "$DEEP" && printf '%s' "$DEEP_PAYLOAD" | XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>"$ERR" )" || true
 case "$OUT" in *hash=*) : ;; *) fail "deep-path repo was not captured"$'\n'"got: ${OUT:-<empty>}" ;; esac
@@ -350,11 +372,18 @@ cp "$SCRIPT" "$COPY/scripts/commit-capture.sh"
 cp "${ROOT_DIR}/scripts/lib/commit-capture-parse.sh" "$COPY/scripts/lib/"
 COPY_PAYLOAD="$(payload 'git commit -q -m x' "$REAL")"
 rm -rf "${STATE_HOME:?}/claude-obsidian"
-snapshot_for "$COPY_PAYLOAD"
+snapshot_for "$COPY_PAYLOAD" "" "$(git -C "$REAL" rev-parse --show-toplevel)"
 ERR="$(mktemp)"
 OUT="$( cd "$REAL" && printf '%s' "$COPY_PAYLOAD" | XDG_STATE_HOME="$STATE_HOME" bash "$COPY/scripts/commit-capture.sh" 2>"$ERR" )" || true
-[ -z "$OUT" ] || { rm -f "$ERR"; fail "hook emitted a record with no config library present"$'\n'"got: $OUT"; }
-grep -q 'vault_path unresolved' "$ERR" || { local_err="$(cat "$ERR")"; rm -f "$ERR"; fail "a missing config library was not reported on stderr"$'\n'"got: ${local_err:-<empty>}"; }
+case "$OUT" in
+  *hash=*) rm -f "$ERR"; fail "hook emitted a record with no config library present"$'\n'"got: $OUT" ;;
+esac
+# Reported on stdout, which is the channel a hook exiting 0 actually surfaces.
+case "$OUT" in
+  *'vault_path unresolved'*) : ;;
+  *) rm -f "$ERR"; fail "a missing config library was not reported"$'\n'"got: ${OUT:-<empty>}" ;;
+esac
+[ ! -s "$ERR" ] || { local_err="$(cat "$ERR")"; rm -f "$ERR"; fail "hook wrote to stderr, where nothing reads it: $local_err"; }
 rm -f "$ERR"
 
 # Without the parsing lib the hook has no decoder at all. It must say so rather
@@ -364,8 +393,25 @@ mkdir -p "$BARE/scripts"
 cp "$SCRIPT" "$BARE/scripts/commit-capture.sh"
 ERR="$(mktemp)"
 OUT="$( cd "$REAL" && printf '%s' "$COPY_PAYLOAD" | XDG_STATE_HOME="$STATE_HOME" bash "$BARE/scripts/commit-capture.sh" 2>"$ERR" )" || true
-[ -z "$OUT" ] || { rm -f "$ERR"; fail "hook emitted a record with no parsing library"$'\n'"got: $OUT"; }
-grep -q 'commit-capture-parse.sh' "$ERR" || { bare_err="$(cat "$ERR")"; rm -f "$ERR"; fail "a missing parsing library was not reported on stderr"$'\n'"got: ${bare_err:-<empty>}"; }
+case "$OUT" in
+  *hash=*) rm -f "$ERR"; fail "hook emitted a record with no parsing library"$'\n'"got: $OUT" ;;
+esac
+case "$OUT" in
+  *'commit-capture-parse.sh'*) : ;;
+  *) bare_err="$(cat "$ERR")"; rm -f "$ERR"; fail "a missing parsing library was not reported"$'\n'"stdout: ${OUT:-<empty>}"$'\n'"stderr: ${bare_err:-<empty>}" ;;
+esac
 rm -f "$ERR"
+
+# A present-but-broken lib must be reported too, not swallowed as a non-commit call.
+BROKEN="$WORK/brokencopy"
+mkdir -p "$BROKEN/scripts/lib"
+cp "$SCRIPT" "$BROKEN/scripts/commit-capture.sh"
+printf 'this is not valid shell (\n' > "$BROKEN/scripts/lib/commit-capture-parse.sh"
+OUT="$( cd "$REAL" && printf '%s' "$COPY_PAYLOAD" | XDG_STATE_HOME="$STATE_HOME" bash "$BROKEN/scripts/commit-capture.sh" 2>/dev/null )" || true
+case "$OUT" in
+  *hash=*) fail "hook emitted a record with a broken parsing library"$'\n'"got: $OUT" ;;
+  *'failed to load'*) : ;;
+  *) fail "a broken parsing library was not reported"$'\n'"got: ${OUT:-<empty>}" ;;
+esac
 
 printf 'ok   commit-capture-parsing.sh (payload parsing, repo resolution, record integrity)\n'

--- a/tests/commit-capture-parsing.sh
+++ b/tests/commit-capture-parsing.sh
@@ -46,11 +46,28 @@ mkrepo() {
   git -C "$dir" commit -q -m "$subject"
 }
 
+# The post-hook only captures when a PreToolUse snapshot says HEAD moved, so
+# every positive case needs one. `sha=` is a value no real HEAD can equal and
+# `root=` is left empty (unvalidated), which keeps these cases about payload
+# parsing and repo resolution rather than about the gate — the gate has its own
+# suite in commit-capture-head-gate.sh.
+snapshot_for() {
+  local payload="$1" sha="${2:-0000000000000000000000000000000000000000}" root="${3:-}" key
+  key="$(
+    . "${ROOT_DIR}/scripts/lib/commit-capture-parse.sh"
+    cc_snapshot_key "$payload"
+  )"
+  mkdir -p "${STATE_HOME:?}/claude-obsidian/pre-commit-head"
+  printf 'sha=%s\nroot=%s\n' "$sha" "$root" \
+    > "${STATE_HOME}/claude-obsidian/pre-commit-head/${key}"
+}
+
 # Run the hook from a chosen working directory with a chosen payload.
 # $1 = cwd to run from, $2 = full JSON payload.
 run_from() {
   local from="$1" payload="$2"
   rm -rf "${STATE_HOME:?}/claude-obsidian"
+  snapshot_for "$payload"
   ( cd "$from" && printf '%s' "$payload" | XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>/dev/null ) || true
 }
 
@@ -140,9 +157,10 @@ case "$OUT" in
 esac
 [ "$ELAPSED" -le 3 ] || fail "hook took ${ELAPSED}s on a 4KB command; payload parsing is not linear enough for a PostToolUse hook"
 
-# --- 3. the failure guard must read the response, not the message ------------
-# The guard matched the entire payload, so a commit whose subject contained
-# `fatal:` or `error:` was discarded as a failure.
+# --- 3. no text — command, subject, or response — decides success ------------
+# There used to be a list of failure phrases matched against the payload, and a
+# `--dry-run` check. Both are gone: whether a commit landed is HEAD_before vs
+# HEAD_after. These cases pin that no guard word can suppress a real capture.
 GUARDED="$WORK/guarded"
 mkrepo "$GUARDED" "git@github.com:nhangen/guarded.git" "fix: swallow fatal: on rebase"
 OUT="$(run_from "$GUARDED" "$(payload 'git commit -q -F -' "$GUARDED")")"
@@ -151,9 +169,9 @@ case "$OUT" in
   *) fail "a commit whose subject contains 'fatal:' was dropped"$'\n'"got: ${OUT:-<empty>}" ;;
 esac
 
-# The guard word has to appear in the COMMAND for this to pin the guard's scope.
-# A subject supplied via `-F -` never reaches the payload at all, so asserting on
-# one proves nothing about whether the guard reads the whole payload.
+# The guard word has to appear in the COMMAND for these to mean anything. A
+# subject supplied via `-F -` never reaches the payload, so asserting on one
+# proves nothing about what the hook reads.
 for cmd in \
   'git commit -q -m "fix: error: handling"' \
   'git commit -q -m "guard fatal: paths"' \
@@ -164,7 +182,7 @@ for cmd in \
   OUT="$(run_from "$REAL" "$(payload "$cmd" "$REAL")")"
   case "$OUT" in
     *hash=*) : ;;
-    *) fail "guard matched the command text instead of the response: $cmd"$'\n'"got: ${OUT:-<empty>}" ;;
+    *) fail "a guard word in the command text suppressed a real capture: $cmd"$'\n'"got: ${OUT:-<empty>}" ;;
   esac
 done
 
@@ -178,10 +196,26 @@ for subj in 'fix: handle error: prefix' 'feat: add --dry-run flag' 'docs: the Ab
   esac
 done
 
-# Guard words in the RESPONSE still reject.
+# Guard words in the RESPONSE no longer decide anything either. This response is
+# the one git prints when nothing was committed — but the snapshot says HEAD
+# moved, so the capture stands. A "nothing to commit" call in the field leaves
+# HEAD where it was and is rejected by the gate, not by this text.
 OUT="$(run_from "$REAL" "$(payload 'git commit -q -F -' "$REAL" 'nothing to commit, working tree clean')")"
-[ -z "$OUT" ] || fail "a real failure in the response was captured"$'\n'"got: $OUT"
-OUT="$(run_from "$REAL" "$(payload 'git commit --dry-run' "$REAL")")"
+case "$OUT" in
+  *hash=*) : ;;
+  *) fail "response text still suppresses a capture the HEAD gate accepted"$'\n'"got: ${OUT:-<empty>}" ;;
+esac
+
+# A dry run cannot move HEAD, so a snapshot equal to the current tip rejects it —
+# and that same snapshot proves the rejection is the gate's, not a flag check.
+SNAP_HEAD="$(git -C "$REAL" rev-parse HEAD)"
+# The root has to be what the hook will resolve — rev-parse output, not the path
+# string — or it reads as a snapshot from a different repo.
+SNAP_ROOT="$(git -C "$REAL" rev-parse --show-toplevel)"
+DRY_PAYLOAD="$(payload 'git commit --dry-run' "$REAL")"
+rm -rf "${STATE_HOME:?}/claude-obsidian"
+snapshot_for "$DRY_PAYLOAD" "$SNAP_HEAD" "$SNAP_ROOT"
+OUT="$( cd "$REAL" && printf '%s' "$DRY_PAYLOAD" | XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>/dev/null )" || true
 [ -z "$OUT" ] || fail "--dry-run was captured"$'\n'"got: $OUT"
 
 # --- 4. repo resolution addresses the right repository ----------------------
@@ -231,15 +265,20 @@ case "$OUT" in
   *) fail "cd to a non-repo was accepted instead of falling back"$'\n'"got: ${OUT:-<empty>}" ;;
 esac
 
-# --- 5. dedup is keyed on the repository, not the cwd string -----------------
+# --- 5. one snapshot, one capture -------------------------------------------
+# `$R`, `$R/sub` and `$R/` are one repository, and used to produce three
+# captures because dedup was keyed on the cwd string. The snapshot replaces that
+# key: it is consumed on use, so no later call can re-capture the same commit
+# however it addresses the repo.
 mkdir -p "$REAL/sub"
 keep() { printf '%s' "$1" | XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>/dev/null || true; }
 rm -rf "${STATE_HOME:?}/claude-obsidian"
+snapshot_for "$(payload 'git commit -q -m x' "$REAL")"
 FIRST="$(keep "$(payload 'git commit -q -m x' "$REAL")")"
 case "$FIRST" in *hash=*) : ;; *) fail "first capture missing"$'\n'"got: ${FIRST:-<empty>}" ;; esac
 for variant in "$REAL/sub" "$REAL/" "$REAL"; do
   AGAIN="$(keep "$(payload 'git commit -q -m x' "$variant")")"
-  [ -z "$AGAIN" ] || fail "same commit re-captured from cwd '$variant' (dedup keyed on the cwd string)"$'\n'"got: $AGAIN"
+  [ -z "$AGAIN" ] || fail "same commit re-captured from cwd '$variant' (snapshot not consumed)"$'\n'"got: $AGAIN"
 done
 
 # --- 6. the record is not injectable via the commit message -----------------
@@ -285,36 +324,48 @@ case "$OUT" in
   *) fail "traversal fixture was not captured"$'\n'"got: ${OUT:-<empty>}" ;;
 esac
 
-# --- 7. a state-write failure must not silently disable dedup ---------------
-# The redirection order sent the error to inherited stderr, and because the key
-# was the whole path a deep worktree exceeded NAME_MAX — dedup off, forever.
+# --- 7. a deep repo path must not break the state write ----------------------
+# Slugging the raw path as the state key exceeded NAME_MAX in a deep worktree:
+# the open failed, the shell error went to the hook's stderr, and the gate
+# silently stopped working. The key is a bounded digest for that reason.
 DEEP="$WORK/$(printf 'd%.0s' $(seq 1 60))/$(printf 'e%.0s' $(seq 1 60))/$(printf 'f%.0s' $(seq 1 60))/repo"
 mkrepo "$DEEP" "git@github.com:nhangen/deep.git" "deep commit"
+DEEP_PAYLOAD="$(payload 'git commit -q -m x' "$DEEP")"
 rm -rf "${STATE_HOME:?}/claude-obsidian"
+snapshot_for "$DEEP_PAYLOAD"
 ERR="$(mktemp)"
-OUT="$( cd "$DEEP" && printf '%s' "$(payload 'git commit -q -m x' "$DEEP")" | XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>"$ERR" )" || true
+OUT="$( cd "$DEEP" && printf '%s' "$DEEP_PAYLOAD" | XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>"$ERR" )" || true
 case "$OUT" in *hash=*) : ;; *) fail "deep-path repo was not captured"$'\n'"got: ${OUT:-<empty>}" ;; esac
 grep -q 'File name too long' "$ERR" && { rm -f "$ERR"; fail "state key is unbounded; the hook printed a shell error"; }
 rm -f "$ERR"
-AGAIN="$( cd "$DEEP" && printf '%s' "$(payload 'git commit -q -m x' "$DEEP")" | XDG_STATE_HOME="$STATE_HOME" bash "$SCRIPT" 2>/dev/null )" || true
-[ -z "$AGAIN" ] || fail "dedup silently disabled for a deep path"$'\n'"got: $AGAIN"
 
-# --- 8. a missing lib must not leave a captured marker behind ---------------
-# resolve-config.sh was sourced unguarded: the hook printed an empty vault_path
-# (which the skill skips silently) after already writing the marker, making the
-# miss permanently unretryable.
+# --- 8. a missing lib must be reported, not silently swallowed ---------------
+# resolve-config.sh was sourced unguarded: the hook printed two shell errors and
+# an empty vault_path, which the skill skips silently — a capture lost with no
+# visible cause. Same requirement now applies to the parsing lib the two hooks
+# share: without it the hook cannot even read the payload.
 COPY="$WORK/plugincopy"
 mkdir -p "$COPY/scripts/lib"
 cp "$SCRIPT" "$COPY/scripts/commit-capture.sh"
+cp "${ROOT_DIR}/scripts/lib/commit-capture-parse.sh" "$COPY/scripts/lib/"
+COPY_PAYLOAD="$(payload 'git commit -q -m x' "$REAL")"
 rm -rf "${STATE_HOME:?}/claude-obsidian"
-# The state dir has to exist, or a premature marker write fails for the wrong
-# reason (no directory yet) and the case passes without proving anything.
-mkdir -p "${STATE_HOME:?}/claude-obsidian"
-OUT="$( cd "$REAL" && printf '%s' "$(payload 'git commit -q -m x' "$REAL")" | XDG_STATE_HOME="$STATE_HOME" bash "$COPY/scripts/commit-capture.sh" 2>/dev/null )" || true
-MARKERS=$(find "$STATE_HOME" -type f 2>/dev/null | wc -l | tr -d ' ')
-if [ -n "$OUT" ]; then
-  fail "hook emitted a record with no config library present"$'\n'"got: $OUT"
-fi
-[ "$MARKERS" -eq 0 ] || fail "hook wrote a captured marker ($MARKERS) despite emitting nothing"
+snapshot_for "$COPY_PAYLOAD"
+ERR="$(mktemp)"
+OUT="$( cd "$REAL" && printf '%s' "$COPY_PAYLOAD" | XDG_STATE_HOME="$STATE_HOME" bash "$COPY/scripts/commit-capture.sh" 2>"$ERR" )" || true
+[ -z "$OUT" ] || { rm -f "$ERR"; fail "hook emitted a record with no config library present"$'\n'"got: $OUT"; }
+grep -q 'vault_path unresolved' "$ERR" || { local_err="$(cat "$ERR")"; rm -f "$ERR"; fail "a missing config library was not reported on stderr"$'\n'"got: ${local_err:-<empty>}"; }
+rm -f "$ERR"
+
+# Without the parsing lib the hook has no decoder at all. It must say so rather
+# than exit 0 like a non-commit call.
+BARE="$WORK/barecopy"
+mkdir -p "$BARE/scripts"
+cp "$SCRIPT" "$BARE/scripts/commit-capture.sh"
+ERR="$(mktemp)"
+OUT="$( cd "$REAL" && printf '%s' "$COPY_PAYLOAD" | XDG_STATE_HOME="$STATE_HOME" bash "$BARE/scripts/commit-capture.sh" 2>"$ERR" )" || true
+[ -z "$OUT" ] || { rm -f "$ERR"; fail "hook emitted a record with no parsing library"$'\n'"got: $OUT"; }
+grep -q 'commit-capture-parse.sh' "$ERR" || { bare_err="$(cat "$ERR")"; rm -f "$ERR"; fail "a missing parsing library was not reported on stderr"$'\n'"got: ${bare_err:-<empty>}"; }
+rm -f "$ERR"
 
 printf 'ok   commit-capture-parsing.sh (payload parsing, repo resolution, record integrity)\n'

--- a/tests/commit-capture-vault-path.sh
+++ b/tests/commit-capture-vault-path.sh
@@ -42,10 +42,24 @@ cleanup_git_stub() {
   GIT_BIN_DIR=""
 }
 
-# Each case gets a fresh XDG_STATE_HOME: the hook records the captured sha to
-# suppress duplicates, and all 9 cases share one stubbed sha, so a shared state
-# dir would make every case after the first return empty. It also keeps the
-# suite from writing to the host's real state dir.
+# Each case gets a fresh XDG_STATE_HOME holding one PreToolUse HEAD snapshot: the
+# hook captures only when the snapshot shows HEAD moved, and it consumes the
+# snapshot, so a shared state dir would make every case after the first return
+# empty. It also keeps the suite from writing to the host's real state dir.
+# `sha=` is a value the stubbed HEAD cannot equal and `root=` is left empty so it
+# is not compared — these cases are about the vault_path parse, not the gate.
+new_state_home() {
+  local dir key
+  dir="$(mktemp -d)"
+  key="$(
+    . "${ROOT_DIR}/scripts/lib/commit-capture-parse.sh"
+    cc_snapshot_key "$1"
+  )"
+  mkdir -p "${dir}/claude-obsidian/pre-commit-head"
+  printf 'sha=1111111111111111111111111111111111111111\nroot=\n' \
+    > "${dir}/claude-obsidian/pre-commit-head/${key}"
+  printf '%s' "$dir"
+}
 # Run the script with a given config file and capture the printf output.
 # Returns the captured vault_path field value via stdout. Empty string if the
 # field is empty or the script took the silent-skip path.
@@ -55,9 +69,9 @@ run_case() {
   local input='{"tool_input":{"command":"git commit -m foo"},"tool_response":{"stdout":"[main abc1234] foo\n"}}'
   local out
   if [ -n "$plugin_root" ]; then
-    out=$(CLAUDE_PLUGIN_ROOT="$plugin_root" XDG_STATE_HOME="$(mktemp -d)" PATH="${GIT_BIN_DIR}:$PATH" bash "$SCRIPT" <<< "$input")
+    out=$(CLAUDE_PLUGIN_ROOT="$plugin_root" XDG_STATE_HOME="$(new_state_home "$input")" PATH="${GIT_BIN_DIR}:$PATH" bash "$SCRIPT" <<< "$input")
   else
-    out=$(env -u CLAUDE_PLUGIN_ROOT XDG_STATE_HOME="$(mktemp -d)" PATH="${GIT_BIN_DIR}:$PATH" bash "$SCRIPT" <<< "$input")
+    out=$(env -u CLAUDE_PLUGIN_ROOT XDG_STATE_HOME="$(new_state_home "$input")" PATH="${GIT_BIN_DIR}:$PATH" bash "$SCRIPT" <<< "$input")
   fi
   # Extract vault_path=<value>. It is no longer the last field — msg moved to the
   # end so a commit subject cannot inject a field ahead of a real one — so stop
@@ -71,9 +85,9 @@ run_case_raw() {
   local plugin_root="${2:-}"
   local input='{"tool_input":{"command":"git commit -m foo"},"tool_response":{"stdout":"[main abc1234] foo\n"}}'
   if [ -n "$plugin_root" ]; then
-    CLAUDE_PLUGIN_ROOT="$plugin_root" XDG_STATE_HOME="$(mktemp -d)" PATH="${GIT_BIN_DIR}:$PATH" bash "$SCRIPT" <<< "$input"
+    CLAUDE_PLUGIN_ROOT="$plugin_root" XDG_STATE_HOME="$(new_state_home "$input")" PATH="${GIT_BIN_DIR}:$PATH" bash "$SCRIPT" <<< "$input"
   else
-    env -u CLAUDE_PLUGIN_ROOT XDG_STATE_HOME="$(mktemp -d)" PATH="${GIT_BIN_DIR}:$PATH" bash "$SCRIPT" <<< "$input"
+    env -u CLAUDE_PLUGIN_ROOT XDG_STATE_HOME="$(new_state_home "$input")" PATH="${GIT_BIN_DIR}:$PATH" bash "$SCRIPT" <<< "$input"
   fi
 }
 

--- a/tests/commit-capture-vault-path.sh
+++ b/tests/commit-capture-vault-path.sh
@@ -46,8 +46,9 @@ cleanup_git_stub() {
 # hook captures only when the snapshot shows HEAD moved, and it consumes the
 # snapshot, so a shared state dir would make every case after the first return
 # empty. It also keeps the suite from writing to the host's real state dir.
-# `sha=` is a value the stubbed HEAD cannot equal and `root=` is left empty so it
-# is not compared — these cases are about the vault_path parse, not the gate.
+# `sha=` is a value the stubbed HEAD cannot equal, and `root=` is the toplevel the
+# stub reports — a pair the real pre-hook could have written. These cases are about
+# the vault_path parse, not the gate.
 new_state_home() {
   local dir key
   dir="$(mktemp -d)"
@@ -56,7 +57,7 @@ new_state_home() {
     cc_snapshot_key "$1"
   )"
   mkdir -p "${dir}/claude-obsidian/pre-commit-head"
-  printf 'sha=1111111111111111111111111111111111111111\nroot=\n' \
+  printf 'sha=1111111111111111111111111111111111111111\nroot=/tmp/test-repo\nintent=\n' \
     > "${dir}/claude-obsidian/pre-commit-head/${key}"
   printf '%s' "$dir"
 }


### PR DESCRIPTION
Closes #60

## Description (Issue Fixed & New Behavior)

The commit-capture hook decided that a commit had happened by reading the Bash command text and then checking that `HEAD` was recent and not already captured. Nothing linked `HEAD` to the invocation being observed, so a `git commit` that *failed* left its predecessor at the tip — and if that commit's capture had ever been dropped, the failed call captured it and stamped it with the hook's clock instead of the commit's. `false && git commit` reproduced that end to end during the #48 review.

This replaces the inference with an observation. A new **PreToolUse** hook records `HEAD` before the call; the **PostToolUse** hook captures only when `HEAD_before != HEAD_after`. The text guards that were standing in for that signal are gone:

- the failure-phrase list (which needed a phrase for every way git can fail, and dropped a commit whose *subject* contained one)
- the `--dry-run` check (and the quote-stripping it needed so `-m "add --dry-run flag"` wasn't mistaken for a dry run)
- the `false &&` false positive, which no phrase could catch
- the last-capture sha marker — a snapshot is consumed on use, so one invocation can produce exactly one capture

The two hooks must agree *exactly* on whether a command invokes `git commit` and which repository it runs in. Where they disagree, one drops a real commit or they compare two different `HEAD`s — and neither divergence is observable in either hook alone. So payload decoding, the command gate, and repo resolution moved into `scripts/lib/commit-capture-parse.sh`, which both source.

Also includes:

- **A foreign snapshot is discarded, not reused.** Without a `tool_use_id` in the payload the key is session-scoped, so two concurrent commits in one session can cross. The other repo's sha differs from this `HEAD` whether or not anything was committed here — that's the exact inference being removed — so the snapshot records its repo root and a mismatch is treated as no snapshot.
- **The freshness window stays, demoted to corroboration.** `git pull && git commit` with a failed commit leaves a tip that moved but was committed earlier; so does a `git checkout` in front of a failed commit.
- **Unborn and not-yet-created repos.** An unborn `HEAD` records `none`, so a repo's first commit is captured. A repo that doesn't exist yet (`mkdir x && cd x && git init && git commit`) records `unresolved`, and the post-hook falls back to requiring a fresh tip.
- **A missing snapshot is reported on stderr, not swallowed.** A hand-wired config carrying only the PostToolUse half would otherwise stop capturing with no visible cause. The message names the fix, and the skill is told these lines are diagnostics, not records.
- **The pre-hook exits 0 on every path**, including a malformed or empty payload — a non-zero PreToolUse hook blocks the Bash call it precedes.
- **Snapshot keys are a bounded digest** of `tool_use_id` (else session id), so an id carrying `/` can't write outside the state dir and a long one can't bust `NAME_MAX`. Abandoned snapshots (denied or interrupted calls) are swept after a day.
- Version bumped to 1.17.0; README hooks table and the commit-capture SKILL updated.

## Testing Procedure

1. Check out this branch.
2. `bash tests/run-all.sh` — all 31 suites pass. `tests/commit-capture-head-gate.sh` is new and drives the real pre/post pair against real git repositories (a stub can't make a commit land).
3. Confirm the retired guards no longer suppress a real capture: in `tests/commit-capture-head-gate.sh` case 3, commits whose subject contains `fatal:`, `nothing to commit`, or `--dry-run`, and calls whose tool output contains `Untracked files:`, are all captured. On `master` each of these is dropped.
4. Confirm nothing is captured when `HEAD` didn't move (case 2): `git commit` with nothing staged, `false && git commit`, `git commit --dry-run`. `false && git commit` is the one `master` gets wrong.
5. Mutation check — each of these must turn a suite red:
   - `scripts/commit-capture-pre.sh`: delete the snapshot write → head-gate fails
   - `scripts/commit-capture.sh`: remove the `HEAD_BEFORE = FULL_SHA` rejection → head-gate fails
   - `scripts/commit-capture.sh`: stop consuming the snapshot (`rm -f`) → head-gate fails
   - `scripts/lib/commit-capture-parse.sh`: ignore `tool_use_id` in the key, or return it undigested → head-gate fails
   18 mutants were checked this way; all 18 died.
6. Both halves are registered: `python3 -c "import json;print(json.load(open('hooks/hooks.json'))['hooks'].keys())"` shows `PreToolUse` and `PostToolUse`. The head-gate suite asserts this too — shipping the post-hook alone turns every capture into a stderr diagnostic.
7. Live check (needs a session restart to reload `hooks.json`): make a commit and confirm the note lands, then run `git commit` with nothing staged and confirm nothing is written.

## Additional Notes / HelpScout Tickets

Environment: local real git repositories plus the existing stubs, run under both bash 5.x and `/bin/bash` 3.2.57. Not yet exercised inside a live Claude Code session — `hooks.json` changes need a restart, so step 7 above is the post-merge check.

Follow-ups this touches but doesn't close: #61 (marker written after the vault append — the marker no longer exists, so this may just close), #63 (state store conventions — the snapshot is a new store and doesn't use `keeper-state.sh`), #67 (the detection stub still strips `-C`, which is why the new suite uses real repos).


---

## Round 2 — mini panel (n=4)

Three specialists plus an auditor, run against the branch with real repositories. The gate itself held up; the fallback layer around it did not. Every item below was reproduced, not argued, and each has a case that fails without its fix. Fixed in `92d1817` (code), `e32bde1` (tests), `0f1b2aa` (docs).

**Blocker.** `git worktree add ../wt && cd ../wt && git commit` — this project's own documented workflow — dropped the capture. The pre-hook can't read a HEAD that doesn't exist yet, so resolution fell through to the surrounding repo; the post-hook resolved the new one, the roots disagreed, and the commit was discarded as foreign. Master captured it. The pre-hook now records the directory the command *named*, and a snapshot whose named repo turns out to be this one counts as "no before-image" rather than "someone else's".

**`sha=unresolved` was a wildcard.** With an empty root it matched every repo and no HEAD at once, leaving the wall clock as the only gate — an unconsumed unresolved snapshot plus `false && git commit` in an unrelated repo captured a commit made before the call. A snapshot that can't name a repository isn't written now.

**The failure #60 names was still reachable.** `git pull && git commit` where the commit fails leaves the *pulled* tip, and the freshness check passed it whenever the teammate's commit was under two minutes old. Single call, no concurrency. The post-hook now asks git what the move was: the old tip (or its parent, for an amend) has to be reachable from the new one, landing exactly on that parent is an undo, and the committer has to be you.

**The wall clock was throwing away real commits.** PostToolUse fires when the whole Bash call ends, not when `git commit` returns, so `git commit && npm test` outlived the 120s window and lost the note with no output on any stream. The window now applies only where there's no before-image.

**Record injection.** `msg=` was scrubbed of the delimiter; `files=` and `branch=` weren't, and both precede `org_repo`/`vault_path` in a first-match-parsed record. `|` is legal in a filename and a refname — the auditor landed it. All author-controlled fields are scrubbed now.

**Diagnostics were on a channel nothing reads.** stdout is what a hook exiting 0 has read; exit-0 stderr has no documented surface, so "not captured" written there was indistinguishable from silence — and SKILL.md told the skill to handle a line it could never receive. Moved to stdout, with `hash=` the only record prefix.

**Three of my own tests couldn't fail.** Two section-3 rows asserted on a commit subject supplied via `-F -`, which never reaches the payload — the same defect this PR fixes in the parsing suite, reintroduced twenty minutes later. Case 12 watched the wrong directory for an escaped write. And the suite had no `XDG_CONFIG_HOME` isolation, so it only passed on a machine with a real vault configured. Mutation testing also caught a fourth: the pulled-commit case needed a shared base commit or the HEAD gate rejected it before the check under test ran.

Two reviewer claims were overturned: `tool_use_id` is documented on all hook payloads (so there's no pre/post asymmetry to guard), and abbreviated function prefixes are already the norm in `scripts/lib/`.

Verification: 31/31 suites pass, 28 mutants checked and all 28 killed, under bash 5.x and `/bin/bash` 3.2.57, and with config resolution pointed at an empty XDG home.

Known residuals, filed as follow-ups rather than fixed here: pulling *your own* commit from another machine within the window and then failing a commit still captures it; a call that makes several commits records the tip and names the rest rather than emitting one record each; the pre-hook's snapshot write is best-effort, so an unwritable state dir is reported by the post-hook rather than by the hook that failed.
