### PR TITLE
Single-source the snapshot path; fold GitLab subgroups (#63, #64)

### DIFF
--- a/scripts/commit-capture-pre.sh
+++ b/scripts/commit-capture-pre.sh
@@ -85,7 +85,7 @@ fi
 # any other non-zero surfaces as a hook error on a call that is otherwise fine.
 warn() { cc_deliver_context PreToolUse "obsidian-commit-capture: $1"; }
 
-SNAP_DIR="$(cc_state_dir)/pre-commit-head"
+SNAP_DIR="$(cc_snapshot_dir)"
 if ! mkdir -p "$SNAP_DIR" 2>/dev/null; then
   warn "not captured — cannot create ${SNAP_DIR}; the commit this call makes will not be captured"
   exit 0
@@ -97,8 +97,8 @@ fi
 # is not a per-Bash-call cost.
 find "$SNAP_DIR" -type f -mtime +1 -delete 2>/dev/null || true
 
-KEY="$(cc_snapshot_key "$INPUT")"
-SNAP_FILE="${SNAP_DIR}/${KEY}"
+SNAP_FILE="$(cc_snapshot_file "$INPUT")"
+KEY="${SNAP_FILE##*/}"
 # Written to a temp name and renamed into place. A direct `> file` truncates before
 # it writes, so a full disk or a killed shell mid-write leaves a file holding half a
 # snapshot — and half a snapshot still parses: a `sha=` line with no `root=` reads as

--- a/scripts/commit-capture.sh
+++ b/scripts/commit-capture.sh
@@ -430,6 +430,25 @@ esac
 case "$ORG_REPO" in
   ''|*/) ORG_REPO="local/$REPO_NAME" ;;
 esac
+# GitLab subgroups nest arbitrarily deep, so `https://gitlab.com/g/sub1/sub2/repo`
+# derived `g/sub1/sub2/repo` and the note landed four levels under
+# Projects/Development/ where every other repo lands two. The prefix-shaped
+# routing overrides in the capture rule do not anticipate that, and neither does
+# anything that globs `Projects/Development/*/*`.
+#
+# org_repo is always exactly two segments now: everything above the repository is
+# folded into the first, joined with `-`. Collapsing to `<top-group>/<repo>`
+# instead — the other option the issue offered — would make `g/team-a/api` and
+# `g/team-b/api` the same folder, so two repos' notes would interleave in one
+# file. Keeping the repository as the leaf also means `repo_name` below, which
+# reads the last segment, needs no special case.
+case "$ORG_REPO" in
+  */*/*)
+    ORG_LEAF="${ORG_REPO##*/}"
+    ORG_GROUPS="${ORG_REPO%/*}"
+    ORG_REPO="$(printf '%s' "$ORG_GROUPS" | tr '/' '-')/${ORG_LEAF}"
+    ;;
+esac
 # Now that the remote has been parsed, it — not any directory — is what names the
 # repository: a clone is free to sit in a directory called anything, and a worktree
 # always does. The `local/` form means no remote resolved, and there the directory

--- a/scripts/commit-capture.sh
+++ b/scripts/commit-capture.sh
@@ -89,7 +89,7 @@ REPO_ROOT=$(GIT rev-parse --show-toplevel 2>/dev/null) || REPO_ROOT=""
 
 # --- Did a commit actually land? ---
 
-SNAP_FILE="$(cc_state_dir)/pre-commit-head/$(cc_snapshot_key "$INPUT")"
+SNAP_FILE="$(cc_snapshot_file "$INPUT")"
 HEAD_BEFORE=""
 SNAP_ROOT=""
 SNAP_INTENT=""
@@ -146,7 +146,7 @@ case "$SNAP_STATE" in
     if [ -n "$HEAD_BEFORE" ]; then
       say "not captured — the PreToolUse snapshot for this call is about ${SNAP_ROOT:-another repository}, not ${REPO_ROOT}"
     else
