### PR TITLE
commit-capture: deliver the record on the channel Claude actually reads

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Both hooks are gated — they inspect the Bash command first and exit silently f
 
 **The two halves are one mechanism: register both or neither.** Whether a commit landed is decided by comparing `HEAD` before the call against `HEAD` after — the only signal that distinguishes a commit from a `git commit` that was rejected, aborted, short-circuited by `false &&`, or had nothing to commit. A tip that moved is necessary but not sufficient, so the post-hook also asks git *what* the move was: the old tip (or its parent, for an amend) has to be reachable from the new one, and the new commit's committer has to be you — a `git pull` that fast-forwards in front of a failed commit leaves someone else's commit at the tip.
 
-With only the PostToolUse half wired up there is no "before". The hook says so, on stdout, alongside every other reason a commit went uncaptured — a hook that exits 0 has its stdout read, and nothing documented reads its stderr, so a diagnostic written there would be indistinguishable from silence. Only a line beginning `obsidian-commit-capture: hash=` is a record.
+With only the PostToolUse half wired up there is no "before". The hook says so, alongside every other reason a commit went uncaptured. Everything it says — the record and every diagnostic — is delivered as `hookSpecificOutput.additionalContext`, which is the only channel a PostToolUse hook has on exit 0: bare stdout goes to the debug log rather than the transcript. Only a line beginning `obsidian-commit-capture: hash=` is a record.
 
 ## Examples
 

--- a/scripts/commit-capture.sh
+++ b/scripts/commit-capture.sh
@@ -22,12 +22,37 @@ case "$INPUT" in
   *) exit 0 ;;
 esac
 
-# Diagnostics go to stdout, not stderr. A hook that exits 0 has its stdout read
-# (that is how the record below reaches the skill at all); exit-0 stderr has no
-# documented surface, so a "not captured" line written there is indistinguishable
-# from dropping the capture in silence. The skill knows that only a line starting
+# Everything this hook has to say — the record and every "not captured" line —
+# leaves through `hookSpecificOutput.additionalContext`, because that is the only
+# channel a PostToolUse hook has on exit 0. Bare stdout goes to the debug log and
+# not the transcript; the documented exceptions whose plain stdout becomes context
+# are UserPromptSubmit, UserPromptExpansion and SessionStart, and this is none of
+# them. Printing the record as text meant the gate could work perfectly and the
+# skill still never heard about the commit.
+#
+# Messages accumulate and one envelope is emitted from an EXIT trap: the hook has
+# a dozen exit points, two of them (`partial —` plus the record) say two things,
+# and two JSON documents on stdout parse as neither. The skill's contract is
+# unchanged — the text inside is the same, and only a line starting
 # `obsidian-commit-capture: hash=` is a record.
-say() { printf 'obsidian-commit-capture: %s\n' "$1"; }
+CC_OUT=""
+say() { CC_OUT="${CC_OUT}obsidian-commit-capture: $1"$'\n'; }
+cc_deliver() {
+  local s="$CC_OUT"
+  [ -n "$s" ] || return 0
+  # Order matters: double the backslashes before introducing any of our own.
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\t'/\\t}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\n'/\\n}"
+  # A raw control byte is not legal in a JSON string, and a commit author picks
+  # the subject. Anything left after the escapes above gets dropped rather than
+  # allowed to make the envelope unparseable.
+  s="$(printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037\177')"
+  printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"%s"}}\n' "$s"
+}
+trap cc_deliver EXIT
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LIB="${SCRIPT_DIR}/lib/commit-capture-parse.sh"
@@ -390,5 +415,5 @@ fi
 # put an attacker-chosen org_repo and vault_path *ahead* of the real ones, and
 # whoever parses the first match resolves a path outside the vault. Last means
 # every parseable field precedes anything a commit author can influence.
-printf 'obsidian-commit-capture: hash=%s | branch=%s | files=%s | org_repo=%s | repo_name=%s | ticket=%s | date=%s | time=%s | vault_path=%s | msg=%s\n' \
-  "$HASH" "$BRANCH" "$FILES" "$ORG_REPO" "$REPO_NAME" "$TICKET" "$TODAY" "$NOW" "$VAULT_PATH" "$MSG"
+say "$(printf 'hash=%s | branch=%s | files=%s | org_repo=%s | repo_name=%s | ticket=%s | date=%s | time=%s | vault_path=%s | msg=%s' \
+  "$HASH" "$BRANCH" "$FILES" "$ORG_REPO" "$REPO_NAME" "$TICKET" "$TODAY" "$NOW" "$VAULT_PATH" "$MSG")"

--- a/skills/commit-capture/SKILL.md
+++ b/skills/commit-capture/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: commit-capture
 description: Captures conversation context around git commits to Obsidian vault. Fires automatically via PostToolUse hook.
