### PR TITLE
Name the repository, not the checkout directory (#82)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/scripts/commit-capture.sh
+++ b/scripts/commit-capture.sh
@@ -342,7 +342,24 @@ cc_files_for() {
 }
 
 REMOTE=$(GIT remote get-url origin 2>/dev/null) || REMOTE="local"
-REPO_NAME=${REPO_ROOT##*/}
+# In a worktree the toplevel is the worktree directory, so its basename is
+# `obsidian-i82` or `wp-content-pr7100-slug` rather than the repository. That name
+# reaches a note's `tags:` and its H1, and PR work happens in worktrees by
+# convention — so most PR commits tagged the daily note with a directory that no
+# longer exists a week later. The linked worktrees share one common git dir; its
+# parent is the main worktree, which is the repository as far as the filesystem
+# can say. (The remote says it better still — see below, once it is parsed.)
+GIT_COMMON=$(GIT rev-parse --git-common-dir 2>/dev/null) || GIT_COMMON=""
+case "$GIT_COMMON" in
+  '') MAIN_ROOT="$REPO_ROOT" ;;
+  /*) MAIN_ROOT="$GIT_COMMON" ;;
+  # Relative, and relative to the directory git ran in — not to the toplevel.
+  *)  MAIN_ROOT="${REPO_DIR}/${GIT_COMMON}" ;;
+esac
+MAIN_ROOT="${MAIN_ROOT%/}"
+MAIN_ROOT="${MAIN_ROOT%/.git}"
+REPO_NAME=${MAIN_ROOT##*/}
+REPO_NAME=${REPO_NAME%.git}
 : "${REPO_NAME:=unknown}"
 TODAY=$(date '+%Y-%m-%d')
 NOW=$(date '+%H:%M')
@@ -412,6 +429,14 @@ case "$ORG_REPO" in
 esac
 case "$ORG_REPO" in
   ''|*/) ORG_REPO="local/$REPO_NAME" ;;
+esac
+# Now that the remote has been parsed, it — not any directory — is what names the
+# repository: a clone is free to sit in a directory called anything, and a worktree
+# always does. The `local/` form means no remote resolved, and there the directory
+# above is already the best available answer.
+case "$ORG_REPO" in
+  local/*) ;;
+  */*) REPO_NAME="${ORG_REPO##*/}" ;;
 esac
 
 # --- Extract ticket number from branch ---

--- a/tests/commit-capture-detection.sh
+++ b/tests/commit-capture-detection.sh
@@ -68,6 +68,8 @@ case "\$*" in
   "diff --name-only HEAD~1..HEAD") echo foo.txt ;;
   "remote get-url origin") echo "${remote}" ;;
   "rev-parse --show-toplevel") echo "/tmp/mtf-builder" ;;
+  # Where the repository really is, which in a worktree the toplevel does not say.
+  "rev-parse --git-common-dir") echo "/tmp/mtf-builder/.git" ;;
   "rev-parse HEAD") echo 0123456789abcdef0123456789abcdef01234567 ;;
   # The post-hook asks git what the HEAD move was: is the snapshot's sha an
   # ancestor, and did we commit it. Answer yes to both — these cases are about

--- a/tests/commit-capture-head-gate.sh
+++ b/tests/commit-capture-head-gate.sh
@@ -856,6 +856,59 @@ case "$POST_OUT" in
   *) fail "the amend record does not name the amended commit's own path"$'\n'"got: $POST_OUT" ;;
 esac
 
