### PR TITLE
Keep the host path out of vault-root scan records (#56)

### DIFF
--- a/scripts/lib/vault-scan.sh
+++ b/scripts/lib/vault-scan.sh
@@ -28,6 +28,26 @@ if [ ! -r "${_vs_lib_dir}/dedup-scan.sh" ]; then
 fi
 . "${_vs_lib_dir}/dedup-scan.sh"
 
+# A record's path field is vault-relative by contract, and every scanner used to
+# strip with `${p#"$vault"/}` inline. That trailing slash is part of the pattern,
+# so it cannot match when the path *is* the vault — a `.md` file directly in the
+# vault root produced `CLUSTER<TAB>/Users/<name>/Documents/Obsidian<TAB>…`, and
+# that row lands in Librarian.md, which Syncthing replicates to every host. The
+# local username left the machine (#56).
+_scan_rel() {
+  local vault="$1" rel="$2"
+  rel="${rel#"$vault"}"
+  rel="${rel#/}"
+  [ -n "$rel" ] || rel="."
+  # find is rooted at the vault, so a path that did not strip is unreachable. If
+  # it ever happens, the row must still not carry an absolute host path into a
+  # synced file — losing the directory beats leaking the home directory.
+  case "$rel" in
+    /*) rel="${rel##*/}" ;;
+  esac
+  printf '%s' "$rel"
+}
+
 _scan_find_md() {
   find "$1" -type f -name '*.md' \
     ! -path '*/.obsidian/*' ! -path '*/.trash/*' \
@@ -40,7 +60,7 @@ scan_frontmatter_gaps() {
   local vault="$1" required="$2" f miss
   while IFS= read -r f; do
     miss="$(frontmatter_missing "$f" "$required" | sort | paste -sd, -)"
-    [ -n "$miss" ] && printf 'GAP\t%s\t%s\n' "${f#"$vault"/}" "$miss"
+    [ -n "$miss" ] && printf 'GAP\t%s\t%s\n' "$(_scan_rel "$vault" "$f")" "$miss"
   done < <(_scan_find_md "$vault")
   return 0
 }
@@ -49,7 +69,7 @@ scan_unfiled() {
   local vault="$1" f
   [ -d "$vault/Inbox" ] || return 0
   while IFS= read -r f; do
-    printf 'UNFILED\t%s\n' "${f#"$vault"/}"
+    printf 'UNFILED\t%s\n' "$(_scan_rel "$vault" "$f")"
   done < <(find "$vault/Inbox" -type f -name '*.md')
   return 0
 }
@@ -58,7 +78,7 @@ scan_open_asks() {
   local vault="$1" f
   while IFS= read -r f; do
     if grep -qI '\[ask' "$f" 2>/dev/null; then
-      printf 'ASK\t%s\n' "${f#"$vault"/}"
+      printf 'ASK\t%s\n' "$(_scan_rel "$vault" "$f")"
     fi
   done < <(_scan_find_md "$vault")
   return 0
@@ -87,7 +107,7 @@ scan_clusters() {
     # splits on `-` only, and this vault has filenames with spaces. `sort -u`
     # keeps the count "distinct files containing the token", not total occurrences.
     slug="${base// /-}"
-    rel="${dir#"$vault"/}"
+    rel="$(_scan_rel "$vault" "$dir")"
     tokenize_slug "$slug" | sort -u | while IFS= read -r tok; do
       [ -n "$tok" ] && printf '%s\t%s\n' "$rel" "$tok"
     done

--- a/tests/vault-scan.sh
+++ b/tests/vault-scan.sh
@@ -205,4 +205,31 @@ _n="$(printf '%s\n' "$_out" | grep -c '^CLUSTER' || true)"
 printf '%s\n' "$_out" | grep -qF "CLUSTER"$'\t'"Awesome Folder 7"$'\t'"note"$'\t'"3" \
   || fail "space-bearing folder name was mangled: $(printf '%s\n' "$_out" | grep 'Awesome' | head -2)"
 
+# --- vault-root records carry no host path (#56) -----------------------------
+# Every row's path field is vault-relative by contract. `${p#"$vault"/}` cannot
+# strip when the path IS the vault, so a .md file directly in the root emitted the
+# absolute directory — into Librarian.md, which Syncthing replicates, so the local
+# username left the machine. The username is the reason this is asserted on the
+# whole output and not just the CLUSTER row.
+ROOTV="$TMP/rootvault"; mkdir -p "$ROOTV"
+for _n in 1 2 3; do printf -- '---\ntags: [x]\n---\n\nhas [ask:q?] marker\n' > "$ROOTV/rooted-topic-$_n.md"; done
+R_CLUST="$(scan_clusters "$ROOTV" 3)"
+R_GAPS="$(scan_frontmatter_gaps "$ROOTV" "tags type")"
+R_ASKS="$(scan_open_asks "$ROOTV")"
+for _f in "$R_CLUST" "$R_GAPS" "$R_ASKS"; do
+  case "$_f" in
+    *"$ROOTV"*) fail "a vault-root record leaked the absolute vault path, which syncs to every host:"$'\n'"$_f" ;;
+    */Users/*|*/home/*) fail "a vault-root record leaked a home directory:"$'\n'"$_f" ;;
+  esac
+done
+# The root's own rel form is `.` — the contract needs a value, and an empty field
+# would shift every column after it in a tab-delimited row.
+printf '%s\n' "$R_CLUST" | grep -qF "CLUSTER"$'\t.\t'"rooted"$'\t'"3" \
+  || fail "vault-root cluster is not labelled '.':"$'\n'"$R_CLUST"
+# A root file's own path field is still just its filename, unchanged by the fix.
+printf '%s\n' "$R_GAPS" | grep -qF "GAP"$'\t'"rooted-topic-1.md"$'\t'"type" \
+  || fail "a root file's GAP path is not the bare filename:"$'\n'"$R_GAPS"
+printf '%s\n' "$R_ASKS" | grep -qF "ASK"$'\t'"rooted-topic-1.md" \
+  || fail "a root file's ASK path is not the bare filename:"$'\n'"$R_ASKS"
+
 echo "PASS: vault-scan"


### PR DESCRIPTION
Closes #56

**Commit:** `d5c8c31`. No version bump — releases are batched until the backlog run is done.

### The bug

Every scanner stripped the vault prefix with `${p#"$vault"/}`. That trailing slash is part of the pattern, so it cannot match when the path *is* the vault. A `.md` file directly in the vault root emitted:

```
CLUSTER	/Users/<name>/Documents/Obsidian	report	4
```

That row lands in `Librarian.md`, which Syncthing replicates to every host — so the local username left the machine. Pre-existing, identical in the old and new implementations, which is why #49's equivalence check couldn't see it.

### The fix

One `_scan_rel` helper owns the strip for all four scanners. The issue named the cluster call site, but the idiom was copy-pasted into `scan_frontmatter_gaps`, `scan_unfiled`, and `scan_open_asks` too — fixing one leaves the same latent bug three times over.

Two details:

- The root's rel form is `.`, not empty. An empty field shifts every column after it in a tab-delimited row.
- A path that somehow fails to strip is reduced to its basename rather than emitted absolute. `find` is rooted at the vault so that's unreachable, but losing a directory beats leaking a home directory.

### Testing

1. `bash tests/vault-scan.sh` — new arm builds a vault with three `.md` files in the root, then asserts no CLUSTER/GAP/ASK row contains the vault path or a `/Users/`–`/home/` segment, the cluster is labelled `.`, and a root file's own path field is still the bare filename.
2. `bash tests/run-all.sh` — all suites pass.
3. Four targeted reverts. Restoring the trailing-slash strip and emitting empty both fail the `.`-label assertion; bypassing the helper in `scan_clusters` fails the ordinary `Projects` cluster; and removing the strip fix *and* the absolute-path guard together is what proves the leak assertion is live rather than decorative.
