### PR TITLE
commit-capture: file list for root commits and merges; reap the vault-path suite's temp dirs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/scripts/commit-capture.sh
+++ b/scripts/commit-capture.sh
@@ -329,15 +329,15 @@ BRANCH="$(scrub_field "$BRANCH")"
 
 # The subject and the file list are per commit; everything else below (branch,
 # org_repo, vault_path, the clock) is a property of the call and is shared.
+# One invocation that answers for all three shapes (#65). `HEAD~1..HEAD` failed
+# outright on a root commit — silently, so `files=` was simply empty — and reported
+# only the first-parent diff on a merge. `--root` covers the root commit;
+# `-m --first-parent` makes a merge report the paths it brought in rather than
+# nothing, which is what a note about a merge is for. Note that `git show
+# --name-only`, the fix the issue proposed, prints nothing at all for a merge.
 cc_files_for() {
-  local sha="$1" raw=""
-  raw=$(GIT diff --name-only "${sha}~1..${sha}" 2>/dev/null) || raw=""
-  # A root commit has no ~1, and a merge's diff against its first parent is not
-  # what it changed; --root handles the first and prints nothing for the second,
-  # which is honest — a merge introduces no paths of its own.
-  if [ -z "$raw" ]; then
-    raw=$(GIT diff-tree --no-commit-id --name-only -r --root "$sha" 2>/dev/null) || raw=""
-  fi
+  local raw=""
+  raw=$(GIT diff-tree --no-commit-id --name-only -r --root -m --first-parent "$1" 2>/dev/null) || raw=""
   printf '%s' "$raw" | tr '\n' ',' | sed 's/,$//'
 }
 

--- a/tests/commit-capture-head-gate.sh
+++ b/tests/commit-capture-head-gate.sh
@@ -764,6 +764,50 @@ if ls -A "$SNAP_DIR" | grep -qv "^$(basename "$KEY_FILE")\$"; then
   fail "a temp file was left in the snapshot dir: $(ls -A "$SNAP_DIR")"
 fi
 
+# --- 24. files= on a root commit and on a merge ------------------------------
+# `HEAD~1..HEAD` failed outright on a root commit, so `files=` went out empty with
+# no indication anything was missing, and on a merge it reported the first-parent
+# diff of whatever the tip happened to be (#65).
+reset_state
+ROOTREPO="$WORK/rootrepo"
+mkdir -p "$ROOTREPO"
+git -C "$ROOTREPO" init -q
+git -C "$ROOTREPO" config core.hooksPath /dev/null
+git -C "$ROOTREPO" config commit.gpgsign false
+git -C "$ROOTREPO" config user.email t@example.com
+git -C "$ROOTREPO" config user.name Tester
+git -C "$ROOTREPO" remote add origin "git@github.com:nhangen/rootrepo.git"
+P="$(payload 'git commit -q -m first' "$ROOTREPO" call-24)"
+run_pre "$P"
+: > "$ROOTREPO/very-first.txt"
+git -C "$ROOTREPO" add very-first.txt
+git -C "$ROOTREPO" commit -q -m "the first commit"
+run_post_verbose "$P"
+case "$POST_OUT" in
+  *'files=very-first.txt'*) : ;;
+  *) fail "a root commit reported no files"$'\n'"got: ${POST_OUT:-<empty>}" ;;
+esac
+
+# A merge commit brought paths in; reporting none of them is not observability.
+reset_state
+git -C "$REPO" checkout -q -b feature-24
+: > "$REPO/from-the-branch.txt"
+git -C "$REPO" add from-the-branch.txt
+git -C "$REPO" commit -q -m "work on the branch"
+git -C "$REPO" checkout -q -
+# The hook only ever fires for a call that invokes `git commit`, so the merge has
+# to be completed by one — which is also how a merge with conflicts or a reviewed
+# merge actually lands.
+P="$(payload 'git merge --no-ff --no-commit feature-24 && git commit -m merged' "$REPO" call-24b)"
+run_pre "$P"
+git -C "$REPO" merge -q --no-ff --no-commit feature-24 >/dev/null 2>&1 || true
+git -C "$REPO" commit -q -m "merge the branch"
+run_post_verbose "$P"
+case "$POST_OUT" in
+  *'from-the-branch.txt'*) : ;;
+  *) fail "a merge commit reported none of the paths it brought in"$'\n'"got: ${POST_OUT:-<empty>}" ;;
+esac
+
 # --- wiring: both halves are registered on Bash ------------------------------
 # The pair is one mechanism. Shipping the post-hook without the pre-hook turns
 # every capture into a stderr diagnostic.

