### PR TITLE
commit-capture: one record per commit when a call makes several

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/scripts/commit-capture.sh
+++ b/scripts/commit-capture.sh
@@ -180,15 +180,17 @@ fi
 # working for two minutes afterwards — `git commit && npm test` lost the note, with
 # no output on any stream). It is kept only for the blind case below, where there is
 # no before-image to reason from.
+RANGE_BASE=""
 if [ "$SNAP_STATE" = "trusted" ] && [ "$HEAD_BEFORE" != "none" ]; then
   # An amend or a reset-then-commit makes the old tip a sibling, not an ancestor,
   # so its parent is what has to be reachable.
   if GIT merge-base --is-ancestor "$HEAD_BEFORE" "$FULL_SHA" >/dev/null 2>&1; then
-    :
+    RANGE_BASE="$HEAD_BEFORE"
   elif GIT merge-base --is-ancestor "${HEAD_BEFORE}^" "$FULL_SHA" >/dev/null 2>&1; then
     # …but landing exactly ON that parent is an undo, not a commit.
     BEFORE_PARENT=$(GIT rev-parse "${HEAD_BEFORE}^" 2>/dev/null) || BEFORE_PARENT=""
     [ "$BEFORE_PARENT" != "$FULL_SHA" ] || exit 0
+    RANGE_BASE="${HEAD_BEFORE}^"
   else
     exit 0
   fi
@@ -224,6 +226,42 @@ fi
 
 HASH=$(GIT rev-parse --short HEAD 2>/dev/null) || exit 0
 
+# Which commits did this call make? Oldest first, so appending the records to a
+# daily note reads in the order the work happened. Without a trusted before-image
+# there is no range to walk and the tip is all we can claim.
+SHAS="$FULL_SHA"
+if [ -n "$RANGE_BASE" ]; then
+  RANGE_LIST=$(GIT rev-list --reverse "${RANGE_BASE}..${FULL_SHA}" 2>/dev/null) || RANGE_LIST=""
+  [ -z "$RANGE_LIST" ] || SHAS="$RANGE_LIST"
+fi
+SHA_COUNT=0
+for SHA_ONE in $SHAS; do
+  SHA_COUNT=$(( SHA_COUNT + 1 ))
+done
+
+# A record per commit is unbounded in principle — a scripted loop over paths can
+# make dozens, and each one costs the skill a note. Cap it, and name what the cap
+# dropped: a truncated capture is indistinguishable from a complete one otherwise.
+MAX_RECORDS="${OBSIDIAN_COMMIT_MAX_RECORDS:-20}"
+case "$MAX_RECORDS" in
+  ''|*[!0-9]*|0) MAX_RECORDS=20 ;;
+esac
+if [ "$SHA_COUNT" -gt "$MAX_RECORDS" ]; then
+  KEPT=""
+  SKIPPED=""
+  N=0
+  for SHA_ONE in $SHAS; do
+    N=$(( N + 1 ))
+    if [ "$N" -le "$MAX_RECORDS" ]; then
+      KEPT="${KEPT}${SHA_ONE}"$'\n'
+    else
+      SKIPPED="${SKIPPED}$(GIT rev-parse --short "$SHA_ONE" 2>/dev/null) "
+    fi
+  done
+  SHAS="$KEPT"
+  say "partial — this call made ${SHA_COUNT} commits; the oldest ${MAX_RECORDS} are captured, skipped: ${SKIPPED% }"
+fi
+
 # The record below is ` | `-delimited and the skill parses it by field name, turning
 # org_repo into a path under the vault and vault_path into a --vault argument. Any
 # field a commit author controls can therefore inject its own `org_repo=` /
@@ -239,26 +277,23 @@ scrub_field() {
   printf '%s' "$s"
 }
 
-MSG=$(GIT log -1 --pretty=format:'%s' 2>/dev/null) || MSG=""
-MSG="$(scrub_field "$MSG")"
 BRANCH=$(GIT rev-parse --abbrev-ref HEAD 2>/dev/null) || BRANCH="unknown"
 BRANCH="$(scrub_field "$BRANCH")"
-FILES_RAW=$(GIT diff --name-only HEAD~1..HEAD 2>/dev/null) || FILES_RAW=""
-FILES=$(printf '%s' "$FILES_RAW" | tr '\n' ',' | sed 's/,$//')
-FILES="$(scrub_field "$FILES")"
 
