### PR TITLE
commit-capture: write the snapshot atomically, and say so when it cannot

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.17.2",
+  "version": "1.18.0",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/scripts/commit-capture-pre.sh
+++ b/scripts/commit-capture-pre.sh
@@ -77,8 +77,19 @@ elif [ -z "$INTENT" ]; then
   exit 0
 fi
 
+# The one thing this hook says, and only when it has failed. Silence here used to
+# mean the post-hook reported "no PreToolUse HEAD snapshot for this call" and named
+# hook registration first — so an unwritable state dir looked like a setup mistake
+# and every commit was lost until someone read the wrong message. Reported through
+# additionalContext rather than a non-zero exit: exit 2 would block the commit, and
+# any other non-zero surfaces as a hook error on a call that is otherwise fine.
+warn() { cc_deliver_context PreToolUse "obsidian-commit-capture: $1"; }
+
 SNAP_DIR="$(cc_state_dir)/pre-commit-head"
-mkdir -p "$SNAP_DIR" 2>/dev/null || exit 0
+if ! mkdir -p "$SNAP_DIR" 2>/dev/null; then
+  warn "not captured — cannot create ${SNAP_DIR}; the commit this call makes will not be captured"
+  exit 0
+fi
 
 # A snapshot is consumed by the post-hook, which deletes it. One is left behind
 # whenever the tool call never completes (denied, interrupted, session killed),
@@ -87,10 +98,30 @@ mkdir -p "$SNAP_DIR" 2>/dev/null || exit 0
 find "$SNAP_DIR" -type f -mtime +1 -delete 2>/dev/null || true
 
 KEY="$(cc_snapshot_key "$INPUT")"
+SNAP_FILE="${SNAP_DIR}/${KEY}"
+# Written to a temp name and renamed into place. A direct `> file` truncates before
+# it writes, so a full disk or a killed shell mid-write leaves a file holding half a
+# snapshot — and half a snapshot still parses: a `sha=` line with no `root=` reads as
+# a snapshot about no particular repository. Rename is atomic within a directory, so
+# a reader sees either the previous snapshot or the complete new one. The temp name
+# carries $$ so two calls cannot land on each other's.
+#
 # One `key=value` per line, and every value is newline-free: sha passes a hex check,
 # root comes from rev-parse, and a newline cannot survive the payload decode into a
 # single shell token. The post-hook reads the keys it knows and ignores the rest, so
 # adding a field does not strand an in-flight snapshot from an older version.
-{ printf 'sha=%s\nroot=%s\nintent=%s\n' "$SHA" "$ROOT" "$INTENT" > "${SNAP_DIR}/${KEY}"; } 2>/dev/null || true
+TMP_FILE="${SNAP_DIR}/.tmp.${KEY}.$$"
+WROTE=0
+if { printf 'sha=%s\nroot=%s\nintent=%s\n' "$SHA" "$ROOT" "$INTENT" > "$TMP_FILE"; } 2>/dev/null; then
+  if mv -f "$TMP_FILE" "$SNAP_FILE" 2>/dev/null; then
+    WROTE=1
+  fi
+fi
+if [ "$WROTE" -eq 0 ]; then
+  # Leaving the temp file would hand the daily sweep — and anything globbing the
+  # directory — a file that is not a snapshot.
+  rm -f "$TMP_FILE" 2>/dev/null || true
+  warn "not captured — could not write the HEAD snapshot under ${SNAP_DIR} (check permissions and free space); the commit this call makes will not be captured"
+fi
 
 exit 0

--- a/scripts/commit-capture.sh
+++ b/scripts/commit-capture.sh
@@ -35,6 +35,11 @@ esac
 # and two JSON documents on stdout parse as neither. The skill's contract is
 # unchanged — the text inside is the same, and only a line starting
 # `obsidian-commit-capture: hash=` is a record.