--- a/tests/commit-capture-vault-path.sh
+++ b/tests/commit-capture-vault-path.sh
@@ -51,7 +51,7 @@ cleanup_git_stub() {
 # the vault_path parse, not the gate.
 new_state_home() {
   local dir key
-  dir="$(mktemp -d)"
+  dir="$(mktemp -d "${SUITE_TMP}/state-XXXXXX")"
   key="$(
     . "${ROOT_DIR}/scripts/lib/commit-capture-parse.sh"
     cc_snapshot_key "$1"
@@ -96,17 +96,20 @@ run_case_raw() {
 # stable XDG path over CLAUDE_PLUGIN_ROOT. Point XDG_CONFIG_HOME at an empty dir
 # and clear the override so these cases deterministically exercise the
 # plugin-root config the test controls, regardless of the host's real config.
-ISOLATED_XDG="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-xdg-XXXXXX")"
+# One scratch root for the whole suite. Every case used to call `mktemp -d` with no
+# reaper, so a run left nine unremoved directories in $TMPDIR (#66).
+SUITE_TMP="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-suite-XXXXXX")"
+ISOLATED_XDG="$(mktemp -d "${SUITE_TMP}/xdg-XXXXXX")"
 export XDG_CONFIG_HOME="$ISOLATED_XDG"
 unset OBSIDIAN_LOCAL_MD
 
 make_git_stub
-trap 'cleanup_git_stub; rm -rf "$ISOLATED_XDG"' EXIT
+trap 'cleanup_git_stub; rm -rf "$SUITE_TMP"' EXIT
 
 PASS_COUNT=0
 
 # ----- Case 1: happy path with tilde expansion -----
-CASE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-XXXXXX")"
+CASE_DIR="$(mktemp -d "${SUITE_TMP}/case-XXXXXX")"
 printf -- '---\nvault_path: ~/Documents/Obsidian\n---\n' > "${CASE_DIR}/obsidian.local.md"
 GOT=$(run_case "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
 EXPECTED="${HOME}/Documents/Obsidian"
@@ -119,41 +122,41 @@ GOT=$(run_case "" "")
 PASS_COUNT=$((PASS_COUNT + 1))
 
 # ----- Case 3: missing config file -> empty vault_path, no error -----
-EMPTY_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-empty-XXXXXX")"
+EMPTY_DIR="$(mktemp -d "${SUITE_TMP}/empty-XXXXXX")"
 GOT=$(run_case "" "$EMPTY_DIR")
 [ -z "$GOT" ] || fail "case3 (missing file): got '$GOT' want empty"
 PASS_COUNT=$((PASS_COUNT + 1))
 
 # ----- Case 4: empty vault_path: value -> empty -----
-CASE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-XXXXXX")"
+CASE_DIR="$(mktemp -d "${SUITE_TMP}/case-XXXXXX")"
 printf -- '---\nvault_path:\n---\n' > "${CASE_DIR}/obsidian.local.md"
 GOT=$(run_case "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
 [ -z "$GOT" ] || fail "case4 (empty value): got '$GOT' want empty"
 PASS_COUNT=$((PASS_COUNT + 1))
 
 # ----- Case 5: CRLF line endings stripped -----
-CASE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-XXXXXX")"
+CASE_DIR="$(mktemp -d "${SUITE_TMP}/case-XXXXXX")"
 printf -- '---\r\nvault_path: /Users/test/vault\r\n---\r\n' > "${CASE_DIR}/obsidian.local.md"
 GOT=$(run_case "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
 [ "$GOT" = "/Users/test/vault" ] || fail "case5 (CRLF): got '$GOT' want '/Users/test/vault'"
 PASS_COUNT=$((PASS_COUNT + 1))
 
 # ----- Case 6: inline comment stripped -----
-CASE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-XXXXXX")"
+CASE_DIR="$(mktemp -d "${SUITE_TMP}/case-XXXXXX")"
 printf -- '---\nvault_path: /Users/test/vault  # main vault\n---\n' > "${CASE_DIR}/obsidian.local.md"
 GOT=$(run_case "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
 [ "$GOT" = "/Users/test/vault" ] || fail "case6 (inline comment): got '$GOT' want '/Users/test/vault'"
 PASS_COUNT=$((PASS_COUNT + 1))
 
 # ----- Case 7: double-quoted value -----
-CASE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-XXXXXX")"
+CASE_DIR="$(mktemp -d "${SUITE_TMP}/case-XXXXXX")"
 printf -- '---\nvault_path: "/Users/test/My Vault"\n---\n' > "${CASE_DIR}/obsidian.local.md"
 GOT=$(run_case "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
 [ "$GOT" = "/Users/test/My Vault" ] || fail "case7 (double-quoted): got '$GOT' want '/Users/test/My Vault'"
 PASS_COUNT=$((PASS_COUNT + 1))
 
 # ----- Case 8: single-quoted value -----
-CASE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-XXXXXX")"
+CASE_DIR="$(mktemp -d "${SUITE_TMP}/case-XXXXXX")"
 printf -- "---\nvault_path: '/Users/test/Vault'\n---\n" > "${CASE_DIR}/obsidian.local.md"
 GOT=$(run_case "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
 [ "$GOT" = "/Users/test/Vault" ] || fail "case8 (single-quoted): got '$GOT' want '/Users/test/Vault'"
@@ -162,7 +165,7 @@ PASS_COUNT=$((PASS_COUNT + 1))
 # ----- Case 9: the record keeps every field, inside the delivery envelope -----
 # The envelope is asserted here too: a PostToolUse hook only reaches Claude through
 # hookSpecificOutput.additionalContext, so a bare record is a record nobody reads.
-CASE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cc-vp-XXXXXX")"
+CASE_DIR="$(mktemp -d "${SUITE_TMP}/case-XXXXXX")"
 printf -- '---\nvault_path: /Users/test/v\n---\n' > "${CASE_DIR}/obsidian.local.md"
 OUT=$(run_case_raw "${CASE_DIR}/obsidian.local.md" "$CASE_DIR")
 case "$OUT" in


### PR DESCRIPTION
Closes #65
Closes #66

Two independent concerns, one commit each.

## `files=` on a root commit and on a merge (#65)

`git diff --name-only HEAD~1..HEAD` fails outright on a root commit — silently, so the field went out empty with nothing to indicate it was incomplete — and reports only the first-parent diff on a merge.

Replaced with a single query that answers all three shapes:

```
git diff-tree --no-commit-id --name-only -r --root -m --first-parent <sha>
```

`--root` covers the first commit in a repo; `-m --first-parent` makes a merge report the paths it brought in rather than nothing. It also collapses the two-step fallback the per-commit walk (#70) had introduced.

**Not `git show --name-only`, which the issue proposed** — verified on a scratch repo with a root commit, a normal commit and a merge: `git show --name-only --format=` prints nothing at all for the merge, so it fixes one half of #65 and leaves the other.

| commit | old `HEAD~1..HEAD` | `git show --name-only` | this PR |
|---|---|---|---|
| root | *(empty — command failed)* | `root.txt` | `root.txt` |
| normal | `main.txt` | `main.txt` | `main.txt` |
| merge | first-parent only | *(empty)* | `topic.txt main.txt` |

## The vault-path suite leaked a temp dir per case (#66)

Nine cases called `mktemp -d` with no reaper. 1620 stale directories had accumulated in `$TMPDIR` on this machine. One scratch root now holds every per-case dir and every state home, and the suite's existing EXIT trap removes it.

Bumps the plugin to 1.19.2.

## Testing Procedure

1. `bash tests/run-all.sh` — 31 suites, all pass; also verified under `/bin/bash` 3.2.57.
2. Revert only `cc_files_for` in `scripts/commit-capture.sh` to `HEAD~1..HEAD` and re-run `tests/commit-capture-head-gate.sh`: case 24 fails with `a root commit reported no files`.
3. Count `$TMPDIR/cc-vp-*` before and after `bash tests/commit-capture-vault-path.sh` — unchanged. Before this PR it grew by nine.

New coverage — head-gate case 24: a fresh repo whose first commit is captured with `files=very-first.txt`, and a `git merge --no-ff --no-commit && git commit` whose record names the path the branch brought in. The merge fixture lands via `git commit` deliberately — the hook only fires for calls that invoke `git commit`, which is also how a conflicted or reviewed merge actually lands.