-# One snapshot answers for one invocation, so a call that made several commits emits
-# one record — for the tip. Name the others: a silent partial capture reads exactly
-# like a complete one.
-if [ "$SNAP_STATE" = "trusted" ] && [ "$HEAD_BEFORE" != "none" ]; then
-  EXTRA=$(GIT rev-list --count "${HEAD_BEFORE}..${FULL_SHA}" 2>/dev/null) || EXTRA=""
-  case "$EXTRA" in
-    ''|*[!0-9]*) ;;
-    *) if [ "$EXTRA" -gt 1 ]; then
-         say "partial — this call made ${EXTRA} commits; only ${HASH} is captured, skipped: $(GIT log --format=%h "${HEAD_BEFORE}..${FULL_SHA}^" 2>/dev/null | tr '\n' ' ')"
-       fi ;;
-  esac
-fi
+# The subject and the file list are per commit; everything else below (branch,
+# org_repo, vault_path, the clock) is a property of the call and is shared.
+cc_files_for() {
+  local sha="$1" raw=""
+  raw=$(GIT diff --name-only "${sha}~1..${sha}" 2>/dev/null) || raw=""
+  # A root commit has no ~1, and a merge's diff against its first parent is not
+  # what it changed; --root handles the first and prints nothing for the second,
+  # which is honest — a merge introduces no paths of its own.
+  if [ -z "$raw" ]; then
+    raw=$(GIT diff-tree --no-commit-id --name-only -r --root "$sha" 2>/dev/null) || raw=""
+  fi
+  printf '%s' "$raw" | tr '\n' ',' | sed 's/,$//'
+}
+
 REMOTE=$(GIT remote get-url origin 2>/dev/null) || REMOTE="local"
 REPO_NAME=${REPO_ROOT##*/}
 : "${REPO_NAME:=unknown}"
@@ -420,5 +455,13 @@ fi
 # put an attacker-chosen org_repo and vault_path *ahead* of the real ones, and
 # whoever parses the first match resolves a path outside the vault. Last means
 # every parseable field precedes anything a commit author can influence.
-say "$(printf 'hash=%s | branch=%s | files=%s | org_repo=%s | repo_name=%s | ticket=%s | date=%s | time=%s | vault_path=%s | msg=%s' \
-  "$HASH" "$BRANCH" "$FILES" "$ORG_REPO" "$REPO_NAME" "$TICKET" "$TODAY" "$NOW" "$VAULT_PATH" "$MSG")"
+#
+# One record per commit this call made, oldest first. The skill reads each line
+# independently, so several records from one invocation need no new contract.
+for SHA_ONE in $SHAS; do
+  ONE_HASH=$(GIT rev-parse --short "$SHA_ONE" 2>/dev/null) || continue
+  ONE_MSG=$(GIT log -1 --pretty=format:'%s' "$SHA_ONE" 2>/dev/null) || ONE_MSG=""
+  say "$(printf 'hash=%s | branch=%s | files=%s | org_repo=%s | repo_name=%s | ticket=%s | date=%s | time=%s | vault_path=%s | msg=%s' \
+    "$ONE_HASH" "$BRANCH" "$(scrub_field "$(cc_files_for "$SHA_ONE")")" "$ORG_REPO" "$REPO_NAME" \
+    "$TICKET" "$TODAY" "$NOW" "$VAULT_PATH" "$(scrub_field "$ONE_MSG")")"
+done

--- a/skills/commit-capture/SKILL.md
+++ b/skills/commit-capture/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: commit-capture
 description: Captures conversation context around git commits to Obsidian vault. Fires automatically via PostToolUse hook.
-version: 2.4.1
+version: 2.5.0
 ---
 
 # Commit Capture
@@ -10,12 +10,12 @@ The value here is not commit metadata — git already has that. The value is the
 
 ## Architecture
 
-Detection and metadata extraction are handled by two shell hooks (zero AI cost): `scripts/commit-capture-pre.sh` records `HEAD` before a `git commit` runs, and `scripts/commit-capture.sh` captures only if `HEAD` moved. This skill is invoked when the post-hook outputs a line starting with `obsidian-commit-capture:` — all metadata is inline, no file read needed.
+Detection and metadata extraction are handled by two shell hooks (zero AI cost): `scripts/commit-capture-pre.sh` records `HEAD` before a `git commit` runs, and `scripts/commit-capture.sh` captures only if `HEAD` moved. This skill is invoked when the post-hook outputs a line starting with `obsidian-commit-capture:` — all metadata is inline, no file read needed. **One invocation can carry several records**, one per commit the call made, oldest first: write a note for each, in order.
 
 **Only a line beginning `obsidian-commit-capture: hash=` is a record.** Records and diagnostics arrive the same way, wrapped in a system reminder next to the tool result: a hook that exits 0 reaches Claude only through `hookSpecificOutput.additionalContext`, so that is where both go. A `not captured` line can also arrive from the *pre*-hook, before the commit runs, when it could not write its HEAD snapshot — the failure is reported by the half that hit it. Two other prefixes exist:
 
 - `obsidian-commit-capture: not captured — …` — nothing was captured, and the rest of the line says why. Do not write a note. Surface the reason if the user asks why a commit went uncaptured, or if it names a fix (an unregistered hook, an unwritable state dir, a missing `vault_path`).
-- `obsidian-commit-capture: partial — …` — a record follows, but the call made more commits than the one captured, and the line lists the shas that were skipped. Write the note for the record; mention the skipped shas only if the user is reconciling history.
+- `obsidian-commit-capture: partial — …` — more commits were made than the cap allows; the records that follow are the oldest `OBSIDIAN_COMMIT_MAX_RECORDS` (20 by default) and the line lists the shas beyond it. Write a note per record; mention the skipped shas only if the user is reconciling history.
 
 The actual write goes through the **keeper CLI** (`scripts/keeper append`) — the
 keeper's deterministic write primitive. The CLI creates the file on absence,

--- a/tests/commit-capture-detection.sh
+++ b/tests/commit-capture-detection.sh
@@ -59,6 +59,14 @@ case "\$*" in
   "config user.email") echo tester@example.com ;;
   "log -1 --format=%ce") echo tester@example.com ;;
   "rev-list --count "*) echo 1 ;;