+#
+# Deliberately NOT the shared cc_deliver_context: two of this hook's messages report
+# that the parsing library is missing or unloadable, and a delivery path that lived in
+# that library could not deliver them. The pre-hook, which has nothing to say until
+# after the library loads, uses the shared one.
 CC_OUT=""
 say() { CC_OUT="${CC_OUT}obsidian-commit-capture: $1"$'\n'; }
 cc_deliver() {

--- a/scripts/lib/commit-capture-parse.sh
+++ b/scripts/lib/commit-capture-parse.sh
@@ -247,6 +247,35 @@ cc_state_dir() {
   printf '%s' "${XDG_STATE_HOME:-$HOME/.local/state}/claude-obsidian"
 }
 
+# Anything either hook says reaches Claude only as hookSpecificOutput.additionalContext:
+# bare stdout on exit 0 goes to the debug log for both PreToolUse and PostToolUse, and
+# the only alternatives — exit 2, or a permissionDecision — block or error the very
+# commit we are trying to observe. Shared here so the two hooks cannot drift on either
+# the envelope or the escaping.
+#
+# The escaping is not decorative: a commit subject reaches this, and an unparseable
+# envelope loses the whole message rather than the subject.
+cc_json_escape() {
+  local s="$1"
+  # Backslashes first, or the escapes added below get doubled.
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\t'/\\t}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\n'/\\n}"
+  # No raw control byte is legal in a JSON string, and nothing above covers them.
+  printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037\177'
+}
+
+# $1 = hook event name, $2 = text. Emits nothing for empty text so a caller can
+# flush unconditionally.
+cc_deliver_context() {
+  local event="$1" text="$2"
+  [ -n "$text" ] || return 0
+  printf '{"hookSpecificOutput":{"hookEventName":"%s","additionalContext":"%s"}}\n' \
+    "$event" "$(cc_json_escape "$text")"
+}
+
 # Keyed on a bounded digest rather than a slug of the raw value: slugging split
 # one repo across several keys and, in a deep worktree, exceeded NAME_MAX.
 # The fallback keeps the value's own bytes (filtered to a filename-safe set, then

--- a/skills/commit-capture/SKILL.md
+++ b/skills/commit-capture/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: commit-capture
 description: Captures conversation context around git commits to Obsidian vault. Fires automatically via PostToolUse hook.
-version: 2.4.0
+version: 2.4.1
 ---
 
 # Commit Capture
@@ -12,7 +12,7 @@ The value here is not commit metadata — git already has that. The value is the
 
 Detection and metadata extraction are handled by two shell hooks (zero AI cost): `scripts/commit-capture-pre.sh` records `HEAD` before a `git commit` runs, and `scripts/commit-capture.sh` captures only if `HEAD` moved. This skill is invoked when the post-hook outputs a line starting with `obsidian-commit-capture:` — all metadata is inline, no file read needed.
 
-**Only a line beginning `obsidian-commit-capture: hash=` is a record.** Records and diagnostics arrive the same way, wrapped in a system reminder next to the tool result: a PostToolUse hook that exits 0 reaches Claude only through `hookSpecificOutput.additionalContext`, so that is where both go. Two other prefixes exist:
+**Only a line beginning `obsidian-commit-capture: hash=` is a record.** Records and diagnostics arrive the same way, wrapped in a system reminder next to the tool result: a hook that exits 0 reaches Claude only through `hookSpecificOutput.additionalContext`, so that is where both go. A `not captured` line can also arrive from the *pre*-hook, before the commit runs, when it could not write its HEAD snapshot — the failure is reported by the half that hit it. Two other prefixes exist:
 
 - `obsidian-commit-capture: not captured — …` — nothing was captured, and the rest of the line says why. Do not write a note. Surface the reason if the user asks why a commit went uncaptured, or if it names a fix (an unregistered hook, an unwritable state dir, a missing `vault_path`).
 - `obsidian-commit-capture: partial — …` — a record follows, but the call made more commits than the one captured, and the line lists the shas that were skipped. Write the note for the record; mention the skipped shas only if the user is reconciling history.

