### PR TITLE
Scan diagnostics: cold-start banner, fault-buffer dedup, threshold guard (#52, #54, #55)

### DIFF
--- a/scripts/lib/keeper-state.sh
+++ b/scripts/lib/keeper-state.sh
@@ -43,10 +43,33 @@ keeper_last_scan_file() { printf '%s/last_scan\n' "$(keeper_cache_dir "$1")"; }
 keeper_record_scan()    { local f; f="$(keeper_last_scan_file "$1")"; mkdir -p "$(dirname "$f")"; now_epoch > "$f"; }
 keeper_last_scan()      { local f; f="$(keeper_last_scan_file "$1")"; [ -f "$f" ] && cat "$f" || true; }
 
+# The banner is the only place a user hears that the index is not being
+# maintained. It used to return silently when last_scan was absent, which is
+# indistinguishable from a fresh successful scan — and absent is exactly what a
+# host whose *first* scan faulted has, because the tick withholds last_scan on a
+# fault. Such a host reported nothing wrong, permanently (#52).
+#
+# The cache dir is the "has the keeper ever run here" test: it is created by
+# keeper_state_init at the top of every tick. Without that condition the banner
+# would nag on any vault where the keeper was never installed, which is not a
+# fault and not this warning's business.
 staleness_banner() {
   local vault="$1" interval="$2" last now
   last="$(keeper_last_scan "$vault")"
-  [ -z "$last" ] && return 0
+  if [ -z "$last" ]; then
+    [ -d "$(keeper_cache_dir "$vault")" ] || return 0
+    printf '⚠ index has never completed a scan on this host\n'
+    return 0
+  fi
+  # A last_scan that is not a number cannot be compared, and the arithmetic below
+  # would abort the caller (ask-staleness.sh runs under set -e). Unreadable is a
+  # state to report, not one to fall silent on.
+  case "$last" in
+    *[!0-9]*)
+      printf '⚠ index last_scan is unreadable on this host\n'
+      return 0
+      ;;
+  esac
   now="$(now_epoch)"
   if [ "$(( now - last ))" -gt "$(( interval * 2 ))" ]; then
     printf '⚠ index last maintained %ss ago\n' "$(( now - last ))"

--- a/scripts/lib/vault-scan.sh
+++ b/scripts/lib/vault-scan.sh
@@ -100,6 +100,19 @@ scan_open_asks() {
 # process substitution for the whole scan, so there is no headroom to run out of.
 scan_clusters() {
   local vault="$1" threshold="$2" f dir base slug rel
+  # The awk gate below coerces a non-numeric threshold to 0, so `""` or `"abc"`
+  # returned every token in the vault as a cluster — silently, filling Librarian.md
+  # with noise. `"3.7"` returned a partial answer for the same reason. The `[ "$cnt"
+  # -ge "$threshold" ]` shape this replaced errored loudly instead, and loud is the
+  # direction this codebase went in #49. Production passes a literal 3 today, so
+  # there is no live defect — but keeper_interval_secs and its neighbours are already
+  # config-sourced, and this is one typo away the moment the threshold joins them.
+  case "$threshold" in
+    ''|*[!0-9]*|0)
+      printf 'vault-scan: cluster threshold must be a positive integer, got "%s"\n' "$threshold" >&2
+      return 1
+      ;;
+  esac
   while IFS= read -r f; do
     dir="${f%/*}"
     base="${f##*/}"; base="${base%.md}"

--- a/scripts/vaultkeeper-tick.sh
+++ b/scripts/vaultkeeper-tick.sh
@@ -64,7 +64,22 @@ CAND="$( {
   if [ -n "$CONFLICTS" ]; then printf '%s\n' "$CONFLICTS"; fi
 } 2>"${SCAN_ERR:-/dev/stderr}" | sed '/^$/d' )"
 if [ -n "$SCAN_ERR" ] && [ -s "$SCAN_ERR" ]; then