-      say "not captured — no PreToolUse HEAD snapshot for this call (register scripts/commit-capture-pre.sh as a PreToolUse Bash hook and restart the session; if it is registered, check that ${XDG_STATE_HOME:-$HOME/.local/state}/claude-obsidian is writable)"
+      say "not captured — no PreToolUse HEAD snapshot for this call (register scripts/commit-capture-pre.sh as a PreToolUse Bash hook and restart the session; if it is registered, check that $(cc_state_dir) is writable)"
     fi
     exit 0
     ;;

--- a/scripts/lib/commit-capture-parse.sh
+++ b/scripts/lib/commit-capture-parse.sh
@@ -305,3 +305,36 @@ cc_snapshot_key() {
   [ -n "$id" ] || id="session:$(cc_json_value "$payload" '"session_id"')"
   cc_digest "$id"
 }
+
+# Where a snapshot lives. The pre-hook writes it and the post-hook reads and
+# deletes it, so the two halves must agree byte for byte on the path — and they
+# each used to assemble it themselves from cc_state_dir + a literal
+# `pre-commit-head` + cc_snapshot_key. Two copies of a layout is a layout that
+# can be half-changed: the pre-hook would keep writing snapshots the post-hook
+# no longer looks for, and the symptom is every commit going uncaptured with
+# both halves reporting success. One accessor, called by both.
+cc_snapshot_dir() {
+  printf '%s/pre-commit-head' "$(cc_state_dir)"
+}
+
+cc_snapshot_file() {
+  printf '%s/%s' "$(cc_snapshot_dir)" "$(cc_snapshot_key "$1")"
+}
+
+# Deliberately NOT keeper-state.sh's shape (#63), and the differences are the
+# reason rather than drift:
+#
+#   - XDG_STATE_HOME, not XDG_CACHE_HOME. A cache is defined as discardable;
+#     losing a snapshot loses a capture, which is the failure the gate exists to
+#     prevent. State is what this is.
+#   - Keyed by invocation, not by a hashed vault id. keeper_vault_id answers
+#     "which vault's index is this" for a durable per-vault snapshot. These
+#     records are per-Bash-call and live for the length of one tool call, so the
+#     tool_use_id is the only key that keeps two concurrent commits apart — a
+#     vault id would collapse them onto one file.
+#   - No keeper_state_init: the pre-hook must mkdir and report failure itself,
+#     because it is the half that can still warn before the commit runs.
+#
+# What it does take from keeper-state.sh is the write discipline — tmp file plus
+# rename, never truncate-in-place — implemented at the pre-hook's write site
+# where the failure can be reported.

--- a/tests/commit-capture-detection.sh
+++ b/tests/commit-capture-detection.sh
@@ -250,7 +250,14 @@ check_org_repo "https://gitlab.com/altamira2/mtf-builder"     "altamira2/mtf-bui
 check_org_repo "git@github.com:nhangen/test.git"              "nhangen/test"
 check_org_repo "https://github.com/nhangen/test.git"          "nhangen/test"
 check_org_repo "git@gitlab.com:altamira2/mtf-builder.git"     "altamira2/mtf-builder"
-check_org_repo "https://gitlab.com/group/sub/repo.git"        "group/sub/repo"
+# GitLab subgroups (#64): org_repo is always exactly two segments, so the note
+# lands two levels under Projects/Development/ like every other repo. Everything
+# above the repository folds into the first segment; the repository stays the
+# leaf, so `group/team-a/api` and `group/team-b/api` remain distinct folders
+# instead of interleaving into one file.
+check_org_repo "https://gitlab.com/group/sub/repo.git"        "group-sub/repo"
+check_org_repo "https://gitlab.com/g/sub1/sub2/repo.git"      "g-sub1-sub2/repo"
+check_org_repo "git@gitlab.com:group/sub/repo.git"            "group-sub/repo"
 check_org_repo "ssh://git@gitlab.com:2222/altamira2/mtf-builder.git" "altamira2/mtf-builder"
 check_org_repo "https://gitlab.com/altamira2/mtf-builder/"    "altamira2/mtf-builder"
 check_org_repo "https://user@gitlab.com/org/repo.git"         "org/repo"