--- a/tests/commit-capture-head-gate.sh
+++ b/tests/commit-capture-head-gate.sh
@@ -23,6 +23,9 @@ STATE_HOME=""
 fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 cleanup() {
   [ -n "$WORK" ] && rm -rf "$WORK"
+  # A case below makes the snapshot dir unwritable; without restoring the bit,
+  # rm -rf leaves the tree behind and every later run inherits it.
+  [ -n "$STATE_HOME" ] && chmod -R u+w "$STATE_HOME" 2>/dev/null
   [ -n "$STATE_HOME" ] && rm -rf "$STATE_HOME"
   [ -n "${ISOLATED_XDG:-}" ] && rm -rf "$ISOLATED_XDG"
   return 0
@@ -84,6 +87,15 @@ run_pre() {
   local rc=0
   ( cd "$WORK" && printf '%s' "$1" | XDG_STATE_HOME="$STATE_HOME" bash "$PRE" ) || rc=$?
   [ "$rc" -eq 0 ] || fail "pre-hook exited $rc — a non-zero PreToolUse hook blocks the Bash call"
+}
+# Pre with output captured; sets PRE_OUT and PRE_ERR. Same cwd rule as run_pre.
+run_pre_verbose() {
+  local err rc=0
+  err="$(mktemp)"
+  PRE_OUT="$( cd "$WORK" && printf '%s' "$1" | XDG_STATE_HOME="$STATE_HOME" bash "$PRE" 2>"$err" )" || rc=$?
+  PRE_ERR="$(cat "$err")"
+  rm -f "$err"
+  [ "$rc" -eq 0 ] || fail "pre-hook exited $rc — a non-zero PreToolUse hook blocks or errors the Bash call"
 }
 # Post with stderr captured; sets POST_OUT and POST_ERR.
 run_post_verbose() {
@@ -577,6 +589,60 @@ ctx = d["hookSpecificOutput"]["additionalContext"]
 assert 'fix "quoted"' in ctx, ctx
 assert "backslash" in ctx, ctx
 EOF
+
+# --- 22. an unwritable state dir is reported by the hook that failed ----------
+# Before this, the pre-hook exited 0 having written nothing and said nothing, and
+# the post-hook then blamed hook registration for the loss (#71). The hook that
+# actually failed has to be the one that speaks — and it speaks through
+# additionalContext, since PreToolUse bare stdout is no more visible than
+# PostToolUse's and exit 2 would block the commit outright.
+reset_state
+mkdir -p "$SNAP_DIR"
+chmod 500 "$SNAP_DIR"
+P="$(payload 'git commit -q -m x' "$REPO" call-22)"
+run_pre_verbose "$P"
+chmod u+w "$SNAP_DIR"
+python3 - "$PRE_OUT" <<'EOF' || fail "an unwritable snapshot dir was not reported by the pre-hook"$'\n'"stdout: ${PRE_OUT:-<empty>}"$'\n'"stderr: ${PRE_ERR:-<empty>}"
+import json, sys
+d = json.loads(sys.argv[1])
+h = d["hookSpecificOutput"]
+assert h["hookEventName"] == "PreToolUse", h
+ctx = h["additionalContext"]
+assert "not captured" in ctx, ctx
+assert "pre-commit-head" in ctx, ctx
+EOF
+# Reporting a failure must not smuggle in a permission decision — the commit still runs.
+case "$PRE_OUT" in
+  *permissionDecision*) fail "the pre-hook's failure report carried a permission decision" ;;
+esac
+[ -z "$PRE_ERR" ] || fail "the pre-hook wrote to stderr: $PRE_ERR"
+# And nothing may be left behind that a later call could read as a snapshot.
+if [ -n "$(ls -A "$SNAP_DIR" 2>/dev/null)" ]; then
+  fail "a failed snapshot write left a file behind: $(ls -A "$SNAP_DIR")"
+fi
+
+# --- 23. the snapshot is swapped into place, not written through -------------
+# A direct `> file` truncates first: a crash or a full disk mid-write leaves a
+# half-written snapshot that parses as a valid one (a `sha=` line and nothing
+# else). Writing a temp file and renaming means a reader sees the old snapshot or
+# the new one. Observable as an inode change — truncate-in-place keeps it.
+reset_state
+mkdir -p "$SNAP_DIR"
+P="$(payload 'git commit -q -m x' "$REPO" call-23)"
+KEY_FILE="${SNAP_DIR}/$( . "${ROOT_DIR}/scripts/lib/commit-capture-parse.sh"; cc_snapshot_key "$P" )"
+printf 'sha=stale\nroot=/nowhere\nintent=\n' > "$KEY_FILE"
+INODE_BEFORE="$(ls -i "$KEY_FILE" | awk '{print $1}')"
+run_pre "$P"
+INODE_AFTER="$(ls -i "$KEY_FILE" | awk '{print $1}')"
+[ "$INODE_BEFORE" != "$INODE_AFTER" ] || fail "the snapshot was written in place (inode $INODE_BEFORE unchanged) — a partial write would be readable"
+# Compare against the resolved toplevel: on macOS $TMPDIR is a symlink, so the
+# hook records /private/var/... where $REPO says /var/....
+REPO_TOP="$(git -C "$REPO" rev-parse --show-toplevel)"
+grep -q "^root=${REPO_TOP}\$" "$KEY_FILE" || fail "the replaced snapshot does not describe this repo"$'\n'"$(cat "$KEY_FILE")"
+# The temp file is an implementation detail and must not survive as a snapshot.
+if ls -A "$SNAP_DIR" | grep -qv "^$(basename "$KEY_FILE")\$"; then
+  fail "a temp file was left in the snapshot dir: $(ls -A "$SNAP_DIR")"
+fi
 
 # --- wiring: both halves are registered on Bash ------------------------------
 # The pair is one mechanism. Shipping the post-hook without the pre-hook turns


### PR DESCRIPTION
Closes #71

## Description (Issue Fixed & New Behavior)

Two failures the pre-hook used to absorb in silence.

**It said nothing when it could not write.** On a read-only or full state dir the write was a no-op and the hook exited 0 silently. The post-hook then reported `no PreToolUse HEAD snapshot for this call` and named hook registration as the first candidate — so an unwritable directory read as a setup mistake while every commit went unrecorded. The half that actually failed now says so.

Reported through `PreToolUse` `hookSpecificOutput.additionalContext`, which resolves the open question in #71 (*"only exit 2 blocks a Bash call, so a non-zero exit is available — but it surfaces as an error on every commit… decide deliberately"*). Neither exit path is right: exit 2 blocks the commit, any other non-zero shows a hook error on a call that is otherwise fine. `additionalContext` — established as the only channel that reaches Claude on exit 0 while fixing #75 — carries the message with no effect on the commit.

**The write truncated before writing.** Half a snapshot still parses: a `sha=` line with no `root=` reads as a snapshot about no particular repository. It now writes a temp file and renames into place, so a reader sees the previous snapshot or the complete new one, never a fragment. The temp name carries `$$` so concurrent calls can't collide, and it's removed on failure so nothing that isn't a snapshot is left in the directory.

The envelope and its escaping move into the shared lib as `cc_deliver_context`, now that both hooks emit one. The post-hook deliberately keeps its own copy — two of its messages report that the parsing lib is missing or unloadable, and a delivery path living in that lib could not deliver them. That's commented at the call site.

Bumps the plugin to 1.18.0.

## Testing Procedure

1. Check out this branch and run `bash tests/run-all.sh` — 31 suites, all pass. Also verified under `/bin/bash` 3.2.57.
2. `chmod 500` case — revert `scripts/commit-capture-pre.sh` and re-run `tests/commit-capture-head-gate.sh`: case 22 fails with `an unwritable snapshot dir was not reported by the pre-hook`.
3. Atomicity case — change the write back to `> "$SNAP_FILE"` (keeping everything else) and re-run: case 23 fails with `the snapshot was written in place (inode … unchanged)`.
4. Live: `chmod 500 ~/.local/state/claude-obsidian/pre-commit-head`, commit anything, and confirm the pre-hook reports the unwritable directory before the commit runs instead of the post-hook blaming registration afterwards. `chmod u+w` to restore.

New coverage in head-gate:

- **case 22** — unwritable snapshot dir: the pre-hook emits a `PreToolUse` envelope naming the directory, exits 0, writes nothing to stderr, carries no `permissionDecision` (the commit must still run), and leaves no file behind.
- **case 23** — the target file's inode changes across the write, which truncate-in-place cannot do; also asserts the replaced snapshot describes the right repo and no temp file survives.

Suite cleanup now restores the write bit on `$STATE_HOME` before `rm -rf`, or case 22's `chmod 500` would strand the tree.

## Additional Notes / HelpScout Tickets

#71's companion claim from the #68 panel — that a stale snapshot then fabricates a capture — did not reproduce, and nothing here relies on it.