+  # One record per commit: the hook walks the range, then asks each sha for its
+  # short hash, subject and paths. A single-commit range keeps these cases about
+  # detection rather than about the walk (head-gate covers the walk on real repos).
+  "rev-list --reverse "*) echo 0123456789abcdef0123456789abcdef01234567 ;;
+  "rev-parse --short "*) echo abc1234 ;;
+  "log -1 --pretty=format:%s "*) echo "test commit" ;;
+  "diff --name-only "*) echo foo.txt ;;
+  "diff-tree --no-commit-id --name-only -r --root "*) echo foo.txt ;;
   *) echo "unexpected git argv: \$*" >&2; exit 99 ;;
 esac
 STUB

--- a/tests/commit-capture-head-gate.sh
+++ b/tests/commit-capture-head-gate.sh
@@ -457,21 +457,70 @@ case "$POST_OUT" in
   *'hash='*) fail "a diagnostic was emitted in record form; the skill would file a note for it"$'\n'"got: $POST_OUT" ;;
 esac
 
-# --- 18. a call that made several commits says so ---------------------------
+# --- 18. a call that made several commits emits a record for each ------------
+# It used to record the tip and name the rest in a `partial` line, so the earlier
+# commits reached the vault as a mention inside another commit's note, or not at
+# all (#70). A split-commit sequence is the normal shape here — one commit per
+# review concern, per implementing-review-feedback.
 reset_state
 P="$(payload 'git commit -q -m one && git commit -q -m two' "$REPO" call-18)"
 run_pre "$P"
 commit_in "$REPO" "commit one"
 commit_in "$REPO" "commit two"
 run_post_verbose "$P"
