### PR TITLE
Ask the note whether a commit is already captured (#62)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.19.3",
+  "version": "1.19.4",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/scripts/keeper
+++ b/scripts/keeper
@@ -44,7 +44,7 @@ keeper_guard_target() {
 
 # append a timestamped section to a dated note, creating it on absence.
 cmd_append() {
-  local vault="" target="" date="" section="" body_file="" init_file=""
+  local vault="" target="" date="" section="" body_file="" init_file="" skip_hash="" skip_given=0
   while [ $# -gt 0 ]; do
     case "$1" in
       --vault)     vault="${2:-}";     shift 2 ;;
@@ -53,6 +53,7 @@ cmd_append() {
       --section)   section="${2:-}";   shift 2 ;;
       --body-file) body_file="${2:-}"; shift 2 ;;
       --init-file) init_file="${2:-}"; shift 2 ;;
+      --skip-if-hash) skip_hash="${2:-}"; skip_given=1; shift 2 ;;
       *) keeper_die "append: unknown arg: $1" ;;
     esac
   done
@@ -68,6 +69,30 @@ cmd_append() {
   local full parent
   full="$vault_abs/$target"
   parent="$(dirname "$full")"
+
+  # Idempotency, read from the vault rather than from a host-local marker (#62).
+  # The old commit-capture gate kept its key under XDG_STATE_HOME, which never
+  # syncs, so it could not see the note it was protecting: two hosts committing
+  # to the same repo each captured, and so did one host re-running after a
+  # Syncthing conflict copy. The note is the shared record; ask it.
+  #
+  # Section headings only. A context bullet legitimately names other commits'
+  # shas ("reverts deadbee"), so matching anywhere in the file would drop that
+  # commit's own record instead of its duplicate.
+  if [ "$skip_given" = 1 ]; then
+    case "$skip_hash" in
+      '') keeper_die "append: --skip-if-hash requires a value" ;;
+      *[!0-9a-fA-F]*) keeper_die "append: --skip-if-hash must be a hex sha: $skip_hash" ;;
+      *)
+        if [ -f "$full" ] && grep -qE "^#{1,6}[[:space:]].*[[:space:]]${skip_hash}[[:space:]]*\$" "$full"; then
+          printf 'keeper: append skipped — %s already has a section for %s\n' "$target" "$skip_hash" >&2
+          printf '%s\n' "$full"
+          return 0
+        fi
+        ;;
+    esac
+  fi
+
   mkdir -p "$parent"
 
   if [ ! -f "$full" ]; then

--- a/skills/commit-capture/SKILL.md
+++ b/skills/commit-capture/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: commit-capture
 description: Captures conversation context around git commits to Obsidian vault. Fires automatically via PostToolUse hook.
-version: 2.5.0
+version: 2.6.0
 ---
 
 # Commit Capture