-  SCAN_FAULT="$(tr -c '[:print:]' ' ' < "$SCAN_ERR")" || SCAN_FAULT="unreadable"
+  # Deduplicate before truncating. `_scan_find_md` backs three scanners, so one
+  # unreadable directory yields the same `find: … Permission denied` line three
+  # times; the 300-char clamp then spent the whole budget on the repetition and cut
+  # off mid-word, hiding anything more serious further down. The buffer is the only
+  # description of the fault the user gets, so what it drops matters.
+  #
+  # Newlines are kept through the control-character scrub so there are lines to
+  # deduplicate, then folded to spaces afterwards for the one-line report. `sort -u`
+  # costs the chronological order, which is worth less here than not losing a
+  # distinct message.
+  SCAN_FAULT="$(tr -c '[:print:]\n' ' ' < "$SCAN_ERR" | sed 's/ *$//' | sed '/^$/d' | sort -u | tr '\n' ' ')" \
+    || SCAN_FAULT="unreadable"
+  SCAN_FAULT="${SCAN_FAULT% }"
+  # An unreadable-but-nonempty buffer must still read as a fault: empty here would
+  # be read as "no fault" by every `-n "$SCAN_FAULT"` test below.
+  [ -n "$SCAN_FAULT" ] || SCAN_FAULT="scanners wrote to stderr but the buffer could not be summarised"
   SCAN_FAULT="${SCAN_FAULT:0:300}"
   printf '%s\n' "$SCAN_FAULT" >&2
 fi

--- a/tests/keeper-state.sh
+++ b/tests/keeper-state.sh
@@ -34,12 +34,36 @@ keeper_has_snapshot "$VAULT" || fail "snapshot should exist after write"
 
 # last_scan + staleness
 [ -z "$(keeper_last_scan "$VAULT")" ] || fail "last_scan should be empty"
-[ -z "$(staleness_banner "$VAULT" 900)" ] || fail "no banner when last_scan absent"
+# An absent last_scan is NOT healthy (#52). The tick withholds last_scan when a
+# scan faults, so a host whose first scan ever faulted has none — and the old
+# behaviour (silence) made that indistinguishable from a fresh successful scan,
+# permanently. The cache dir exists here because keeper_state_init ran above,
+# which is the same condition a real tick establishes.
+COLD="$(staleness_banner "$VAULT" 900)"
+[ -n "$COLD" ] \
+  || fail "a host that has never recorded a scan reported nothing wrong"
+case "$COLD" in
+  *never*) : ;;
+  *) fail "cold start must say it has never scanned, not reuse the stale wording: $COLD" ;;
+esac
+# …but a vault the keeper has never touched is not a fault, and must stay quiet.
+UNTOUCHED="$TMP/untouched"; mkdir -p "$UNTOUCHED"
+[ -z "$(staleness_banner "$UNTOUCHED" 900)" ] \
+  || fail "warned about a vault where the keeper has never run: $(staleness_banner "$UNTOUCHED" 900)"
 keeper_record_scan "$VAULT"
 [ -n "$(keeper_last_scan "$VAULT")" ] || fail "last_scan not recorded"
 [ -z "$(staleness_banner "$VAULT" 900)" ] || fail "fresh scan should not warn"
 # force stale: last_scan far in the past (> 2*interval)
 printf '1000\n' > "$(keeper_cache_dir "$VAULT")/last_scan"
 [ -n "$(staleness_banner "$VAULT" 900)" ] || fail "stale scan should warn"
+
+# A corrupt last_scan must be reported, not silently compared. The arithmetic
+# below it would otherwise abort the caller — ask-staleness.sh runs under set -e.
+printf 'not-a-number\n' > "$(keeper_cache_dir "$VAULT")/last_scan"
+BAD="$(staleness_banner "$VAULT" 900)" || fail "an unreadable last_scan aborted staleness_banner"
+case "$BAD" in
+  *unreadable*) : ;;
+  *) fail "an unreadable last_scan produced no distinct warning: ${BAD:-<empty>}" ;;
+esac
 
 echo "PASS: keeper-state"

--- a/tests/vault-scan.sh
+++ b/tests/vault-scan.sh
@@ -205,6 +205,24 @@ _n="$(printf '%s\n' "$_out" | grep -c '^CLUSTER' || true)"
 printf '%s\n' "$_out" | grep -qF "CLUSTER"$'\t'"Awesome Folder 7"$'\t'"note"$'\t'"3" \
   || fail "space-bearing folder name was mangled: $(printf '%s\n' "$_out" | grep 'Awesome' | head -2)"
 