@@ -259,6 +266,15 @@ check_org_repo "https://oauth2:ghp_SECRET@gitlab.com:8443/org/repo.git" "org/rep
 # putting the token in stdout and in a synced note's `repo:` frontmatter.
 check_org_repo "https://oauth2:ghp_SECRET@gitlab.com/org/repo.git" "org/repo"
 check_org_repo "https://host:8443/org/repo.git"               "org/repo"
+
+# The fold must not reach repo_name: that field is a note's H1 and a tag, so a
+# subgroup repo would otherwise be titled `g-sub1-sub2-repo`.
+make_git_stub 0 "https://gitlab.com/g/sub1/sub2/repo.git"
+OUT="$(run_hook "$QUIET")"
+case "$OUT" in
+  *'repo_name=repo '*|*'repo_name=repo') : ;;
+  *) fail "a subgroup remote must still name the repository, not the folded group path"$'\n'"got: ${OUT:-<empty>}" ;;
+esac
 check_org_repo "file:///srv/git/repo.git"                     "local/mtf-builder"
 check_org_repo "/srv/git/bare-repo"                           "local/mtf-builder"
 

--- a/tests/commit-capture-state-store.sh
+++ b/tests/commit-capture-state-store.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# The snapshot store's shape (#63): one accessor owns the path, the two hooks
+# call it, and the store is state rather than cache on purpose.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/cc-state-XXXXXX")"; trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck source=../scripts/lib/commit-capture-parse.sh
+. "$ROOT_DIR/scripts/lib/commit-capture-parse.sh"
+
+PAYLOAD='{"tool_name":"Bash","tool_use_id":"toolu_state_1","session_id":"s-1","tool_input":{"command":"git commit -m x","cwd":"/tmp"}}'
+
+# 1. The composed path is exactly dir + key. Anything else means a caller that
+#    builds the path from the parts lands somewhere the accessor does not.
+XDG_STATE_HOME="$TMP/state"
+export XDG_STATE_HOME
+DIR="$(cc_snapshot_dir)"
+KEY="$(cc_snapshot_key "$PAYLOAD")"
+FILE="$(cc_snapshot_file "$PAYLOAD")"
+[ -n "$KEY" ] || fail "cc_snapshot_key returned nothing, so every call would share one snapshot file"
+[ "$FILE" = "${DIR}/${KEY}" ] \
+  || fail "cc_snapshot_file is not cc_snapshot_dir + key:"$'\n'"file: $FILE"$'\n'"dir:  $DIR"$'\n'"key:  $KEY"
+
+# 2. State, not cache (#63). A cache is discardable by definition and losing a
+#    snapshot loses a capture, so the store must not migrate under XDG_CACHE_HOME
+#    just to match keeper-state.sh's directory convention.
+case "$DIR" in
+  "$TMP/state"/*) : ;;
+  *) fail "cc_snapshot_dir ignored XDG_STATE_HOME; got: $DIR" ;;
+esac
+XDG_CACHE_HOME="$TMP/cache" DIR2="$(cc_snapshot_dir)"
+case "$DIR2" in
+  *"$TMP/cache"*) fail "cc_snapshot_dir resolved under XDG_CACHE_HOME: $DIR2" ;;
+esac
+
+# 3. Both hooks go through the accessor. The pre-hook writes the snapshot and the
+#    post-hook reads and deletes it, so a hook that assembles the path itself can
+#    be half-updated: the pre-hook keeps writing where the post-hook no longer
+#    looks, every commit goes uncaptured, and both halves report success.
+for h in scripts/commit-capture-pre.sh scripts/commit-capture.sh; do
+  if grep -q 'pre-commit-head' "$ROOT_DIR/$h"; then
+    fail "$h composes the snapshot path itself (found a literal 'pre-commit-head'); call cc_snapshot_dir/cc_snapshot_file instead:"$'\n'"$(grep -n 'pre-commit-head' "$ROOT_DIR/$h")"
+  fi
+  grep -q 'cc_snapshot_file' "$ROOT_DIR/$h" \
+    || fail "$h does not call cc_snapshot_file, so it is not reading the shared layout"
+done
+
+# 4. Two concurrent commits in one session get two snapshots. The key is the
+#    invocation, which is why this store cannot adopt keeper_vault_id — a
+#    per-vault id would collapse both calls onto one file and the second commit
+#    would consume the first's snapshot.
+OTHER='{"tool_name":"Bash","tool_use_id":"toolu_state_2","session_id":"s-1","tool_input":{"command":"git commit -m y","cwd":"/tmp"}}'
+[ "$(cc_snapshot_file "$OTHER")" != "$FILE" ] \
+  || fail "two invocations in one session resolved to the same snapshot file"
+
+# 5. No tool_use_id falls back to the session, and two sessions still differ.
+S1='{"tool_name":"Bash","session_id":"sess-a","tool_input":{"command":"git commit -m x","cwd":"/tmp"}}'
+S2='{"tool_name":"Bash","session_id":"sess-b","tool_input":{"command":"git commit -m x","cwd":"/tmp"}}'
+[ -n "$(cc_snapshot_key "$S1")" ] || fail "a payload with no tool_use_id produced an empty key"
+[ "$(cc_snapshot_file "$S1")" != "$(cc_snapshot_file "$S2")" ] \
+  || fail "two sessions collapsed onto one snapshot file"
+
+echo "PASS: commit-capture-state-store"


### PR DESCRIPTION
Closes #63
Closes #64

No version bump — releases are batched until the backlog run is done.

### #63 — one accessor owns the snapshot path (`4dc8b4d`)

Both hooks assembled `cc_state_dir` + a literal `pre-commit-head` + `cc_snapshot_key` themselves. Two copies of a layout can be half-changed: the pre-hook keeps writing snapshots the post-hook no longer looks for, every commit goes uncaptured, and both halves report success. `cc_snapshot_dir` / `cc_snapshot_file` are now the only place the layout exists.

Most of what the issue asked for had already landed: the write is tmp + `mv -f` (so the read-then-write race it names is closed) and #71 made the failure reportable. What was left was the duplication and the undocumented divergence from `keeper-state.sh`, so the divergences are recorded next to the accessors as decisions rather than drift:

- `XDG_STATE_HOME`, not `XDG_CACHE_HOME` — a cache is discardable by definition, and losing a snapshot loses a capture.
- keyed by `tool_use_id`, not a hashed vault id — these are per-invocation records, and a per-vault key would collapse two concurrent commits onto one file.
- no `keeper_state_init` — the pre-hook has to mkdir and report the failure itself, since it is the half that can still warn before the commit runs.

### #64 — GitLab subgroups fold into two segments (`e5d2eaf`)

`https://gitlab.com/g/sub1/sub2/repo` derived `g/sub1/sub2/repo`, so the note landed four levels under `Projects/Development/` where every other repo lands two — past the reach of the prefix-shaped routing overrides and of anything globbing `*/*`.

Everything above the repository now folds into the first segment, joined with `-`: `g-sub1-sub2/repo`. The issue's other option, collapsing to `<top-group>/<repo>`, would make `group/team-a/api` and `group/team-b/api` the same folder and interleave two repos' notes in one file. Keeping the repository as the leaf also leaves `repo_name` reading the repository rather than the folded path.

`altamira2/mtf-builder` is two segments already, so no existing note moves folders and there is no migration.

### Testing

1. `bash tests/commit-capture-state-store.sh` — new suite: the composed path is exactly dir + key, the store resolves under `XDG_STATE_HOME` and never under `XDG_CACHE_HOME`, neither hook contains a literal `pre-commit-head`, and two invocations (and two sessions) get distinct files.
2. `bash tests/commit-capture-detection.sh` — subgroup expectations updated from `group/sub/repo` to `group-sub/repo`, plus a three-level case and an assertion that `repo_name` stays `repo`.
3. `bash tests/run-all.sh` and `/bin/bash tests/run-all.sh` (3.2.57) — all suites pass.
4. Six targeted reverts, each caught by the assertion written for it: path != dir+key, store moved under the cache dir, pre-hook rebuilding the literal path, key ignoring the invocation, subgroup fold removed, fold replaced by the top-group collapse.