@@ -94,13 +94,25 @@ Vault path is passed inline by the hook (parsed once from the resolved config �
      --target "Projects/Development/<org_repo>/<date>.md" \
      --section "## <time> — <hash>" \
      --body-file "<body-temp>" \
-     --init-file "<header-temp>"
+     --init-file "<header-temp>" \
+     --skip-if-hash "<hash>"
    ```
 
    The CLI creates parent dirs, writes the header on first commit of the day,
    and appends the section. No `Read`/`Write`/`mkdir`, no subagent.
 
-7. **Confirm silently** — output only: `Captured <hash> → <org_repo>/<date>.md`
+   `--skip-if-hash` makes the append idempotent per commit: if the note already
+   has a section heading ending in that sha, nothing is written and the CLI says
+   so on stderr. **Always pass it.** The check reads the note, which is the
+   record that syncs — the earlier gate kept its key in a host-local state dir
+   and so could not see the file it was protecting, and two hosts committing to
+   the same repo (or one host re-running after a Syncthing conflict copy) each
+   captured (#62).
+
+7. **Confirm silently** — output only: `Captured <hash> → <org_repo>/<date>.md`.
+   If the CLI printed `append skipped` on stderr, say
+   `Already captured <hash> → <org_repo>/<date>.md` instead — the note already
+   holds this commit, and claiming a fresh capture would be false.
 
 ## Important
 

--- a/tests/keeper-cli.sh
+++ b/tests/keeper-cli.sh
@@ -46,6 +46,56 @@ grep -qE '^## [0-9]{2}:[0-9]{2} — entry' "$V/Notes/y.md" || fail "default sect
 printf 'stdin body\n' | bash "$KEEPER" append --vault "$V" --target "Notes/s.md" --section '## s — t' >/dev/null
 grep -q '^stdin body' "$V/Notes/s.md" || fail "stdin body not appended"
 
+# --- --skip-if-hash: the append is idempotent per commit sha ---
+#
+# The capture gate this replaces lived in a host-local state dir while the vault
+# is Syncthing-replicated (#62), so it could not see the note it was protecting.
+# The note itself is the shared record, and it is what the guard reads.
+
+# 15. a second append for a sha the target already has a section for is a no-op:
+#     no new section, no duplicated body, and the reason goes to stderr.
+S="$V/Projects/foo/2026-06-29.md"
+BEFORE="$(cat "$S")"
+printf 'a second capture of the same commit\n' > "$TMP/dup.md"
+bash "$KEEPER" append --vault "$V" --target "Projects/foo/2026-06-29.md" \
+  --section '## 16:45 — abc1234' --body-file "$TMP/dup.md" --skip-if-hash abc1234 \
+  >"$TMP/skip.out" 2>"$TMP/skip.err" \
+  || fail "--skip-if-hash on an already-captured sha must exit 0, not fail"
+[ "$(cat "$S")" = "$BEFORE" ] \
+  || fail "--skip-if-hash appended anyway; the target changed:"$'\n'"$(diff <(printf '%s\n' "$BEFORE") "$S" || true)"
+grep -q 'skipped' "$TMP/skip.err" \
+  || fail "the skip was silent — nothing on stderr said why nothing was written:"$'\n'"$(cat "$TMP/skip.err")"
+grep -qF "Projects/foo/2026-06-29.md" "$TMP/skip.out" \
+  || fail "skip did not print the target path on stdout, so a caller cannot tell which note holds it"
+
+# 16. a sha the target does NOT have appends normally — the guard is per sha, not
+#     a blanket "this file already exists" refusal.
+bash "$KEEPER" append --vault "$V" --target "Projects/foo/2026-06-29.md" \
+  --section '## 17:00 — 99f00d5' --body-file "$TMP/dup.md" --skip-if-hash 99f00d5 >/dev/null
+grep -q '^## 17:00 — 99f00d5' "$S" || fail "--skip-if-hash blocked an sha the note did not have"
+
+# 17. the guard reads section headings, not prose. A context bullet is free to
+#     mention another commit's sha; matching anywhere in the file would then
+#     silently drop that commit's own record.
+printf 'reverts deadbee, see also deadbee\n' > "$TMP/prose.md"
+bash "$KEEPER" append --vault "$V" --target "Notes/prose.md" \
+  --section '## 12:00 — 1111111' --body-file "$TMP/prose.md" >/dev/null
+bash "$KEEPER" append --vault "$V" --target "Notes/prose.md" \
+  --section '## 12:05 — deadbee' --body-file "$TMP/b.md" --skip-if-hash deadbee >/dev/null
+grep -q '^## 12:05 — deadbee' "$V/Notes/prose.md" \
+  || fail "a sha mentioned in body prose was read as an existing section, dropping the record"
+
+# 18. a malformed --skip-if-hash fails loudly. Silently treating an unusable
+#     value as "no guard" turns a typo into a duplicate note, which is the
+#     failure this flag exists to prevent.
+bash "$KEEPER" append --vault "$V" --target "Notes/bad.md" --section x \
+  --body-file "$TMP/b.md" --skip-if-hash "not-a-sha" 2>/dev/null \
+  && fail "non-hex --skip-if-hash must fail rather than append unguarded"
+[ -f "$V/Notes/bad.md" ] && fail "a rejected --skip-if-hash still wrote the note"
+bash "$KEEPER" append --vault "$V" --target "Notes/bad.md" --section x \
+  --body-file "$TMP/b.md" --skip-if-hash "" 2>/dev/null \
+  && fail "empty --skip-if-hash must fail rather than append unguarded"
+
 # --- validation guards (each must exit non-zero) ---
 
 # 7. unknown subcommand


### PR DESCRIPTION
Closes #62

**Commit:** `b8d374e` — 1.19.3 → 1.19.4

### The problem

The capture dedup key lived under `XDG_STATE_HOME` while the vault is Syncthing-replicated, so the gate could not see the file it was protecting. Two hosts committing to the same repo each captured; so did one host re-running after a conflict copy.

Post-#68 there is no durable marker left to fix — the PreToolUse snapshot is per-invocation and consumed by `rm -f`. And the hook cannot resolve the note path, because the per-org routing overrides live in the user's global capture rule, not in the plugin. So the guard belongs where the issue put it: read the target note for the sha before appending.

### The fix

`keeper append --skip-if-hash <sha>` — if the target already has a section heading ending in that sha, nothing is written, the reason goes to stderr, and stdout still carries the path so a caller can say which note holds it. `commit-capture` passes it on every append and reports `Already captured <hash>` on a skip rather than claiming a fresh one.

Two deliberate calls:

- **Section headings only.** A context bullet legitimately names other commits' shas ("reverts deadbee"), so matching anywhere in the file would drop that commit's own record instead of its duplicate.
- **A malformed value dies.** Non-hex or empty is rejected rather than quietly read as "no guard" — otherwise a typo turns straight back into the duplicate the flag exists to prevent (`enum-config-typo-fallback`).

### Testing

1. `bash tests/keeper-cli.sh` — four new cases (15–18): skip on a sha the note has, normal append on one it doesn't, no false skip on a sha in body prose, and both malformed forms rejected without writing.
2. `bash tests/run-all.sh` and `/bin/bash tests/run-all.sh` (3.2.57) — all suites pass.
3. Each new assertion was checked against a targeted revert. Five mutants, each caught by the case written for it: guard bypassed, match-anywhere, non-hex accepted, silent skip, no stdout path.
4. Live: this PR's own commit was captured through the new flag into `Projects/Development/nhangen/claude-obsidian-plugin/2026-07-30.md`; re-running the identical append skipped it and the note's section count stayed at 3.

### Loose end

One `run-all.sh` invocation printed `1 suite(s) failed` with the suite name cut off by a `tail -3`, and did not reproduce in 12 consecutive runs after. Unidentified; nothing ties it to this change, but I'd rather record it than say the suite is clean without qualification.