-version: 2.3.0
+version: 2.4.0
 ---
 
 # Commit Capture
@@ -12,7 +12,7 @@ The value here is not commit metadata — git already has that. The value is the
 
 Detection and metadata extraction are handled by two shell hooks (zero AI cost): `scripts/commit-capture-pre.sh` records `HEAD` before a `git commit` runs, and `scripts/commit-capture.sh` captures only if `HEAD` moved. This skill is invoked when the post-hook outputs a line starting with `obsidian-commit-capture:` — all metadata is inline, no file read needed.
 
-**Only a line beginning `obsidian-commit-capture: hash=` is a record.** The hook uses the same channel for diagnostics, because a hook that exits 0 has its stdout read and nothing documented reads its stderr — a "not captured" line written there would be indistinguishable from dropping the capture in silence. Two other prefixes exist:
+**Only a line beginning `obsidian-commit-capture: hash=` is a record.** Records and diagnostics arrive the same way, wrapped in a system reminder next to the tool result: a PostToolUse hook that exits 0 reaches Claude only through `hookSpecificOutput.additionalContext`, so that is where both go. Two other prefixes exist:
 
 - `obsidian-commit-capture: not captured — …` — nothing was captured, and the rest of the line says why. Do not write a note. Surface the reason if the user asks why a commit went uncaptured, or if it names a fix (an unregistered hook, an unwritable state dir, a missing `vault_path`).
 - `obsidian-commit-capture: partial — …` — a record follows, but the call made more commits than the one captured, and the line lists the shas that were skipped. Write the note for the record; mention the skipped shas only if the user is reconciling history.

--- a/tests/commit-capture-head-gate.sh
+++ b/tests/commit-capture-head-gate.sh
@@ -528,6 +528,56 @@ if [ -n "$(ls -A "${STATE_HOME}/claude-obsidian/pre-commit-head" 2>/dev/null)" ]
   fail "the snapshot survived a capture behind a wrapper"
 fi
 
+# --- 21. the record is delivered on the only channel Claude reads -------------
+# `PostToolUse` plain stdout goes to the debug log, not the transcript: the docs
+# list only UserPromptSubmit, UserPromptExpansion and SessionStart as the events
+# whose bare stdout becomes context. On exit 0 the sole way to reach the model is
+# hookSpecificOutput.additionalContext, which is inserted next to the tool result.
+# Printing the record as bare text meant the gate worked and the skill never heard
+# about it (issue #75).
+reset_state
+P="$(payload 'git commit -q -m x' "$REPO" call-21)"
+run_pre "$P"
+commit_in "$REPO" "delivered work"
+run_post_verbose "$P"
+python3 - "$POST_OUT" <<'EOF' || fail "the record was not delivered as PostToolUse additionalContext"$'\n'"got: ${POST_OUT:-<empty>}"
+import json, sys
+d = json.loads(sys.argv[1])
+h = d["hookSpecificOutput"]
+assert h["hookEventName"] == "PostToolUse", h
+ctx = h["additionalContext"]
+assert "obsidian-commit-capture: hash=" in ctx, ctx
+assert "org_repo=altamira2/mtf-builder" in ctx, ctx
+EOF
+
+# A diagnostic travels the same way — a "not captured" line printed as bare text
+# is as invisible as the record was.
+reset_state
+P="$(payload 'git commit -q -m x' "$REPO" call-21b)"
+commit_in "$REPO" "no snapshot for this one"
+run_post_verbose "$P"
+python3 - "$POST_OUT" <<'EOF' || fail "a diagnostic was not delivered as additionalContext"$'\n'"got: ${POST_OUT:-<empty>}"
+import json, sys
+d = json.loads(sys.argv[1])
+assert "not captured" in d["hookSpecificOutput"]["additionalContext"]
+EOF
+
+# The payload is JSON now, so anything a commit author controls has to be escaped
+# or the envelope is unparseable and the whole record is lost — a quote in a
+# subject is not exotic.
+reset_state
+P="$(payload 'git commit -q -m x' "$REPO" call-21c)"
+run_pre "$P"
+commit_in "$REPO" 'fix "quoted" and \backslash\ and	tab'
+run_post_verbose "$P"
+python3 - "$POST_OUT" <<'EOF' || fail "a quoted/backslashed subject broke the JSON envelope"$'\n'"got: ${POST_OUT:-<empty>}"
+import json, sys
+d = json.loads(sys.argv[1])
+ctx = d["hookSpecificOutput"]["additionalContext"]
+assert 'fix "quoted"' in ctx, ctx
+assert "backslash" in ctx, ctx
+EOF
+
 # --- wiring: both halves are registered on Bash ------------------------------
 # The pair is one mechanism. Shipping the post-hook without the pre-hook turns
 # every capture into a stderr diagnostic.