+# --- 26. a commit made in a worktree names the repository, not the worktree ---
+# `repo_name` reaches a note's `tags:` and its H1, and PR work happens in a
+# worktree by convention — so this used to tag the daily note with a directory
+# that no longer exists once the PR lands. The remote names the repository; the
+# worktree directory is deliberately something else.
+reset_state
+WT="$WORK/pr-1234-slug"
+git -C "$REPO" worktree add -q -b wt-branch "$WT" >/dev/null 2>&1
+P="$(payload 'git commit -q -m wt' "$WT" call-26)"
+run_pre "$P"
+: > "$WT/in-the-worktree.txt"
+git -C "$WT" add in-the-worktree.txt
+git -C "$WT" commit -q -m "work in a worktree"
+run_post_verbose "$P"
+case "$POST_OUT" in
+  *hash=*) : ;;
+  *) fail "a commit made in a worktree was not captured at all"$'\n'"got: ${POST_OUT:-<empty>}"$'\n'"stderr: $POST_ERR" ;;
+esac
+GOT_NAME="$(printf '%s' "$POST_OUT" | sed -n 's/.*repo_name=\([^ |]*\).*/\1/p')"
+[ "$GOT_NAME" = "mtf-builder" ] \
+  || fail "repo_name=${GOT_NAME:-<absent>}, expected mtf-builder — a note filed from a PR worktree must not be tagged with the checkout directory"$'\n'"got: $POST_OUT"
+case "$POST_OUT" in
+  *'org_repo=altamira2/mtf-builder'*) : ;;
+  *) fail "a worktree commit was filed under the wrong org_repo"$'\n'"got: $POST_OUT" ;;
+esac
+
+# Same shape with no remote at all: nothing can name the repository except the
+# filesystem, and the *main* worktree is the closest it gets. Without the common-dir
+# lookup this reports the linked worktree's directory and org_repo becomes
+# local/<throwaway-dir> — the folder fragmentation the org/repo work removed for
+# remotes, reappearing for repos that have none.
+reset_state
+BARE="$WORK/no-remote"
+mkrepo "$BARE"
+git -C "$BARE" remote remove origin
+commit_in "$BARE" "seed"
+BWT="$WORK/no-remote-wt"
+git -C "$BARE" worktree add -q -b wt2 "$BWT" >/dev/null 2>&1
+P="$(payload 'git commit -q -m wt' "$BWT" call-26b)"
+run_pre "$P"
+: > "$BWT/x.txt"
+git -C "$BWT" add x.txt
+git -C "$BWT" commit -q -m "work with no remote"
+run_post_verbose "$P"
+case "$POST_OUT" in
+  *'repo_name=no-remote '*) : ;;
+  *) fail "a remoteless worktree commit did not fall back to the main worktree's name"$'\n'"got: ${POST_OUT:-<empty>}"$'\n'"stderr: $POST_ERR" ;;
+esac
+case "$POST_OUT" in
+  *'org_repo=local/no-remote '*) : ;;
+  *) fail "a remoteless worktree commit was filed under the worktree directory"$'\n'"got: $POST_OUT" ;;
+esac
+
 # --- wiring: both halves are registered on Bash ------------------------------
 # The pair is one mechanism. Shipping the post-hook without the pre-hook turns
 # every capture into a stderr diagnostic.


### PR DESCRIPTION
Closes #82

## Description (Issue Fixed & New Behavior)

`repo_name` came from the toplevel basename, which in a worktree is the worktree directory. The field reaches a note's frontmatter `tags:` and its `# <repo_name> — <date>` heading, and PR work happens in a worktree by convention — so most PR commits tagged the daily note with a path that stops existing when the worktree is removed. This repo's own capture, two commits ago, said `repo_name=obsidian-i67`.

Two sources, in order:

- **The remote.** Once it is parsed, its basename names the repository. A clone can sit in a directory called anything; a worktree always does.
- **The common git dir**, when there is no remote. Linked worktrees share one, and its parent is the main worktree — the closest the filesystem gets to "the repository." This half also keeps `org_repo` off the throwaway directory, since its no-remote fallback is `local/$REPO_NAME`: a remoteless worktree used to file under `local/pr-1234-slug`, which is the folder fragmentation the host-agnostic `org_repo` work removed for remotes, reappearing for repos without one.

`org_repo` for a repo *with* a remote is unchanged, so no existing note moves folders.

## Testing Procedure

1. Check out this branch, run `bash tests/run-all.sh` — 31 suites, `ALL PASS`. Also green under `/bin/bash` (3.2.57).
2. Delete the `*/*) REPO_NAME="${ORG_REPO##*/}" ;;` line from `scripts/commit-capture.sh` and run `bash tests/commit-capture-head-gate.sh`: case 26 fails with `repo_name=repo, expected mtf-builder`.
3. Restore it, change `REPO_NAME=${MAIN_ROOT##*/}` back to `${REPO_ROOT##*/}`, and re-run: case 26b fails ("a remoteless worktree commit did not fall back to the main worktree's name"). Case 26 still passes, since the remote covers it — the two halves answer different cases.
4. After `/plugin` update + `/reload-plugins`, commit from a worktree and read the record: `repo_name` should be the repository. Before this change it is the worktree directory (the capture of this PR's own commit reports `repo_name=obsidian-i82`, since the installed 1.19.2 is what runs).

## Additional Notes

Version 1.19.2 → 1.19.3; marketplace entry bumped separately in `nhangen/claude-plugins`.

Found while verifying #67 (PR #81) — the commit-capture record for that PR's own commit named the worktree.