### PR TITLE
Scanner completeness signal, quarantine capture, fd arm, receipt survival (#51, #53, #57, #58)

### DIFF
--- a/scripts/lib/surfacing.sh
+++ b/scripts/lib/surfacing.sh
@@ -3,19 +3,26 @@
 # append only genuinely-new candidates to Pending.md (transition-gated against
 # the prior-scan snapshot). Requires note-hash.sh + keeper-state.sh.
 
-# surfacing_digest <vault> [status]
+# surfacing_digest <vault> [status] [unreadable-count]
 # `status` is stamped as `scan_status:` when non-empty. The caller passes INCOMPLETE
 # when the scanners faulted: this file is the human-facing artifact and it was
 # claiming a fresh full scan — timestamp AND section counts — on ticks the keeper
 # itself refused to record as complete.
+#
+# `unreadable-count` is stamped as `paths_unreadable:`. It is separate from status on
+# purpose (#51): a path the host is not allowed to read is a standing condition, not
+# a fault — every readable note was still scanned — so the scan stays complete and
+# says how much of the vault it could not see. A count and not the paths: they are
+# absolute host paths, and this file is replicated to every host.
 surfacing_digest() {
-  local vault="$1" status="${2:-}" lines tmp target="$1/Librarian.md" kind label
+  local vault="$1" status="${2:-}" unreadable="${3:-}" lines tmp target="$1/Librarian.md" kind label
   lines="$(cat)"
   tmp="$(mktemp "$vault/.Librarian-XXXXXX")" || return 1
   {
     printf '%s\n' '<!-- MACHINE-OWNED: regenerated each vaultkeeper scan. Edits do not persist. -->'
     printf '# Librarian\n\nlast_scan: %s\n' "$(now_epoch)"
     [ -n "$status" ] && printf 'scan_status: %s\n' "$status"
+    [ -n "$unreadable" ] && printf 'paths_unreadable: %s\n' "$unreadable"
     for kind in GAP UNFILED ASK CLUSTER QUARANTINE; do
       if [ "$kind" = "GAP" ]; then label="Frontmatter gaps"
       elif [ "$kind" = "UNFILED" ]; then label="Unfiled (Inbox)"

--- a/scripts/lib/surfacing.sh
+++ b/scripts/lib/surfacing.sh
@@ -38,6 +38,36 @@ surfacing_digest() {
   mv "$tmp" "$target"
 }
 
+# surfacing_pending_append <vault>
+# Append rows to Pending.md without touching the prior-scan snapshot. For rows whose
+# side effect already happened and cannot be re-derived (#58).
+#
+# The four scanners re-derive their rows every tick, so withholding them on a faulted
+# tick loses nothing — the next healthy tick emits them again. QUARANTINE is not like
+# that: the row is a receipt for an irreversible `mv`, emitted exactly once, and the
+# file it names is excluded from every later walk, so a row dropped here is dropped
+# permanently. The user loses the `- [ ] QUARANTINE: …` line telling them a sync
+# conflict needs merging. The file is safely in .vaultkeeper-quarantine either way.
+#
+# Append-only is what makes this safe next to the transition gate: the snapshot is
+# left alone, and because the row can never be re-derived, the next healthy tick's
+# `comm -23` cannot see it as new and re-append it.
+surfacing_pending_append() {
+  local vault="$1" pending="$1/Pending.md" line out
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    out="- [ ] $(printf '%s' "$line" | sed 's/'$'\t''/: /')"
+    # Idempotent against what is already there. The move happens once so a repeat is
+    # not reachable today, but Pending.md is hand-edited and Syncthing-replicated —
+    # a duplicated checklist line is exactly the damage #49 went to lengths to avoid.
+    if [ -f "$pending" ] && grep -qxF -- "$out" "$pending"; then
+      continue
+    fi
+    printf '%s\n' "$out" >> "$pending"
+  done
+  return 0
+}
+
 surfacing_pending_transition() {
   local vault="$1" cur snap new pending="$1/Pending.md"
   cur="$(sort -u)"

--- a/scripts/lib/vault-scan.sh
+++ b/scripts/lib/vault-scan.sh
@@ -48,8 +48,77 @@ _scan_rel() {
   printf '%s' "$rel"
 }
 
+# Two different things used to arrive on the scanners' stderr and the tick could
+# only see "some bytes", so it treated both as a fault (#51):
+#
+#   unreadable — one `chmod 000` directory, an iCloud path macOS TCC refuses, a
+#     stale network mount. `find` prints `Permission denied` and walks on. Every
+#     readable note WAS scanned, and no tick can ever fix the path, so treating it
+#     as a fault made the gate latch: INCOMPLETE forever, last_scan never recorded,
+#     no recovery. Counted here and reported as a count, not a fault.
+#   truncated — the scan stopped early: `find` killed by a signal, or dying of fd
+#     or memory exhaustion. The candidate set is short and nothing said so. This is
+#     the half stderr missed entirely, because a scanner killed by a signal prints
+#     nothing at all.
+#
+# So the walk gets a real status instead of a diagnostic channel. Deliberately a
+# noise *denylist* rather than a fatal-pattern allowlist: a too-narrow allowlist
+# fails silent, which is the bug class this is removing, hand-rebuilt. A too-narrow
+# denylist merely reports a benign line as a fault — loud, and recoverable.
+#
+# The unreadable channel is a file because the walk runs inside a pipeline (and,
+# for the scanners, inside a process substitution), so a variable set here would be
+# set in a subshell and lost. The caller opts in by creating it; a caller that does
+# not gets the old behaviour — every line on stderr — which is loud, not silent.
+#
+# Returns non-zero when it could not record the line, so the caller can fall back
+# to stderr. Swallowing it here instead would make an unset collector mean "drop
+# these silently" — the exact silence this classification exists to remove, just
+# relocated.
+_scan_note_unreadable() {
+  [ -n "${KEEPER_SCAN_UNREADABLE_FILE:-}" ] || return 1
+  printf '%s\n' "$1" >> "$KEEPER_SCAN_UNREADABLE_FILE" 2>/dev/null || return 1
+  return 0
+}
+
+_scan_walk() {
+  local root="$1"; shift
+  local err rc=0 line
+  err="$(mktemp "${TMPDIR:-/tmp}/kbwalk-XXXXXX" 2>/dev/null)" || err=""
+  if [ -z "$err" ]; then
+    # No buffer means no classification, and silently reclassifying everything as
+    # benign is the failure this function exists to prevent. Say so and let the
+    # walk's own stderr through untouched.
+    printf 'vault-scan: cannot buffer find stderr (mktemp failed); walk of %s is not verifiable\n' "$root" >&2
+    find "$root" "$@" || true
+    return 0
+  fi
+  # `|| rc=$?` and not a bare call: an unreadable directory makes find exit 1, and
+  # the only production caller runs under `set -e`, so a bare call would kill this
+  # subshell right here — skipping the classification below, which is the whole
+  # point of the function.
+  find "$root" "$@" 2>"$err" || rc=$?
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$line" in
+      *'Permission denied'*|*'Operation not permitted'*)
+        _scan_note_unreadable "$line" || printf '%s\n' "$line" >&2
+        ;;
+      *) printf '%s\n' "$line" >&2 ;;
+    esac
+  done < "$err"
+  rm -f "$err" 2>/dev/null || true
+  # 128+N is "killed by signal N", which is the shape of a walk that stopped
+  # partway. find's plain exit 1 covers the unreadable-path case too, so it is not
+  # evidence of truncation on its own — the lines above already spoke for that.
+  if [ "$rc" -ge 128 ]; then
+    printf 'vault-scan: the walk of %s was killed (exit %s) — the candidate set is truncated\n' "$root" "$rc" >&2
+  fi
+  return 0
+}
+
 _scan_find_md() {
-  find "$1" -type f -name '*.md' \
+  _scan_walk "$1" -type f -name '*.md' \
     ! -path '*/.obsidian/*' ! -path '*/.trash/*' \
     ! -path '*/.git/*' ! -path '*/.vaultkeeper-quarantine/*' \
     ! -path '*/.vaultkeeper/*' \
@@ -70,7 +139,7 @@ scan_unfiled() {
   [ -d "$vault/Inbox" ] || return 0
   while IFS= read -r f; do
     printf 'UNFILED\t%s\n' "$(_scan_rel "$vault" "$f")"
-  done < <(find "$vault/Inbox" -type f -name '*.md')
+  done < <(_scan_walk "$vault/Inbox" -type f -name '*.md')
   return 0
 }
 

--- a/scripts/vaultkeeper-tick.sh
+++ b/scripts/vaultkeeper-tick.sh
@@ -35,7 +35,6 @@ if ! keeper_is_owner "$LEASE" "$HOST" "$PRIORITY" "$MAXAGE"; then
   exit 0
 fi
 
-CONFLICTS="$(keeper_quarantine_conflicts "$VAULT" || true)"
 # Capture the scanners' stderr instead of letting it fly past. Every scanner
 # returns 0 unconditionally, so a truncated scan was indistinguishable from a
 # complete one and got recorded as complete — for every one of 700+ consecutive
@@ -80,12 +79,37 @@ cleanup_bufs() {
   return 0
 }
 trap cleanup_bufs EXIT
+# Quarantine runs here, INSIDE the fault capture, and its status is kept (#53). It
+# used to run above — before the buffer even existed — with `|| true`, so a failed
+# `mv` printed `failed to quarantine …` straight past the gate and the non-zero exit
+# was discarded: the QUARANTINE list came back short and the tick recorded the scan
+# as complete. Same invariant as the scanners, one function over.
+#
+# It stays above the digest so its rows appear in Librarian.md. That its rows cannot
+# reach Pending.md on a faulted tick is a separate, filed problem (#58) — the move is
+# irreversible and no later tick re-derives the row.
 CAND="$( {
+  # First inside the group, not before it (#53). Before it, `CONFLICTS="$(… || true)"`
+  # ran while the buffer did not exist yet — and even appending to the buffer would
+  # not have worked, because the group's own `2>"$SCAN_ERR"` truncates the file when
+  # it opens. So a failed `mv` printed `failed to quarantine …` past the gate and
+  # `|| true` discarded the status: the QUARANTINE list came back short and the tick
+  # recorded the scan as complete. Inside, its stderr is the scanners' stderr.
+  #
+  # First and not last, because the scanners must not see the files it moves — run
+  # after them, a conflict file that was quarantined successfully still shows up as a
+  # frontmatter gap. Its rows go straight into CAND; the separate CONFLICTS variable
+  # existed only to carry them across the group boundary.
+  #
+  # It stays above the digest so its rows reach Librarian.md. That its rows cannot
+  # reach Pending.md on a faulted tick is a separate, filed problem (#58): the move is
+  # irreversible and no later tick re-derives the row.
+  keeper_quarantine_conflicts "$VAULT" \
+    || printf 'keeper_quarantine_conflicts exited non-zero\n' >&2
   scan_frontmatter_gaps "$VAULT" "$REQUIRED"
   scan_unfiled "$VAULT"
   scan_open_asks "$VAULT"
   scan_clusters "$VAULT" 3
-  if [ -n "$CONFLICTS" ]; then printf '%s\n' "$CONFLICTS"; fi
 } 2>"${SCAN_ERR:-/dev/stderr}" | sed '/^$/d' )"
 if [ -n "$SCAN_ERR" ] && [ -s "$SCAN_ERR" ]; then
   # Deduplicate before truncating. `_scan_find_md` backs three scanners, so one

--- a/scripts/vaultkeeper-tick.sh
+++ b/scripts/vaultkeeper-tick.sh
@@ -150,10 +150,9 @@ fi
 # base_view_write's content does not depend on CAND, and the digest is a full
 # overwrite that nothing reads back. A permanently-faulting host therefore still
 # surfaces something, which beats surfacing nothing — and the digest is told to say
-# which it is. Caveat: keeper_quarantine_conflicts (line 38) already moved any sync
-# conflict irreversibly and emits its row once, so on a faulted tick that row never
-# reaches Pending.md and no later tick can re-emit it. The file is safely in
-# .vaultkeeper-quarantine either way; the missing checklist line is filed separately.
+# which it is. keeper_quarantine_conflicts has already moved any sync conflict
+# irreversibly and emitted its row once, so that row cannot survive being withheld —
+# the fault branch below appends it, and only it, for that reason (#58).
 base_view_write "$VAULT/_vaultkeeper.base"
 printf '%s\n' "$CAND" | surfacing_digest "$VAULT" "${SCAN_FAULT:+INCOMPLETE}" "$SCAN_UNREADABLE"
 
@@ -167,8 +166,20 @@ if [ -n "$SCAN_FAULT" ]; then
   # complete tells it the vault was fully examined. Note the banner only fires once a
   # PREVIOUS last_scan ages out — a host that has never recorded one stays silent, so
   # a latched fault here is invisible rather than loud. That gap is filed separately.
-  printf 'vaultkeeper: scan INCOMPLETE on %s — snapshot and Pending.md left untouched; scanners said: %s\n' \
-    "$HOST" "$SCAN_FAULT" >&2
+  #
+  # One exception, and only one: rows whose side effect already happened and cannot be
+  # re-derived (#58). keeper_quarantine_conflicts has already `mv`d the conflict file
+  # and emitted its receipt once, and the file is excluded from every later walk — so a
+  # QUARANTINE row withheld here is withheld permanently, and the user never learns a
+  # sync conflict needs merging. Appended without touching the snapshot, which is what
+  # keeps the transition gate intact: a row that cannot be re-derived cannot come back
+  # through `comm -23` as new.
+  QUARANTINE_ROWS="$(printf '%s\n' "$CAND" | grep '^QUARANTINE'$'\t' || true)"
+  if [ -n "$QUARANTINE_ROWS" ]; then
+    printf '%s\n' "$QUARANTINE_ROWS" | surfacing_pending_append "$VAULT"
+  fi
+  printf 'vaultkeeper: scan INCOMPLETE on %s — snapshot untouched%s; scanners said: %s\n' \
+    "$HOST" "${QUARANTINE_ROWS:+, quarantine receipts appended to Pending.md}" "$SCAN_FAULT" >&2
   exit 0
 fi
 

--- a/scripts/vaultkeeper-tick.sh
+++ b/scripts/vaultkeeper-tick.sh
@@ -45,9 +45,7 @@ CONFLICTS="$(keeper_quarantine_conflicts "$VAULT" || true)"
 SCAN_FAULT=""
 SCAN_ERR="$(mktemp "${TMPDIR:-/tmp}/kbscan-XXXXXX" 2>/dev/null)" || SCAN_ERR=""
 if [ -n "$SCAN_ERR" ]; then
-  # trap, not a bare rm below: a tick killed for overrunning its launchd window
-  # otherwise leaks one buffer every 15 minutes, and the fault goes with it.
-  trap 'rm -f "$SCAN_ERR"' EXIT
+  :
 else
   # Fail closed. With no buffer the fault check can never fire, and failing open
   # here restored the exact bug this gate removes — a partial scan recorded as
@@ -56,6 +54,32 @@ else
   # an independent one.
   SCAN_FAULT="cannot create the scan-fault buffer (mktemp failed); scan not verifiable"
 fi
+# Permanently-unreadable paths are not a fault (#51). One `chmod 000` directory, or
+# an iCloud path macOS TCC refuses, made `find` print `Permission denied` — and the
+# gate, which could only see bytes on stderr, then reported INCOMPLETE on every tick
+# from then on and never recorded last_scan. No tick can fix such a path, so there
+# was no recovery: a vault whose readable notes were all scanned looked permanently
+# broken. vault-scan.sh now separates the two, routing these here to be counted.
+SCAN_UNREADABLE=""
+KEEPER_SCAN_UNREADABLE_FILE="$(mktemp "${TMPDIR:-/tmp}/kbunread-XXXXXX" 2>/dev/null)" \
+  || KEEPER_SCAN_UNREADABLE_FILE=""
+if [ -n "$KEEPER_SCAN_UNREADABLE_FILE" ]; then
+  export KEEPER_SCAN_UNREADABLE_FILE
+else
+  # Unlike the fault buffer, failing open here is the safe direction: with nowhere
+  # to record them, the unreadable lines stay on stderr and land in SCAN_FAULT — the
+  # old over-triggering behaviour, which is loud rather than silent.
+  unset KEEPER_SCAN_UNREADABLE_FILE
+fi
+# One trap for both buffers, set once they are both decided. A tick killed for
+# overrunning its launchd window otherwise leaks a file every 15 minutes — and
+# `rm -f ""` is not a no-op, so each path is guarded rather than interpolated bare.
+cleanup_bufs() {
+  [ -n "${SCAN_ERR:-}" ] && rm -f "$SCAN_ERR" 2>/dev/null
+  [ -n "${KEEPER_SCAN_UNREADABLE_FILE:-}" ] && rm -f "$KEEPER_SCAN_UNREADABLE_FILE" 2>/dev/null
+  return 0
+}
+trap cleanup_bufs EXIT
 CAND="$( {
   scan_frontmatter_gaps "$VAULT" "$REQUIRED"
   scan_unfiled "$VAULT"
@@ -84,6 +108,20 @@ if [ -n "$SCAN_ERR" ] && [ -s "$SCAN_ERR" ]; then
   printf '%s\n' "$SCAN_FAULT" >&2
 fi
 
+# Unreadable paths get reported every tick, and separately from the fault, because
+# they are a standing condition rather than an event: the count says "this many
+# places I am not allowed to look", the scan of everything else is complete, and
+# last_scan is recorded. Reported by count, not by path — the paths are absolute
+# host paths, and the digest is replicated to every host (#56).
+if [ -n "${KEEPER_SCAN_UNREADABLE_FILE:-}" ] && [ -s "$KEEPER_SCAN_UNREADABLE_FILE" ]; then
+  SCAN_UNREADABLE="$(sort -u "$KEEPER_SCAN_UNREADABLE_FILE" | grep -c . | tr -d ' ')"
+  [ "$SCAN_UNREADABLE" = "0" ] && SCAN_UNREADABLE=""
+fi
+if [ -n "$SCAN_UNREADABLE" ]; then
+  printf 'vaultkeeper: %s path(s) unreadable on %s — every readable note was scanned; permissions are not something a tick can fix\n' \
+    "$SCAN_UNREADABLE" "$HOST" >&2
+fi
+
 # These two stay above the gate because both survive a partial candidate set:
 # base_view_write's content does not depend on CAND, and the digest is a full
 # overwrite that nothing reads back. A permanently-faulting host therefore still
@@ -93,7 +131,7 @@ fi
 # reaches Pending.md and no later tick can re-emit it. The file is safely in
 # .vaultkeeper-quarantine either way; the missing checklist line is filed separately.
 base_view_write "$VAULT/_vaultkeeper.base"
-printf '%s\n' "$CAND" | surfacing_digest "$VAULT" "${SCAN_FAULT:+INCOMPLETE}"
+printf '%s\n' "$CAND" | surfacing_digest "$VAULT" "${SCAN_FAULT:+INCOMPLETE}" "$SCAN_UNREADABLE"
 
 if [ -n "$SCAN_FAULT" ]; then
   # Stop before the snapshot. surfacing_pending_transition diffs against it and then

--- a/tests/commit-capture-head-gate.sh
+++ b/tests/commit-capture-head-gate.sh
@@ -60,10 +60,20 @@ mkrepo() {
   git -C "$dir" remote add origin "$remote"
 }
 
+# Fixture files are named from the repo's own commit count and appended to, never
+# from $RANDOM into an empty file. The old shape drew `f$RANDOM.txt` and wrote it
+# empty, so any repeated draw across this suite's ~30 commits re-added an identical
+# blob at an identical path: git found nothing to commit, exited 1, and the arm
+# failed with `nothing to commit, working tree clean` — intermittently, at roughly
+# one whole-suite run in fifteen under bash 3.2, and never reproducibly. The commit
+# count is strictly increasing per repo (so it is unique even when a caller runs in a
+# subshell, where a shell counter would reset), and appending guarantees the content
+# differs even if a path is somehow reused — an amend leaves the count unchanged.
 commit_in() {
-  local dir="$1" subject="$2" file
-  file="f$RANDOM.txt"
-  : > "$dir/$file"
+  local dir="$1" subject="$2" file n
+  n="$(git -C "$dir" rev-list --count HEAD 2>/dev/null)" || n=0
+  file="f${n}.txt"
+  printf 'commit %s: %s\n' "$n" "$subject" >> "$dir/$file"
   git -C "$dir" add "$file"
   git -C "$dir" commit -q -m "$subject"
 }

--- a/tests/vault-scan.sh
+++ b/tests/vault-scan.sh
@@ -205,6 +205,73 @@ _n="$(printf '%s\n' "$_out" | grep -c '^CLUSTER' || true)"
 printf '%s\n' "$_out" | grep -qF "CLUSTER"$'\t'"Awesome Folder 7"$'\t'"note"$'\t'"3" \
   || fail "space-bearing folder name was mangled: $(printf '%s\n' "$_out" | grep 'Awesome' | head -2)"
 
+# --- unreadable is counted; truncated is reported (#51) ----------------------
+# The tick's gate could only see "bytes on stderr", so a permanently-unreadable
+# directory read as a fault and latched: INCOMPLETE forever, last_scan never
+# recorded, no recovery. The walk now classifies instead.
+if [ "$(id -u)" = "0" ]; then
+  echo "note: running as root, skipping the unreadable-path arms" >&2
+else
+  PV="$TMP/permvault"; mkdir -p "$PV/readable" "$PV/locked"
+  printf -- '---\ntags: [x]\n---\nbody\n' > "$PV/readable/seen.md"
+  printf -- '---\ntags: [x]\n---\nbody\n' > "$PV/locked/hidden.md"
+  chmod 000 "$PV/locked"
+  # chmod is undone in the trap's stead — rm -rf on a 000 directory fails otherwise
+  # and the fixture would outlive the suite.
+  restore_perm() { chmod 755 "$PV/locked" 2>/dev/null || true; }
+
+  # 1. Without the collector the benign line still reaches stderr, so a caller that
+  #    has not opted in behaves exactly as before — the tick's fail-open path.
+  P_ERR="$TMP/perm-noopt.err"
+  P_OUT="$(unset KEEPER_SCAN_UNREADABLE_FILE; scan_frontmatter_gaps "$PV" "tags type" 2>"$P_ERR")" \
+    || { restore_perm; fail "scan aborted on an unreadable directory"; }
+  grep -qE 'Permission denied|Operation not permitted' "$P_ERR" \
+    || { restore_perm; fail "with no collector the unreadable path must still be reported somewhere: $(cat "$P_ERR")"; }
+
+  # 2. With the collector, stderr is CLEAN — this is what un-latches the gate — and
+  #    the path is recorded for the caller to count.
+  U_FILE="$TMP/unreadable.list"; : > "$U_FILE"
+  P_ERR2="$TMP/perm-opt.err"
+  KEEPER_SCAN_UNREADABLE_FILE="$U_FILE" scan_frontmatter_gaps "$PV" "tags type" >/dev/null 2>"$P_ERR2" \
+    || { restore_perm; fail "scan aborted with the collector set"; }
+  if [ -s "$P_ERR2" ]; then
+    restore_perm
+    fail "an unreadable path still wrote to stderr, so the tick's gate will keep latching: $(cat "$P_ERR2")"
+  fi
+  [ -s "$U_FILE" ] \
+    || { restore_perm; fail "the unreadable path was suppressed but never recorded — that is silence, not classification"; }
+
+  # 3. Suppressing the noise must not suppress a real fault arriving the same way.
+  #    A too-narrow denylist should over-report, never under-report.
+  : > "$U_FILE"
+  F_ERR="$TMP/perm-fatal.err"
+  KEEPER_SCAN_UNREADABLE_FILE="$U_FILE" bash -c '
+    . "'"${ROOT_DIR}"'/scripts/lib/frontmatter.sh"
+    . "'"${ROOT_DIR}"'/scripts/lib/vault-scan.sh"
+    find() { command find "$@"; printf "find: %s: Too many open files\n" "$1" >&2; return 1; }
+    scan_open_asks "'"$PV"'" >/dev/null
+  ' 2>"$F_ERR" || { restore_perm; fail "the fatal-line probe aborted"; }
+  grep -q 'Too many open files' "$F_ERR" \
+    || { restore_perm; fail "a genuine fault was swallowed along with the benign lines: $(cat "$F_ERR")"; }
+
+  # 4. A walk killed by a signal says the set is truncated. Nothing said so before:
+  #    a scanner killed mid-walk prints nothing at all, so stderr — the only signal
+  #    the gate had — stayed empty and the short candidate set read as complete.
+  K_ERR="$TMP/killed.err"
+  KEEPER_SCAN_UNREADABLE_FILE="$U_FILE" bash -c '
+    . "'"${ROOT_DIR}"'/scripts/lib/frontmatter.sh"
+    . "'"${ROOT_DIR}"'/scripts/lib/vault-scan.sh"
+    # 128+9: exactly what a walk killed by SIGKILL leaves behind, and it writes
+    # nothing to stderr, which is why the old gate could not see it.
+    find() { return 137; }
+    scan_open_asks "'"$PV"'" >/dev/null
+  ' 2>"$K_ERR" || { restore_perm; fail "the killed-walk probe aborted"; }
+  grep -q 'truncated' "$K_ERR" \
+    || { restore_perm; fail "a walk killed by a signal reported nothing, so a short scan reads as complete: ${K_ERR:+$(cat "$K_ERR")}"; }
+
+  restore_perm
+fi
+
 # --- a non-numeric cluster threshold fails loudly (#55) ----------------------
 # awk coerces a non-numeric `t` to 0, so an unusable threshold returned every token
 # in the vault as a cluster — silently, filling Librarian.md with noise. Each of

--- a/tests/vaultkeeper-tick.sh
+++ b/tests/vaultkeeper-tick.sh
@@ -110,6 +110,59 @@ if [ -f "$CV/Pending.md" ]; then
     || fail "fault/heal cycles duplicated $_dups Pending.md item(s): $(grep '^- \[ \]' "$CV/Pending.md" | sort | uniq -d | head -3)"
 fi
 
+# --- the whole tick under real fd exhaustion (#57) ---------------------------
+# The scanner fix and the fault gate were each pinned individually, but nothing ran
+# the composition against the condition that produced the incident: the tick's own
+# fault arms shadow a scanner with a stub that writes to stderr, and per
+# `test-the-fix-not-the-investigation` a stub override exercising the stub is not
+# coverage of the shipped condition. This arm exhausts real file descriptors.
+#
+# The negative half restores the PRE-#49 scan_clusters verbatim from
+# f670411^ — nested process substitutions, two live fds per directory. Reconstructed
+# rather than stubbed, so what it proves is that the shipped code is what survives.
+FDV="$TMP/fdtickvault"; mkdir -p "$FDV/Inbox"
+for _i in $(seq 1 120); do
+  _d="$FDV/Folder $_i"; mkdir -p "$_d"
+  for _j in 1 2 3; do printf -- '---\ntags: [x]\ntype: a\n---\nbody\n' > "$_d/topic$_i note $_j.md"; done
+done
+FDCFG="$TMP/fdtick.local.md"; sed "s|^vault_path: .*|vault_path: $FDV|" "$CFG" > "$FDCFG"
+
+# 1. Shipped code, 64 fds: the tick completes and records the scan.
+FD1="$TMP/fdtick-fixed.out"
+( ulimit -n 64; OBSIDIAN_LOCAL_MD="$FDCFG" VAULTKEEPER_HOST="ml-1" \
+    bash "${ROOT_DIR}/scripts/vaultkeeper-tick.sh" >"$FD1" 2>&1 ) \
+  || fail "the tick failed under ulimit -n 64; got: $(cat "$FD1")"
+grep -q 'scan complete' "$FD1" \
+  || fail "the tick did not complete under ulimit -n 64; got: $(cat "$FD1")"
+grep -q 'scan INCOMPLETE' "$FD1" \
+  && fail "the tick reported a fault under ulimit -n 64 with the shipped scanner; got: $(cat "$FD1")"
+[ -f "$(keeper_last_scan_file "$FDV")" ] \
+  || fail "the tick completed under ulimit -n 64 but did not record last_scan"
+# 120 dirs x 3 files sharing 2 tokens each — the whole set, not whatever fd headroom
+# happened to allow. This is the number the incident's host got wrong (503 idle, 211
+# under load, silently).
+_fdclusters="$(grep -c '^- ' "$FDV/Librarian.md" || true)"
+[ "$_fdclusters" -ge 240 ] \
+  || fail "the digest lists only $_fdclusters rows under ulimit -n 64; the candidate set was truncated"
+
+# 2. Pre-#49 scanner, same limit: the tick must NOT record the scan as complete.
+FDLIB="$TMP/fdticklib"; mkdir -p "$FDLIB"; cp "${ROOT_DIR}"/scripts/lib/*.sh "$FDLIB/"
+git -C "$ROOT_DIR" show f670411^:scripts/lib/vault-scan.sh \
+  | sed -n '/^scan_clusters/,/^}/p' >> "$FDLIB/vault-scan.sh" \
+  || fail "could not recover the pre-#49 scan_clusters from git history"
+FDS="$TMP/fdtickscripts"; mkdir -p "$FDS"; cp "${ROOT_DIR}"/scripts/*.sh "$FDS/" 2>/dev/null || true
+cp -R "$FDLIB" "$FDS/lib"
+FDV2="$TMP/fdtickvault2"; cp -R "$FDV" "$FDV2"; rm -f "$FDV2/Librarian.md" "$FDV2/Pending.md"
+FDCFG2="$TMP/fdtick2.local.md"; sed "s|^vault_path: .*|vault_path: $FDV2|" "$CFG" > "$FDCFG2"
+FD2="$TMP/fdtick-old.out"
+( ulimit -n 64; OBSIDIAN_LOCAL_MD="$FDCFG2" VAULTKEEPER_HOST="ml-1" \
+    bash "$FDS/vaultkeeper-tick.sh" >"$FD2" 2>&1 ) \
+  || fail "the reverted-scanner tick aborted rather than reporting; got: $(cat "$FD2")"
+grep -q 'scan INCOMPLETE' "$FD2" \
+  || fail "the pre-#49 scanner exhausted fds and the tick still called the scan complete — the gate does not see it: $(cat "$FD2")"
+[ -f "$(keeper_last_scan_file "$FDV2")" ] \
+  && fail "the reverted-scanner tick recorded last_scan on a truncated scan"
+
 # --- a failed quarantine move is a fault too (#53) ---------------------------
 # `CONFLICTS="$(keeper_quarantine_conflicts … || true)"` ran above the buffer, so a
 # failed `mv` printed `failed to quarantine …` straight past the gate and `|| true`

--- a/tests/vaultkeeper-tick.sh
+++ b/tests/vaultkeeper-tick.sh
@@ -110,6 +110,52 @@ if [ -f "$CV/Pending.md" ]; then
     || fail "fault/heal cycles duplicated $_dups Pending.md item(s): $(grep '^- \[ \]' "$CV/Pending.md" | sort | uniq -d | head -3)"
 fi
 
+# --- a faulted tick keeps the quarantine receipt (#58) -----------------------
+# The four scanners re-derive their rows every tick, so withholding them on a fault
+# costs nothing. QUARANTINE is a receipt for an irreversible `mv`, emitted once, and
+# the file it names is excluded from every later walk — so a row withheld here was
+# withheld permanently and the user never learned a sync conflict needed merging.
+RQV="$TMP/receiptvault"; mkdir -p "$RQV/Inbox"
+printf -- '---\ntags: [x]\ntype: a\n---\nbody\n' > "$RQV/n.md"
+printf 'conflicted\n' > "$RQV/Pending.sync-conflict-20260730-120000-RECEIPT.md"
+# A re-derivable row that is NEW on the faulted tick. It must NOT be appended: the
+# exception is for rows that cannot come back, and letting the rest through reopens
+# #49's duplication — the snapshot is deliberately not updated, so the next healthy
+# tick's transition would append the same row a second time.
+printf -- '---\ntags: [x]\n---\nbody\n' > "$RQV/rederivable-gap.md"
+RQCFG="$TMP/receipt.local.md"; sed "s|^vault_path: .*|vault_path: $RQV|" "$CFG" > "$RQCFG"
+# A scanner that faults, so the tick takes the gated path with a real conflict present.
+RQLIB="$TMP/receiptlib"; mkdir -p "$RQLIB"; cp "${ROOT_DIR}"/scripts/lib/*.sh "$RQLIB/"
+cat >> "$RQLIB/vault-scan.sh" <<'EOF'
+scan_open_asks() { printf 'vault-scan.sh: RECEIPT-FAULT\n' >&2; return 0; }
+EOF
+RQS="$TMP/receiptscripts"; mkdir -p "$RQS"; cp "${ROOT_DIR}"/scripts/*.sh "$RQS/" 2>/dev/null || true
+cp -R "$RQLIB" "$RQS/lib"
+RQOUT="$TMP/receipt.out"
+OBSIDIAN_LOCAL_MD="$RQCFG" VAULTKEEPER_HOST="ml-1" \
+  bash "$RQS/vaultkeeper-tick.sh" >"$RQOUT" 2>&1 \
+  || fail "the faulted receipt tick aborted; got: $(cat "$RQOUT")"
+grep -q 'scan INCOMPLETE' "$RQOUT" \
+  || fail "the receipt fixture did not fault, so it proves nothing; got: $(cat "$RQOUT")"
+[ -f "$RQV/Pending.md" ] \
+  || fail "a faulted tick dropped the quarantine receipt entirely — no later tick can re-emit it"
+grep -q 'QUARANTINE: Pending.sync-conflict-20260730-120000-RECEIPT.md' "$RQV/Pending.md" \
+  || fail "Pending.md has no QUARANTINE line for the moved conflict: $(cat "$RQV/Pending.md")"
+# The snapshot must still be untouched — that is what stops a truncated candidate set
+# from making the next healthy tick re-append everything this scan missed.
+keeper_has_snapshot "$RQV" \
+  && fail "the faulted tick wrote the prior-scan snapshot; the transition gate is defeated"
+grep -q 'GAP: rederivable-gap.md' "$RQV/Pending.md" \
+  && fail "the faulted tick appended a re-derivable row too; the snapshot is not updated, so the next healthy tick will append it again: $(cat "$RQV/Pending.md")"
+# And the row must not duplicate: a healthy tick afterwards no longer sees the file
+# (it is inside .vaultkeeper-quarantine), so `comm -23` must not re-add it.
+OBSIDIAN_LOCAL_MD="$RQCFG" VAULTKEEPER_HOST="ml-1" \
+  bash "${ROOT_DIR}/scripts/vaultkeeper-tick.sh" >>"$RQOUT" 2>&1 \
+  || fail "the follow-up healthy tick aborted; got: $(cat "$RQOUT")"
+_rq="$(grep -c 'QUARANTINE: Pending.sync-conflict-20260730-120000-RECEIPT.md' "$RQV/Pending.md" | tr -d ' ')"
+[ "$_rq" = "1" ] \
+  || fail "the quarantine receipt appears $_rq times in Pending.md after a fault/heal cycle"
+
 # --- the whole tick under real fd exhaustion (#57) ---------------------------
 # The scanner fix and the fault gate were each pinned individually, but nothing ran
 # the composition against the condition that produced the incident: the tick's own

--- a/tests/vaultkeeper-tick.sh
+++ b/tests/vaultkeeper-tick.sh
@@ -110,6 +110,54 @@ if [ -f "$CV/Pending.md" ]; then
     || fail "fault/heal cycles duplicated $_dups Pending.md item(s): $(grep '^- \[ \]' "$CV/Pending.md" | sort | uniq -d | head -3)"
 fi
 
+# --- a failed quarantine move is a fault too (#53) ---------------------------
+# `CONFLICTS="$(keeper_quarantine_conflicts … || true)"` ran above the buffer, so a
+# failed `mv` printed `failed to quarantine …` straight past the gate and `|| true`
+# threw away the status: the QUARANTINE list came back short and the tick recorded
+# the scan as complete. Same invariant as the scanners, one function over.
+if [ "$(id -u)" = "0" ]; then
+  echo "note: running as root, skipping the failed-quarantine arm" >&2
+else
+  QV="$TMP/quarantinevault"; mkdir -p "$QV/Inbox"
+  printf -- '---\ntags: [x]\n---\nbody\n' > "$QV/n.md"
+  # A real Syncthing conflict name, so the quarantine matcher fires on it.
+  printf 'conflicted\n' > "$QV/Pending.sync-conflict-20260730-120000-ABCDEFG.md"
+  # Pre-create the destination read-only: mkdir -p succeeds, the mv into it does not.
+  mkdir -p "$QV/.vaultkeeper-quarantine"
+  chmod 555 "$QV/.vaultkeeper-quarantine"
+  QCFG="$TMP/quarantine.local.md"; sed "s|^vault_path: .*|vault_path: $QV|" "$CFG" > "$QCFG"
+  QOUT="$TMP/quarantine.out"
+  OBSIDIAN_LOCAL_MD="$QCFG" VAULTKEEPER_HOST="ml-1" \
+    bash "${ROOT_DIR}/scripts/vaultkeeper-tick.sh" >"$QOUT" 2>&1 \
+    || { chmod 755 "$QV/.vaultkeeper-quarantine"; fail "a failed quarantine must not abort the tick; got: $(cat "$QOUT")"; }
+  chmod 755 "$QV/.vaultkeeper-quarantine"
+  grep -q 'scan INCOMPLETE' "$QOUT" \
+    || fail "a failed quarantine move was recorded as a complete scan; got: $(cat "$QOUT")"
+  grep -q 'quarantine' "$QOUT" \
+    || fail "the quarantine failure's own words never reached the report; got: $(cat "$QOUT")"
+  [ -f "$(keeper_last_scan_file "$QV")" ] \
+    && fail "a tick whose quarantine failed still recorded last_scan"
+
+  # And a SUCCESSFUL quarantine must run before the scanners, not merely inside the
+  # same capture: run after them, the conflict file is still in place when they walk
+  # the vault, so a file that was correctly quarantined also gets reported as a
+  # frontmatter gap that no longer exists.
+  QV2="$TMP/quarantineok"; mkdir -p "$QV2/Inbox"
+  printf -- '---\ntags: [x]\ntype: a\n---\nbody\n' > "$QV2/n.md"
+  printf 'conflicted\n' > "$QV2/Pending.sync-conflict-20260730-120000-HIJKLMN.md"
+  Q2CFG="$TMP/quarantineok.local.md"; sed "s|^vault_path: .*|vault_path: $QV2|" "$CFG" > "$Q2CFG"
+  Q2OUT="$TMP/quarantineok.out"
+  OBSIDIAN_LOCAL_MD="$Q2CFG" VAULTKEEPER_HOST="ml-1" \
+    bash "${ROOT_DIR}/scripts/vaultkeeper-tick.sh" >"$Q2OUT" 2>&1 \
+    || fail "a successful quarantine aborted the tick; got: $(cat "$Q2OUT")"
+  grep -q 'scan complete' "$Q2OUT" \
+    || fail "a successful quarantine was reported as a fault; got: $(cat "$Q2OUT")"
+  grep -q '^- Pending.sync-conflict-20260730-120000-HIJKLMN.md$' "$QV2/Librarian.md" \
+    || fail "the quarantined conflict was not listed in the digest: $(cat "$QV2/Librarian.md")"
+  grep -qE '^- Pending\.sync-conflict-20260730-120000-HIJKLMN\.md\s' "$QV2/Librarian.md" \
+    && fail "the quarantined file was ALSO scanned as a gap, so quarantine ran after the scanners: $(cat "$QV2/Librarian.md")"
+fi
+
 # --- an unreadable directory must not latch the gate (#51) -------------------
 # One `chmod 000` directory made find print `Permission denied`, and the gate — which
 # could only see bytes on stderr — reported INCOMPLETE on every tick from then on and

--- a/tests/vaultkeeper-tick.sh
+++ b/tests/vaultkeeper-tick.sh
@@ -110,6 +110,48 @@ if [ -f "$CV/Pending.md" ]; then
     || fail "fault/heal cycles duplicated $_dups Pending.md item(s): $(grep '^- \[ \]' "$CV/Pending.md" | sort | uniq -d | head -3)"
 fi
 
+# --- an unreadable directory must not latch the gate (#51) -------------------
+# One `chmod 000` directory made find print `Permission denied`, and the gate — which
+# could only see bytes on stderr — reported INCOMPLETE on every tick from then on and
+# never recorded last_scan. No tick can fix a permission, so there was no recovery:
+# a vault whose every readable note WAS scanned looked permanently broken. Four
+# agents reproduced it across consecutive ticks.
+if [ "$(id -u)" = "0" ]; then
+  echo "note: running as root, skipping the unreadable-directory tick arm" >&2
+else
+  PTV="$TMP/permtickvault"; mkdir -p "$PTV/Inbox" "$PTV/locked"
+  printf -- '---\ntags: [x]\n---\nbody\n' > "$PTV/n.md"
+  printf -- '---\ntags: [x]\n---\nbody\n' > "$PTV/locked/hidden.md"
+  chmod 000 "$PTV/locked"
+  PTCFG="$TMP/permtick.local.md"; sed "s|^vault_path: .*|vault_path: $PTV|" "$CFG" > "$PTCFG"
+  PTOUT="$TMP/permtick.out"
+  # Twice: the latch only showed up as "and it never recovers", so one tick cannot
+  # tell a latch from a first fault.
+  for _r in 1 2; do
+    OBSIDIAN_LOCAL_MD="$PTCFG" VAULTKEEPER_HOST="ml-1" \
+      bash "${ROOT_DIR}/scripts/vaultkeeper-tick.sh" >"$PTOUT" 2>&1 \
+      || { chmod 755 "$PTV/locked"; fail "an unreadable directory aborted the tick; got: $(cat "$PTOUT")"; }
+  done
+  if grep -q 'scan INCOMPLETE' "$PTOUT"; then
+    chmod 755 "$PTV/locked"
+    fail "an unreadable directory still reports INCOMPLETE, so the gate latches with no recovery path; got: $(cat "$PTOUT")"
+  fi
+  grep -q 'scan complete' "$PTOUT" \
+    || { chmod 755 "$PTV/locked"; fail "the scan of every readable note was not reported complete; got: $(cat "$PTOUT")"; }
+  [ -f "$(keeper_last_scan_file "$PTV")" ] \
+    || { chmod 755 "$PTV/locked"; fail "last_scan was withheld, so the staleness banner will nag forever about a healthy vault"; }
+  # Suppressed is not the same as ignored: the condition has to be visible, by count.
+  grep -q 'unreadable' "$PTOUT" \
+    || { chmod 755 "$PTV/locked"; fail "the unreadable path was never mentioned — that is silence, not classification; got: $(cat "$PTOUT")"; }
+  grep -q '^paths_unreadable: 1' "$PTV/Librarian.md" \
+    || { chmod 755 "$PTV/locked"; fail "the digest does not record the unreadable count: $(head -6 "$PTV/Librarian.md")"; }
+  # …and the count must not carry the absolute host path into the synced digest.
+  case "$(cat "$PTV/Librarian.md")" in
+    *"$PTV/locked"*) chmod 755 "$PTV/locked"; fail "the digest leaked the unreadable path itself" ;;
+  esac
+  chmod 755 "$PTV/locked"
+fi
+
 # --- one repeated benign error must not crowd out a serious one (#54) --------
 # `_scan_find_md` backs three scanners, so a single unreadable directory puts the
 # same `find: … Permission denied` line in the buffer three times. The 300-char


### PR DESCRIPTION
Closes #51
Closes #53
Closes #57
Closes #58

The structural half of the #49 review-panel cluster. Five commits, one concern each. No version bump — releases are batched until the backlog run is done.

### #51 — give the walk a status instead of reading its diagnostics (`b5f3ce3`)

The gate treated any byte on the scanners' stderr as a fault, so two unrelated conditions were one signal.

**Over-triggering, and latching.** One `chmod 000` directory — or an iCloud path macOS TCC refuses — makes `find` print `Permission denied` and walk on. Every readable note was scanned, and no tick can ever fix the path, so the tick printed INCOMPLETE and withheld `last_scan` on every tick from then on, with no recovery.

**Under-triggering.** A walk killed by a signal prints nothing at all, so a short candidate set read as complete.

`_scan_walk` now classifies. Unreadable lines go to a collector the tick counts and reports as `paths_unreadable:` — a standing condition, not an event, so the scan stays complete and `last_scan` is recorded. A walk exiting 128+N says the set is truncated, which is the signal stderr never carried. Everything else still reaches stderr and still trips the gate.

A noise **denylist**, not a fatal-pattern allowlist, per the issue: too narrow an allowlist fails silent (the bug class being removed), too narrow a denylist reports a benign line as a fault — loud and recoverable. Same reasoning for the fail-open paths: a caller with no collector, or a tick that could not create one, gets every line on stderr as before.

The count and not the paths — they are absolute host paths and the digest replicates to every host (#56).

### #53 — run quarantine inside the fault capture (`f26a209`)

`CONFLICTS="$(keeper_quarantine_conflicts … || true)"` ran above the capture, so a failed `mv` printed past the gate and `|| true` discarded the status.

The obvious fix doesn't work: appending quarantine's stderr to the buffer from outside is wiped, because the scan group's own `2>"$SCAN_ERR"` **truncates** the file when it opens. The call moved inside the group instead, where its stderr *is* the scanners' stderr, and its rows go straight into `CAND`.

First inside the group, not last — run after the scanners, a conflict file that was quarantined successfully is still in place while they walk, so it gets reported as a frontmatter gap for a file that no longer exists. I only caught that because the first mutant passed; both the failure and the ordering are now pinned.

### #58 — keep the quarantine receipt when a tick faults (`928d45c`)

The four scanners re-derive their rows every tick, so withholding them behind the gate costs nothing. QUARANTINE is a receipt for an irreversible `mv`, emitted once, and the file it names is excluded from every later walk — so a row withheld there was withheld permanently.

`surfacing_pending_append` appends without touching the snapshot, and the fault branch uses it for QUARANTINE rows only. Append-only is what makes it safe beside the transition gate: a row that can never be re-derived cannot come back through `comm -23` as new — which is also why the exception cannot be widened to re-derivable rows. Chosen over making quarantine idempotent via state, which would need a durable path list plus a way to know when a row had landed.

### #57 — run the whole tick under real fd exhaustion (`93e9284`)

Two halves over a 120-directory vault at `ulimit -n 64`. Shipped code: the tick completes, records `last_scan`, and the digest lists all 240 rows — the count the incident's host got wrong silently (503 idle, 211 under load). Pre-#49 `scan_clusters`, recovered verbatim from `f670411^` rather than stubbed: it dies with `cannot duplicate fd: Too many open files`, the tick reports INCOMPLETE, `last_scan` stays absent.

### Also: the test flake from PR #84 (`41614e2`)

I recorded an unidentified `1 suite(s) failed` as a loose end on #84. It was `commit_in` in the head-gate suite drawing `f$RANDOM.txt` and writing it **empty** — any repeated draw across ~30 commits re-added an identical blob at an identical path, so git refused with `nothing to commit, working tree clean`. About one whole-suite run in fifteen under bash 3.2.

It never reproduced on demand (20+ clean runs), so I proved it by forcing the collision: a fixed filename reproduces exactly `rc=1` and `On branch main`, and the replacement survives it. Fixture files are now named from the repo's commit count (strictly increasing, so unique even from a subshell where a shell counter would reset) and appended to, so content differs even if a path is reused.

### Testing

1. `bash tests/vault-scan.sh` — unreadable paths recorded and stderr clean with the collector, still on stderr without it, a genuine `Too many open files` line not swallowed alongside them, and a walk exiting 137 reporting truncation.
2. `bash tests/vaultkeeper-tick.sh` — two consecutive ticks over a vault with a `chmod 000` directory both report complete, record `last_scan`, mention the count, stamp `paths_unreadable: 1`, and never print the path; failed quarantine reports INCOMPLETE and withholds `last_scan`; successful quarantine is not also scanned as a gap; a faulted tick keeps the QUARANTINE line, leaves the snapshot alone, does *not* append a re-derivable row, and does not duplicate the receipt across a fault/heal cycle; the fd arms above.
3. `bash tests/run-all.sh` and `/bin/bash tests/run-all.sh` (3.2.57) — all suites pass.
4. 13 targeted reverts, each caught by the assertion written for it. Two evaded at first and drove better assertions: quarantine-last, and appending everything rather than only the irreversible rows.

Root arms skip when `id -u` is 0, since `chmod 000` does not stop root.