--- a/tests/commit-capture-vault-path.sh
+++ b/tests/commit-capture-vault-path.sh
@@ -159,12 +159,14 @@ GOT=$(run_case "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
 [ "$GOT" = "/Users/test/Vault" ] || fail "case8 (single-quoted): got '$GOT' want '/Users/test/Vault'"
 PASS_COUNT=$((PASS_COUNT + 1))
 
-# ----- Case 9: output preserves all metadata fields with vault_path appended -----
+# ----- Case 9: the record keeps every field, inside the delivery envelope -----
+# The envelope is asserted here too: a PostToolUse hook only reaches Claude through
+# hookSpecificOutput.additionalContext, so a bare record is a record nobody reads.
 CASE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-XXXXXX")"
 printf -- '---\nvault_path: /Users/test/v\n---\n' > "${CASE_DIR}/obsidian.local.md"
 OUT=$(run_case_raw "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
 case "$OUT" in
-  'obsidian-commit-capture: hash='*' | branch='*' | files='*' | org_repo='*' | repo_name='*' | ticket='*' | date='*' | time='*' | vault_path=/Users/test/v | msg='*) ;;
+  '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"obsidian-commit-capture: hash='*' | branch='*' | files='*' | org_repo='*' | repo_name='*' | ticket='*' | date='*' | time='*' | vault_path=/Users/test/v | msg='*) ;;
   *) fail "case9 (schema): got '$OUT'" ;;
 esac
 PASS_COUNT=$((PASS_COUNT + 1))


### PR DESCRIPTION
Closes #75

## Description (Issue Fixed & New Behavior)

A `PostToolUse` hook's bare stdout goes to the debug log, not the transcript. From the hooks docs:

> **Exit 0** means success. Claude Code parses stdout for JSON output fields… For most events, stdout is written to the debug log but not shown in the transcript. The exceptions are `UserPromptSubmit`, `UserPromptExpansion`, and `SessionStart`, where stdout is added as context that Claude can see and act on.

`PostToolUse` is not one of the exceptions. On exit 0 the only channel to the model is `hookSpecificOutput.additionalContext`, which the docs describe as wrapped in a system reminder and inserted next to the tool result.

So the record was being printed where nobody could read it. With 1.17.1 the gate is demonstrably correct — on a live commit the pre-hook's snapshot is written and the post-hook consumes it — and the vault still got no note, because the line describing the commit went to a debug log. Every `not captured` diagnostic went the same nowhere, which is why the whole thing took a payload probe to see at all.

Messages now accumulate and a single envelope is emitted from an `EXIT` trap. A trap rather than a flush before each `exit`: there are a dozen exit points, the `partial —` path says two things, and two JSON documents on stdout parse as neither. The text inside is byte-for-byte what it was, so the skill's contract is unchanged — a line beginning `obsidian-commit-capture: hash=` is still the only record.

Quotes, backslashes, tabs and stray control bytes are escaped or dropped. The commit subject is attacker-controlled and an unparseable envelope loses the entire record, not just the subject.

Corrects the reasoning in `commit-capture.sh`, `README.md` and `SKILL.md`, all of which asserted that exit-0 stdout is read. That claim came from PR #68's audit and was wrong for this event.

Bumps the plugin to 1.17.2 and the skill to 2.4.0.

## Testing Procedure

1. Check out this branch and run `bash tests/run-all.sh` — 31 suites, all pass. Also verified under `/bin/bash` 3.2.57.
2. Revert only `scripts/commit-capture.sh` (`git stash push scripts/commit-capture.sh`) and re-run `tests/commit-capture-head-gate.sh` and `tests/commit-capture-vault-path.sh`. Both fail — the first on a JSON decode of a bare record, the second on the case-9 schema.
3. Live check after installing 1.17.2 (`/plugin` update, then `/reload-plugins`): commit anything from a Claude Code session. The record should now arrive in the transcript as a system reminder next to the tool result. Before this change nothing arrived, on any channel, for a commit the hook had positively observed.

New coverage — head-gate case 21:

- the record is delivered as `hookSpecificOutput.additionalContext` with `hookEventName: "PostToolUse"`, parsed with `json.loads` rather than pattern-matched
- a `not captured` diagnostic travels the same way
- a subject containing `"`, `\` and a tab still yields a parseable envelope with the subject intact

vault-path case 9 now asserts the envelope around the field-order schema it already checked, so the delivery shape is pinned in two suites.

## Additional Notes / HelpScout Tickets

Third and last link in the chain that started with #48: the gate (#68), the wrapper in front of git (#73), and now the channel. The first two were verifiable from the tests; this one was invisible to every suite because a test harness reads the hook's stdout directly and the transcript does not.