### PR TITLE
commit-capture: see through a wrapper in front of git (rtk)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/scripts/lib/commit-capture-parse.sh
+++ b/scripts/lib/commit-capture-parse.sh
@@ -139,6 +139,22 @@ cc_invokes_commit() {
     cc_take_token "$seg"
     word="$CC_TOKEN"
     args="$CC_REST"
+    # A wrapper can sit in front of git. RTK's own PreToolUse hook returns
+    # `updatedInput` from `rtk rewrite`, so the command the PostToolUse payload
+    # reports is `rtk git commit` while the pre-hook's payload still said
+    # `git commit` — the two halves of the gate then disagreed about whether a
+    # commit happened and the capture died silently. Allowlisted by name: skipping
+    # any unrecognized leading word would make `rtk echo git commit` a commit.
+    if [ "${word##*/}" = rtk ] && [ -n "$args" ]; then
+      cc_take_token "$args"
+      word="$CC_TOKEN"
+      args="$CC_REST"
+      if [ "${word##*/}" = proxy ] && [ -n "$args" ]; then
+        cc_take_token "$args"
+        word="$CC_TOKEN"
+        args="$CC_REST"
+      fi
+    fi
     # Match the basename so /usr/bin/git counts, and remember a `cd` target: it is
     # where git actually ran.
     case "${word##*/}" in

--- a/tests/commit-capture-head-gate.sh
+++ b/tests/commit-capture-head-gate.sh
@@ -508,6 +508,26 @@ else
   printf 'skip commit-capture-head-gate.sh case 19: filesystem refused a path containing |\n' >&2
 fi
 
+# --- 20. a wrapper rewritten in between the two halves ----------------------
+# The real asymmetry from issue #73: RTK's PreToolUse hook returns `updatedInput`,
+# so the pre-hook's payload says `git commit` and the post-hook's says
+# `rtk git commit`. Both halves share cc_invokes_commit, and it has to answer the
+# same for both texts or the snapshot is written and never read.
+reset_state
+P_PRE="$(payload 'git commit -q -m x' "$REPO" call-rtk)"
+P_POST="$(payload 'rtk git commit -q -m x' "$REPO" call-rtk)"
+run_pre "$P_PRE"
+commit_in "$REPO" "work behind a wrapper"
+run_post_verbose "$P_POST"
+case "$POST_OUT" in
+  *"org_repo=altamira2/mtf-builder"*) : ;;
+  *) fail "a commit whose command was rewritten to 'rtk git' between pre and post was lost"$'\n'"got: ${POST_OUT:-<empty>}"$'\n'"stderr: $POST_ERR" ;;
+esac
+# And the snapshot must be consumed, not leaked until the daily sweep.
+if [ -n "$(ls -A "${STATE_HOME}/claude-obsidian/pre-commit-head" 2>/dev/null)" ]; then
+  fail "the snapshot survived a capture behind a wrapper"
+fi
+
 # --- wiring: both halves are registered on Bash ------------------------------
 # The pair is one mechanism. Shipping the post-hook without the pre-hook turns
 # every capture into a stderr diagnostic.

--- a/tests/commit-capture-parsing.sh
+++ b/tests/commit-capture-parsing.sh
@@ -414,4 +414,42 @@ case "$OUT" in
   *) fail "a broken parsing library was not reported"$'\n'"got: ${OUT:-<empty>}" ;;
 esac
 