+# --- a non-numeric cluster threshold fails loudly (#55) ----------------------
+# awk coerces a non-numeric `t` to 0, so an unusable threshold returned every token
+# in the vault as a cluster — silently, filling Librarian.md with noise. Each of
+# these must refuse instead, and refuse without emitting rows: a caller that
+# ignores the status must not receive plausible-looking output.
+for _bad in "" "abc" "3.7" "-1" "0" " 3"; do
+  _terr="$TMP/thr.err"
+  if _tout="$(scan_clusters "$V" "$_bad" 2>"$_terr")"; then
+    fail "threshold '$_bad' was accepted; got $(printf '%s\n' "$_tout" | grep -c '^CLUSTER' || true) cluster row(s)"
+  fi
+  [ -z "$_tout" ] \
+    || fail "threshold '$_bad' was refused but still emitted rows:"$'\n'"$_tout"
+  grep -q 'cluster threshold' "$_terr" \
+    || fail "threshold '$_bad' failed without saying why: $(cat "$_terr")"
+done
+# A valid threshold is unaffected.
+scan_clusters "$V" 3 >/dev/null || fail "a valid threshold was refused"
+
 # --- vault-root records carry no host path (#56) -----------------------------
 # Every row's path field is vault-relative by contract. `${p#"$vault"/}` cannot
 # strip when the path IS the vault, so a .md file directly in the root emitted the

--- a/tests/vaultkeeper-tick.sh
+++ b/tests/vaultkeeper-tick.sh
@@ -110,6 +110,45 @@ if [ -f "$CV/Pending.md" ]; then
     || fail "fault/heal cycles duplicated $_dups Pending.md item(s): $(grep '^- \[ \]' "$CV/Pending.md" | sort | uniq -d | head -3)"
 fi
 
