### PR TITLE
commit-capture: ask the reflog whether this repo made the commit

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/scripts/commit-capture.sh
+++ b/scripts/commit-capture.sh
@@ -234,6 +234,53 @@ if [ -n "$RANGE_BASE" ]; then
   RANGE_LIST=$(GIT rev-list --reverse "${RANGE_BASE}..${FULL_SHA}" 2>/dev/null) || RANGE_LIST=""
   [ -z "$RANGE_LIST" ] || SHAS="$RANGE_LIST"
 fi
+# Which of those did this repo actually create? The committer check above catches a
+# teammate's commit, but not your own commit pushed from another machine — same
+# email, so `git pull && git commit` with a failing commit captured the pulled tip
+# as though this call had made it (#72). Identity cannot separate those; provenance
+# can. HEAD's reflog records how each ref update happened: a local commit leaves
+# `commit: …` (or `commit (amend)`, `commit (initial)`), a real merge leaves
+# `merge …: Merge made by …`, while anything that arrived over the wire leaves a
+# Fast-forward entry — and the intermediate commits of a fast-forward appear in the
+# reflog not at all, since only the final ref update is logged.
+#
+# Read the entry that created each sha rather than the top of the log: after
+# `git commit && git checkout`, the newest entry is the checkout. That is why #68
+# rejected `git reflog -1` and left this open.
+# Every entry for the sha, not the newest: a sha keeps its `commit` entry while
+# later operations add their own for the same value. `git commit && git checkout -b`
+# logs the checkout against the same sha, so reading one entry — even the first
+# matching one — answers "what happened last" instead of "was this created here".
+cc_is_ours() {
+  local sha="$1" entry
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    case "${entry#* }" in
+      commit*) return 0 ;;
+      merge*Fast-forward|pull*Fast-forward) ;;
+      merge*) return 0 ;;
+      *) ;;
+    esac
+  done <<EOF
+$(printf '%s\n' "$REFLOG" | grep "^${sha} " || true)
+EOF
+  return 1
+}
+# No reflog at all (core.logAllRefUpdates off, the bare-repo default) means no
+# evidence either way, and absent evidence is not evidence of a pull — capture.
+REFLOG=$(GIT reflog show --format='%H %gs' 2>/dev/null) || REFLOG=""
+if [ -n "$REFLOG" ]; then
+  OURS=""
+  for SHA_ONE in $SHAS; do
+    if cc_is_ours "$SHA_ONE"; then
+      OURS="${OURS}${SHA_ONE}"$'\n'
+    fi
+  done
+  # Every commit in the range came from somewhere else, so this call made none.
+  [ -n "$OURS" ] || exit 0
+  SHAS="$OURS"
+fi
+
 SHA_COUNT=0
 for SHA_ONE in $SHAS; do
   SHA_COUNT=$(( SHA_COUNT + 1 ))

--- a/tests/commit-capture-detection.sh
+++ b/tests/commit-capture-detection.sh
@@ -62,6 +62,10 @@ case "\$*" in
   # One record per commit: the hook walks the range, then asks each sha for its
   # short hash, subject and paths. A single-commit range keeps these cases about
   # detection rather than about the walk (head-gate covers the walk on real repos).
+  # Provenance: HEAD's reflog says this repo committed the tip rather than pulling
+  # it. Answer as a local commit — the pulled-commit cases live in head-gate, where
+  # a real pull can actually happen.
+  "reflog show --format=%H %gs") echo "0123456789abcdef0123456789abcdef01234567 commit: test commit" ;;
   "rev-list --reverse "*) echo 0123456789abcdef0123456789abcdef01234567 ;;
   "rev-parse --short "*) echo abc1234 ;;
   "log -1 --pretty=format:%s "*) echo "test commit" ;;

--- a/tests/commit-capture-head-gate.sh
+++ b/tests/commit-capture-head-gate.sh
@@ -410,6 +410,77 @@ case "$POST_OUT" in
   *hash=*) fail "something was captured for a call that committed nothing"$'\n'"got: $POST_OUT" ;;
 esac
 