+# --- 9. a wrapper in front of git (rtk) --------------------------------------
+# RTK's own PreToolUse hook returns `updatedInput` from `rtk rewrite`, so the
+# command the PostToolUse payload reports is `rtk git commit`, not `git commit`.
+# The pre-hook sees the payload before that rewrite and records a snapshot, so a
+# gate that only knows the word `git` leaves the two halves disagreeing about
+# whether a commit happened — and the capture dies silently (issue #73).
+WRAPPED="$WORK/wrapped"
+mkrepo "$WRAPPED" "git@github.com:nhangen/wrapped.git" "wrapped commit"
+OUT="$(run_from "$WORK" "$(payload "cd $WRAPPED && rtk git commit -q -m x")")"
+case "$OUT" in
+  *"org_repo=nhangen/wrapped"*) : ;;
+  *) fail "rtk-wrapped git commit was not recognized"$'\n'"got: ${OUT:-<empty>}" ;;
+esac
+
+# The wrapper must not hide `-C` from resolution either: the flag is parsed after
+# the command word, so a skipped wrapper has to hand off mid-argv intact.
+OUT="$(run_from "$WORK" "$(payload "rtk git -C $WRAPPED commit -q -m x")")"
+case "$OUT" in
+  *"org_repo=nhangen/wrapped"*) : ;;
+  *) fail "rtk-wrapped 'git -C <dir> commit' lost the -C target"$'\n'"got: ${OUT:-<empty>}" ;;
+esac
+
+# `rtk proxy <cmd>` is the second wrapper shape in RTK's docs, which is why the
+# skip loops instead of stripping one token.
+OUT="$(run_from "$WORK" "$(payload "cd $WRAPPED && rtk proxy git commit -q -m x")")"
+case "$OUT" in
+  *"org_repo=nhangen/wrapped"*) : ;;
+  *) fail "'rtk proxy git commit' was not recognized"$'\n'"got: ${OUT:-<empty>}" ;;
+esac
+
+# The allowlist is narrow on purpose. Skipping any unrecognized leading word
+# would make `rtk echo git commit` — and every other command that merely names
+# git — read as a commit.
+OUT="$(run_from "$WORK" "$(payload "cd $WRAPPED && rtk echo git commit")")"
+case "$OUT" in
+  *hash=*) fail "a wrapped command that only names git was captured"$'\n'"got: $OUT" ;;
+esac
+
 printf 'ok   commit-capture-parsing.sh (payload parsing, repo resolution, record integrity)\n'


### PR DESCRIPTION
Closes #73

## Description (Issue Fixed & New Behavior)

Commit capture was dead in every Claude Code session on a machine running the RTK rewrite hook, and it failed with no output on any channel.

`~/.claude/hooks/rtk-rewrite.sh` is a `PreToolUse` Bash hook that returns `updatedInput` from `rtk rewrite`. The command the *PostToolUse* payload reports is therefore `rtk git commit`, while the pre-hook's payload — read before the rewrite — still said `git commit`. `cc_invokes_commit` dispatches on the command word (`case "${word##*/}" in git) ;; *) continue ;;`), so the post-hook returned false and exited at `commit-capture.sh:50`, before it ever computed the snapshot key. The pre-hook wrote a correct before-image that nothing read, and the snapshot leaked until the one-day sweep.

The fix skips a leading `rtk` — and `rtk proxy`, the second wrapper shape in RTK's docs — before dispatching. Allowlisted by name rather than skipping any unrecognized leading word, which would make `rtk echo git commit` read as a commit.

Both halves of the gate share `cc_invokes_commit`, so one change restores agreement.

Also bumps the plugin to 1.17.1.

## Testing Procedure

1. Check out this branch and run `bash tests/run-all.sh` — 31 suites, all pass. Also verified under `/bin/bash` 3.2.57.
2. Revert just the fix (`git stash push scripts/lib/commit-capture-parse.sh`) and re-run `tests/commit-capture-parsing.sh` and `tests/commit-capture-head-gate.sh`. Both fail:
   - `rtk-wrapped git commit was not recognized`
   - `a commit whose command was rewritten to 'rtk git' between pre and post was lost`
3. Live check after installing 1.17.1 (`/plugin` update, then restart): commit anything from a Claude Code session and confirm the hook emits an `obsidian-commit-capture: hash=` record instead of going quiet. Before this fix that commit produced nothing.

New coverage:

- parsing suite section 9 — `rtk git commit`, `rtk git -C <dir> commit` (the wrapper must not hide `-C` from repo resolution), `rtk proxy git commit`, and the negative `rtk echo git commit`
- head-gate case 20 — drives the two halves with the two *different* command texts they actually receive, and asserts the snapshot is consumed rather than leaked

## Additional Notes / HelpScout Tickets

Diagnosed by temporarily teeing the delegator's payload: the post-hook did run and its payload did carry `tool_use_id`, and it computed the same key (`419286165030`) the pre-hook had written — so the `tool_use_id` asymmetry raised as finding #11 on PR #68 is not real. The command text was the only thing that differed.

Corroborating the blast radius: `nhangen/shield-wall` captured on 2026-07-30 with `source: cursor` (no RTK hook), while `nhangen/claude-plugins` (Claude Code) last captured 2026-06-11. When `git commit` entered RTK's rewrite registry is not established; the mechanism is.