+# --- one repeated benign error must not crowd out a serious one (#54) --------
+# `_scan_find_md` backs three scanners, so a single unreadable directory puts the
+# same `find: … Permission denied` line in the buffer three times. The 300-char
+# clamp then spent its whole budget on the repetition and cut off mid-word, so the
+# fault the user actually needed to see never got reported. The buffer is the only
+# description of the fault they get.
+RV="$TMP/repeatvault"; mkdir -p "$RV/Inbox"
+printf -- '---\ntags: [x]\n---\nbody\n' > "$RV/n.md"
+RCFG="$TMP/repeat.local.md"; sed "s|^vault_path: .*|vault_path: $RV|" "$CFG" > "$RCFG"
+RLIB="$TMP/repeatlib"; mkdir -p "$RLIB"; cp "${ROOT_DIR}"/scripts/lib/*.sh "$RLIB/"
+cat >> "$RLIB/vault-scan.sh" <<'EOF'
+scan_open_asks() {
+  local i
+  # Identical every time, exactly as one chmod 000 directory reaches the buffer
+  # through three callers — only more of them, so the clamp is unambiguous.
+  for i in $(seq 1 40); do
+    printf 'find: /vault/some/deep/unreadable/directory/path: Permission denied\n' >&2
+  done
+  printf 'find: CRITICAL-LATE-FAULT too many open files\n' >&2
+  return 0
+}
+EOF
+RS="$TMP/repeatscripts"; mkdir -p "$RS"; cp "${ROOT_DIR}"/scripts/*.sh "$RS/" 2>/dev/null || true
+cp -R "$RLIB" "$RS/lib"
+ROUT="$TMP/repeat.out"
+OBSIDIAN_LOCAL_MD="$RCFG" VAULTKEEPER_HOST="ml-1" \
+  bash "$RS/vaultkeeper-tick.sh" >"$ROUT" 2>&1 \
+  || fail "a repeated scanner fault must not abort the tick; got: $(cat "$ROUT")"
+grep -q 'scan INCOMPLETE' "$ROUT" \
+  || fail "the repeated-fault tick was not named incomplete; got: $(cat "$ROUT")"
+grep -q 'CRITICAL-LATE-FAULT' "$ROUT" \
+  || fail "the serious fault was truncated away by 40 copies of a benign one; got: $(cat "$ROUT")"
+# The tick reports the buffer twice (once raw, once in the INCOMPLETE line), so a
+# deduplicated buffer shows the repeated message twice in total. Without the dedup
+# the clamp packs several copies into each of those lines.
+_reps="$(grep -o 'Permission denied' "$ROUT" | wc -l | tr -d ' ')"
+[ "$_reps" -le 2 ] \
+  || fail "the repeated message appears $_reps times, so it is still eating the 300-char budget"
+
 # --- a gate that cannot arm must not wave the tick through (#42, panel) ---
 # `SCAN_ERR="$(mktemp …)" || SCAN_ERR=""` failed open: with no buffer the fault
 # check could never fire, so the tick recorded a partial scan as complete — the


### PR DESCRIPTION
Closes #52
Closes #54
Closes #55

Three self-contained items from the #49 review-panel cluster, one commit each. No version bump — releases are batched until the backlog run is done. The structural siblings (#51, #53, #57, #58) are still open; they need a design, not a patch.

### #52 — a host that has never completed a scan says so (`02ef787`)

`staleness_banner` returned silently when `last_scan` was absent, which is indistinguishable from a fresh successful scan. The tick withholds `last_scan` on a faulted scan, so a host whose *first* scan ever faulted had none and reported nothing wrong, permanently.

Absent now warns, gated on the cache dir existing — `keeper_state_init` creates it at the top of every tick, so that is the "has the keeper ever run here" test, and without it the banner would nag on any vault where the keeper was never installed.

Also fixed while in there: a non-numeric `last_scan` reached the arithmetic, which under `ask-staleness.sh`'s `set -e` aborted the caller rather than reporting anything. It gets its own warning. The mutant for this one fails with `an unreadable last_scan aborted staleness_banner`, so the abort was real, not theoretical.

The existing test asserted the old silence and now asserts the warning.

### #54 — deduplicate the fault buffer before clamping (`4fbb59b`)

`_scan_find_md` backs three scanners, so one unreadable directory puts the same `find: … Permission denied` line in the buffer three times. The 300-char clamp ran after the repetition and cut mid-word, so a repeated benign error could consume the whole budget and hide a serious fault below it.

Newlines now survive the control-character scrub so there are lines to deduplicate; `sort -u` collapses them; the fold to one line happens after. That costs chronological order, which is worth less than a distinct message. A buffer that is non-empty but summarises to nothing gets a stand-in string, because an empty `SCAN_FAULT` reads as "no fault" to every check below it.

### #55 — refuse a threshold that isn't a positive integer (`2085924`)

awk coerces a non-numeric `t` to 0, so `""` / `"abc"` returned every token in the vault as a cluster and `"3.7"` returned a partial answer — both silently, into `Librarian.md`.

No live defect: the tick passes a literal `3`. But `keeper_interval_secs` and its neighbours are already config-sourced, so this is one typo away the moment the threshold joins them. Inside the tick the refusal lands in the scan-fault buffer (the command substitution's status is the pipeline's, so `set -e` doesn't fire), and the gate reports an incomplete scan rather than the tick dying.

### Testing

1. `bash tests/keeper-state.sh` — cold start warns and says "never", an untouched vault stays quiet, a corrupt `last_scan` is reported without aborting.
2. `bash tests/vaultkeeper-tick.sh` — new arm runs the tick with a scanner emitting 40 identical `Permission denied` lines followed by one `CRITICAL-LATE-FAULT`; asserts the serious line survives into the report and the repeated one appears at most twice (once per report line).
3. `bash tests/vault-scan.sh` — `""`, `abc`, `3.7`, `-1`, `0`, `" 3"` each refused, with no rows emitted and a message naming the problem; a valid threshold unaffected.
4. `bash tests/run-all.sh` and `/bin/bash tests/run-all.sh` (3.2.57) — all suites pass.
5. Eight targeted reverts, each caught by the assertion written for it: silent-on-absent, warning without the cache-dir condition, no corrupt-value guard, pre-fix collapse, dedup dropped, guard removed, guard that warns but continues, and a partial guard that still accepts `""` and `0`.