-case "$POST_OUT" in
-  *'partial —'*) : ;;
-  *) fail "two commits in one call captured one and said nothing about the other"$'\n'"got: ${POST_OUT:-<empty>}" ;;
-esac
-case "$POST_OUT" in
-  *'msg=commit two'*) : ;;
-  *) fail "the tip commit was not the one captured"$'\n'"got: $POST_OUT" ;;
-esac
+python3 - "$POST_OUT" <<'EOF' || fail "two commits in one call did not produce two records"$'\n'"got: ${POST_OUT:-<empty>}"
+import json, sys
+ctx = json.loads(sys.argv[1])["hookSpecificOutput"]["additionalContext"]
+recs = [l for l in ctx.splitlines() if l.startswith("obsidian-commit-capture: hash=")]
+assert len(recs) == 2, recs
+# Oldest first, so appending them to a daily note reads in the order they happened.
+assert "msg=commit one" in recs[0], recs
+assert "msg=commit two" in recs[1], recs
+assert recs[0].split(" | ")[0] != recs[1].split(" | ")[0], recs
+assert "partial" not in ctx, ctx
+EOF
+
+# Per-commit `files=`. The old field came from HEAD~1..HEAD of whatever the tip
+# was, so a record for an earlier commit would have claimed the tip's paths.
+reset_state
+P="$(payload 'git commit -q -m a && git commit -q -m b' "$REPO" call-18b)"
+run_pre "$P"
+: > "$REPO/only-in-first.txt"
+git -C "$REPO" add only-in-first.txt
+git -C "$REPO" commit -q -m "first of two"
+: > "$REPO/only-in-second.txt"
+git -C "$REPO" add only-in-second.txt
+git -C "$REPO" commit -q -m "second of two"
+run_post_verbose "$P"
+python3 - "$POST_OUT" <<'EOF' || fail "records did not carry per-commit file lists"$'\n'"got: ${POST_OUT:-<empty>}"
+import json, sys
+ctx = json.loads(sys.argv[1])["hookSpecificOutput"]["additionalContext"]
+recs = [l for l in ctx.splitlines() if l.startswith("obsidian-commit-capture: hash=")]
+assert len(recs) == 2, recs
+assert "files=only-in-first.txt" in recs[0], recs[0]
+assert "files=only-in-second.txt" in recs[1], recs[1]
+EOF
+
+# --- 18c. the cap is announced, never silent --------------------------------
+# One record per commit is unbounded in principle — a scripted loop could make
+# dozens. Capping is fine; capping quietly is not, because a truncated capture
+# reads exactly like a complete one.
+reset_state
+P="$(payload 'git commit -q -m loop' "$REPO" call-18c)"
+run_pre "$P"
+for i in 1 2 3 4; do commit_in "$REPO" "loop commit $i"; done
+export OBSIDIAN_COMMIT_MAX_RECORDS=2
+run_post_verbose "$P"
+unset OBSIDIAN_COMMIT_MAX_RECORDS
+python3 - "$POST_OUT" <<'EOF' || fail "a capped multi-commit capture did not announce what it dropped"$'\n'"got: ${POST_OUT:-<empty>}"
+import json, sys
+ctx = json.loads(sys.argv[1])["hookSpecificOutput"]["additionalContext"]
+recs = [l for l in ctx.splitlines() if l.startswith("obsidian-commit-capture: hash=")]
+assert len(recs) == 2, recs
+partial = [l for l in ctx.splitlines() if "partial" in l]
+assert partial, ctx
+assert "4" in partial[0], partial
+EOF
 
 # --- 19. a path or branch cannot inject a field ahead of a real one ---------
 # `|` is legal in a filename and in a refname, and files=/branch= both precede


### PR DESCRIPTION
Closes #70

## Description (Issue Fixed & New Behavior)

A Bash call that committed twice produced one record — for the tip — and named the rest in a `partial` line. The earlier commits reached the vault as a mention inside another commit's note, or not at all. That's the normal shape here, not an edge case: one commit per review concern per `implementing-review-feedback`, a scripted split-commit sequence, a `for` loop over paths.

The hook now walks `rev-list --reverse <base>..HEAD` and emits a record per commit, **oldest first**, so appending them to a daily note reads in the order the work happened. The base is whichever ref satisfied the ancestry check, so an amend or a reset-then-commit still walks from the right place.

`files=` is now scoped per commit. It came from `HEAD~1..HEAD` of the tip, so any record but the last would have claimed another commit's paths. A root commit falls back to `diff-tree --root`; a merge reports no paths of its own, which is honest — it introduces none.

`partial —` survives with a narrower meaning: the walk is capped at `OBSIDIAN_COMMIT_MAX_RECORDS` (20 by default) and the line names the shas beyond it. Unbounded, a scripted loop costs the skill a note per commit; capped silently, a truncated capture reads exactly like a complete one.

Per-line the skill contract is unchanged — several records from one invocation need no new parsing, just the knowledge that it happens, which SKILL.md now states.

Bumps the plugin to 1.19.0 and the skill to 2.5.0.

## Testing Procedure

1. Check out this branch and run `bash tests/run-all.sh` — 31 suites, all pass. Also verified under `/bin/bash` 3.2.57.
2. Revert `scripts/commit-capture.sh` (`git stash push scripts/commit-capture.sh`) and re-run `tests/commit-capture-head-gate.sh`: case 18 fails with `two commits in one call did not produce two records`.
3. Live: `git commit -m one && git commit -m two` in a scratch repo, and confirm two `obsidian-commit-capture: hash=` lines arrive, oldest first, each with its own sha and its own `files=`.

New coverage in head-gate:

- **case 18** — two commits in one call yield exactly two records, ordered oldest-first, with distinct shas and no `partial` line.
- **case 18b** — each record carries only its own commit's paths (`only-in-first.txt` / `only-in-second.txt`), the assertion the old tip-scoped `files=` could not pass.
- **case 18c** — with `OBSIDIAN_COMMIT_MAX_RECORDS=2` and four commits, exactly two records plus a `partial` line naming the total.

The stub-git detection suite gained arms for the new argv (`rev-list --reverse`, per-sha `rev-parse --short` / `log -1 --pretty=format:%s`, `diff --name-only <range>`, `diff-tree --root`). Its range is a single commit on purpose — the walk itself is asserted on real repos in head-gate, since a stub cannot make commits land.