+# --- 14b. your own commit, pulled from another machine, is still not ours -----
+# Same shape as 14 but the committer email matches, because it is you on a second
+# machine. Identity cannot separate these, so the question becomes: did THIS repo
+# create the commit? HEAD's reflog answers it — a local commit leaves a `commit`
+# entry for that sha, a fast-forward pull leaves `pull:` (#72).
+reset_state
+UP2="$WORK/upstream2.git"
+git init -q --bare "$UP2"
+OTHER="$WORK/other-machine"
+mkrepo "$OTHER" "$UP2"
+git -C "$OTHER" config user.email me@example.com
+git -C "$OTHER" config user.name Me
+commit_in "$OTHER" "shared base"
+git -C "$OTHER" push -q origin HEAD:refs/heads/main
+
+HERE="$WORK/here"
+git clone -q "$UP2" "$HERE"
+git -C "$HERE" config core.hooksPath /dev/null
+git -C "$HERE" config commit.gpgsign false
+git -C "$HERE" config user.email me@example.com
+git -C "$HERE" config user.name Me
+
+commit_in "$OTHER" "my work from the laptop"
+git -C "$OTHER" push -q origin HEAD:refs/heads/main
+
+BEFORE_PULL2="$(git -C "$HERE" rev-parse HEAD)"
+P="$(payload 'git pull && git commit -q -m mine' "$HERE" call-14b)"
+run_pre "$P"
+git -C "$HERE" pull -q --ff-only origin main
+git -C "$HERE" remote set-url origin "git@github.com:nhangen/here.git"
+[ "$(git -C "$HERE" rev-parse HEAD)" != "$BEFORE_PULL2" ] \
+  || fail "case 14b fixture did not fast-forward"
+[ "$(git -C "$HERE" log -1 --format=%ce)" = "me@example.com" ] \
+  || fail "case 14b fixture: the pulled commit must carry OUR committer email or it proves nothing"
+run_post_verbose "$P"
+case "$POST_OUT" in
+  *"msg=my work from the laptop"*) fail "a commit pulled from another of your own machines was captured as made here"$'\n'"got: $POST_OUT" ;;
+  *hash=*) fail "something was captured for a call that committed nothing"$'\n'"got: $POST_OUT" ;;
+esac
+
+# --- 14c. a commit followed by a checkout is still ours ----------------------
+# The reason #68 rejected `git reflog -1`: after `git commit && git checkout`, the
+# newest reflog entry is the checkout. The check has to find the entry that created
+# THIS sha, not read the top of the log.
+reset_state
+P="$(payload 'git commit -q -m x && git checkout -q -b scratch' "$REPO" call-14c)"
+run_pre "$P"
+commit_in "$REPO" "committed then switched"
+git -C "$REPO" checkout -q -b scratch
+run_post_verbose "$P"
+case "$POST_OUT" in
+  *"msg=committed then switched"*) : ;;
+  *) fail "a commit followed by a checkout was not captured"$'\n'"got: ${POST_OUT:-<empty>}" ;;
+esac
+git -C "$REPO" checkout -q -
+
+# A repo with no reflog (core.logAllRefUpdates off, the bare default) must still
+# capture: absent evidence is not evidence of a pull.
+reset_state
+git -C "$REPO" config core.logAllRefUpdates false
+rm -f "$REPO/.git/logs/HEAD"
+P="$(payload 'git commit -q -m x' "$REPO" call-14d)"
+run_pre "$P"
+commit_in "$REPO" "no reflog here"
+run_post_verbose "$P"
+git -C "$REPO" config core.logAllRefUpdates true
+case "$POST_OUT" in
+  *"msg=no reflog here"*) : ;;
+  *) fail "a commit in a repo without a reflog was dropped"$'\n'"got: ${POST_OUT:-<empty>}" ;;
+esac
+
 # --- 15. a slow call does not lose the commit it made -----------------------
 # PostToolUse fires when the whole Bash call finishes, not when `git commit`
 # returns. `git commit && npm test` outlived the 120s recency window and the note


### PR DESCRIPTION
Closes #72

## Description (Issue Fixed & New Behavior)

The committer check from #68 catches a teammate's commit. It cannot catch your own commit pushed from another machine — same email — so `git pull && git commit` where the commit fails captured the pulled tip as though this call had made it. Identity can't separate those. Provenance can.

HEAD's reflog records *how* each ref update happened:

| reflog message | made here? |
|---|---|
| `commit: …`, `commit (amend)`, `commit (initial)` | yes |
| `merge topic: Merge made by the 'ort' strategy` | yes |
| `pull: Fast-forward`, `merge origin/main: Fast-forward` | no — arrived over the wire |
| no entry for the sha at all | no — it's an intermediate commit of a fast-forward |

That last row matters more after #70: only the *final* ref update is logged, so a fast-forward pull of five commits leaves four shas with no reflog entry, and the walk added in #70 would otherwise have emitted a record for each.

**Every entry for a sha is read, not the newest.** `git commit && git checkout -b x` logs the checkout against the same sha, so reading one entry answers "what happened last" instead of "was this created here" — exactly why #68 rejected `git reflog -1` and left this residual open. `git commit && git push` is unaffected: push doesn't touch HEAD's reflog.

No reflog at all (`core.logAllRefUpdates` off, the bare-repo default) means no evidence either way, and absent evidence is not evidence of a pull — the filter is skipped rather than dropping the commit.

Bumps the plugin to 1.19.1.

## Testing Procedure

1. Check out this branch and run `bash tests/run-all.sh` — 31 suites, all pass. Also verified under `/bin/bash` 3.2.57.
2. Revert `scripts/commit-capture.sh` (`git stash push scripts/commit-capture.sh`) and re-run `tests/commit-capture-head-gate.sh`: case 14b fails with `a commit pulled from another of your own machines was captured as made here`.
3. Live: clone one repo twice, commit and push from clone A with the same `user.email`, then in clone B run `git pull && git commit -m x` where the commit has nothing to commit. Nothing should be captured. Then `git commit -m real && git push` in B — that should be captured.

New coverage in head-gate:

- **case 14b** — the #72 shape: a real bare upstream, a second clone with *your* email, a fast-forward pull plus a failing commit. The fixture asserts the pulled commit carries your committer email, so the case can't silently degrade into case 14.
- **case 14c** — `git commit && git checkout -b` is still captured; this is the assertion that the single-entry reading would fail.
- **case 14d** — a repo with `core.logAllRefUpdates false` and no `logs/HEAD` still captures.