### PR TITLE
Temp-swap invariant, installer refusal, autostart parse, schema seed (#43, #44, #45, #46, #47)

### DIFF
--- a/scripts/install-watcher.sh
+++ b/scripts/install-watcher.sh
@@ -7,6 +7,45 @@ LABEL="com.nhangen.obsidian-vaultkeeper"
 
 usage() { echo "usage: install-watcher.sh {label|render-launchd|render-cron|install} <tick_abs_path> [interval_secs]" >&2; exit 2; }
 
+# Did WE render what is installed? The discriminator is the program's basename, not
+# its full path (#44).
+#
+# A full-path comparison cannot work: our own path is version-pinned into the plugin
+# cache, so it legitimately changes on every plugin update, and refusing on any
+# difference would block the re-install that heals a stranded pinned path (#35) — the
+# very failure the delegator exists to avoid. Every path we render ends in
+# `vaultkeeper-tick.sh`; a hand-written wrapper (the live host's
+# `~/.claude/hooks/obsidian-vaultkeeper-tick.sh`, which resolves the newest versioned
+# dir with `sort -V`) does not. So: same basename → ours, replace it; anything else →
+# somebody configured this on purpose, and silently replacing it swapped a
+# version-resilient wrapper for a pinned path while printing "activated".
+_TICK_BASENAME="vaultkeeper-tick.sh"
+
+_program_of() {
+  # First <string> inside ProgramArguments that is not the interpreter.
+  sed -n '/<key>ProgramArguments<\/key>/,/<\/array>/p' "$1" 2>/dev/null \
+    | sed -n 's/.*<string>\(.*\)<\/string>.*/\1/p' \
+    | grep -v '^/bin/bash$' \
+    | head -1
+}
+
+_own_program() {
+  local plist="$1" prog
+  # Nothing there yet is ours to write.
+  [ -f "$plist" ] || return 0
+  prog="$(_program_of "$plist")"
+  # An unparseable or program-less plist is not something to guess about either.
+  [ -n "$prog" ] || return 1
+  [ "${prog##*/}" = "$_TICK_BASENAME" ]
+}
+
+_own_cron_line() {
+  case "$1" in
+    *"/$_TICK_BASENAME"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 render_launchd() {
   local tick="$1" interval="$2"
   cat <<EOF
@@ -22,6 +61,12 @@ render_launchd() {
   </array>
   <key>StartInterval</key><integer>${interval}</integer>
   <key>RunAtLoad</key><true/>
+  <!-- Logs, because the tick's own stderr is the only account of a fault on a
+       host nobody is watching: the 700+ ticks that logged "Too many open files"
+       above "scan complete" (#42) were diagnosed from exactly these two paths on
+       a hand-written plist, and a rendered one had no such record. -->
+  <key>StandardOutPath</key><string>${HOME}/Library/Logs/${LABEL}.log</string>
+  <key>StandardErrorPath</key><string>${HOME}/Library/Logs/${LABEL}.log</string>
 </dict>
 </plist>
 EOF
@@ -38,6 +83,12 @@ install_watcher() {
   case "$(uname -s)" in
     Darwin)
       local plist="$HOME/Library/LaunchAgents/${LABEL}.plist"
+      if ! _own_program "$plist"; then
+        echo "install-watcher: $plist runs $(_program_of "$plist"), which this script did not render — refusing to replace it" >&2
+        echo "install-watcher: that is usually a deliberate wrapper (a delegator that resolves the newest plugin version, per #35). Remove or update the plist by hand if you want it rebuilt." >&2
+        exit 1
+      fi
+      mkdir -p "$HOME/Library/Logs"
       render_launchd "$tick" "$interval" > "$plist"
       launchctl unload "$plist" 2>/dev/null || true
       if ! launchctl load "$plist"; then
@@ -47,6 +98,13 @@ install_watcher() {
       fi
       echo "installed launchd agent: $plist" ;;
     *)
+      local existing
+      existing="$(crontab -l 2>/dev/null | grep -F "# ${LABEL}" | head -1)" || existing=""
+      if [ -n "$existing" ] && ! _own_cron_line "$existing"; then
+        echo "install-watcher: the existing ${LABEL} crontab line runs something this script did not render — refusing to replace it" >&2
+        echo "install-watcher: [$existing]" >&2
+        exit 1
+      fi
       local line; line="$(render_cron "$tick" "$interval")"
       ( crontab -l 2>/dev/null | grep -vF "# ${LABEL}"; printf '%s\n' "$line" ) | crontab -
       echo "installed cron line for ${LABEL}" ;;

--- a/scripts/lib/base-views.sh
+++ b/scripts/lib/base-views.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # base-views.sh — maintain the write-only Obsidian Bases view that renders
-# frontmatter gaps inside the GUI. WRITE-ONLY: no keeper code reads a .base to
+# frontmatter gaps inside the GUI. Requires note-hash.sh (keeper_swap_or_clean).
+# WRITE-ONLY: no keeper code reads a .base to
 # answer a query (headless reader is the frontmatter walk). Idempotent.
 
 base_view_content() {
@@ -26,5 +27,5 @@ base_view_write() {
     rm -f "$tmp"
     return 0
   fi
-  mv "$tmp" "$target"
+  keeper_swap_or_clean "$tmp" "$target"
 }

--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -88,14 +88,38 @@ keeper_ensure_active() {
   local cfg="$1" vault="$2" interval="${3:-900}"
   [ -f "$cfg" ] && [ -d "$vault" ] || return 0
 
-  # `|| autostart=""` because a config without the key makes grep exit 1, and with
-  # `pipefail` that becomes the assignment's status — errexit would abort the
-  # errexit caller here, on the ordinary first-run config — session-save.sh is not
-# one today (`set -uo pipefail`, and it calls this with `|| true`), so this guards
-# the next sourcer rather than a live bug. Absent means "not false".
-  local autostart
-  autostart="$(grep '^keeper_autostart:' "$cfg" | head -1 | sed 's/^keeper_autostart:[[:space:]]*//')" || autostart=""
-  [ "$autostart" = "false" ] && return 0
+  # The key's presence is tested on its own, not folded into the pipeline that
+  # extracts its value (#45). The old single `|| autostart=""` had to be there for
+  # the ordinary case — a config without the key makes grep exit 1 and `pipefail`
+  # promotes it, which would abort an errexit caller on a first-run config — but it
+  # also absorbed a failure in `head` or `sed`, and an empty autostart means "not
+  # false", so a broken stage silently overrode a documented `keeper_autostart:
+  # false` and installed the scheduler anyway. Neutralizing the pipeline instead
+  # (`{ grep || true; } | head | sed`) was tested and is worse: it aborts the caller
+  # under errexit and still installs.
+  local autostart_line autostart
+  if autostart_line="$(grep '^keeper_autostart:' "$cfg")"; then
+    # Present. From here a parse failure must not read as consent to install.
+    autostart="$(printf '%s\n' "$autostart_line" | head -1 | sed 's/^keeper_autostart:[[:space:]]*//')" \
+      || autostart="__unreadable__"
+    # Trim trailing whitespace and a CRLF config's carriage return.
+    autostart="${autostart%$'\r'}"
+    autostart="${autostart%"${autostart##*[![:space:]]}"}"
+    case "$autostart" in
+      false) return 0 ;;
+      true)  : ;;
+      *)
+        # A value we do not recognise cannot be read as "yes, install" — the user
+        # wrote something here on purpose, and guessing wrong installs a scheduler
+        # against an intended opt-out. Refuse and name it, per
+        # enum-config-typo-fallback.
+        printf 'vaultkeeper: keeper_autostart in %s is "%s", which is neither true nor false; activation skipped (fix the value or remove the line)\n' \
+          "$cfg" "$autostart" >&2
+        return 0
+        ;;
+    esac
+  fi
+  # Absent means "not false" — the documented default for a first-run config.
 
   # Resolve the scripts dir before the label, so a lib that cannot find its own
   # siblings says that, instead of blaming install-watcher.sh for a file that is

--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -84,6 +84,41 @@ _kb_cfg_ensure() {
 }
 
 # keeper_ensure_active <config_file> <vault_path> [interval_secs]
+# Does the config still lack a usable frontmatter_required? Absent OR present-but-empty
+# both count: the seed used to write the key empty when nothing cleared its threshold,
+# and readers then fall back to a hardcoded `tags type` while the seed's own presence
+# check short-circuits forever.
+_kb_needs_schema() {
+  local cfg="$1" line
+  line="$(grep '^frontmatter_required:' "$cfg" 2>/dev/null | head -1)" || return 0
+  line="${line#frontmatter_required:}"
+  line="${line%$'\r'}"
+  # Strip surrounding whitespace; what is left is the value.
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
+  [ -z "$line" ]
+}
+
+# Run the seed and quote what it said. Its stderr used to go to /dev/null, so a
+# degraded seed printed a fallback notice that never said why (#46) — the one thing a
+# user needs to fix it. Bounded and stripped of control bytes, like the installer's
+# stderr above: this is subprocess text headed for a hook's stderr.
+_kb_seed_schema() {
+  local scripts="$1" vault="$2" cfg="$3" tmp="" err=""
+  tmp="$(mktemp "${TMPDIR:-/tmp}/kbseed-XXXXXX" 2>/dev/null)" || tmp=""
+  if [ -n "$tmp" ]; then
+    bash "$scripts/seed-frontmatter-schema.sh" "$vault" "$cfg" >/dev/null 2>"$tmp" && { rm -f "$tmp"; return 0; }
+    err="$(tr -c '[:print:]' ' ' < "$tmp")" || err=""
+    err="${err:0:300}"
+    rm -f "$tmp"
+  else
+    bash "$scripts/seed-frontmatter-schema.sh" "$vault" "$cfg" >/dev/null 2>&1 && return 0
+  fi
+  printf 'vaultkeeper: frontmatter-schema seed failed; using default (tags type)%s\n' \
+    "${err:+ — it said: ${err%"${err##*[![:space:]]}"}}" >&2
+  return 0
+}
+
 keeper_ensure_active() {
   local cfg="$1" vault="$2" interval="${3:-900}"
   [ -f "$cfg" ] && [ -d "$vault" ] || return 0
@@ -162,14 +197,21 @@ keeper_ensure_active() {
     return 0
   fi
 
+  # The seed used to sit BELOW this gate, and it documents itself as one-time, so a
+  # seed that produced nothing usable during the single activation session was never
+  # retried on that host — the wrong value was permanent (#46). It runs above the gate
+  # now, but only when the config has no usable frontmatter_required: an installed
+  # host pays one grep per session, not a spawn.
+  if _kb_needs_schema "$cfg"; then
+    _kb_seed_schema "$scripts" "$vault" "$cfg"
+  fi
+
   # Pass the label we already resolved: the predicate would otherwise spawn the
   # installer a second time, every session, to ask what we just asked it.
   keeper_scheduler_installed "$label" && return 0
 
   local tick="$scripts/vaultkeeper-tick.sh"
-  if ! bash "$scripts/seed-frontmatter-schema.sh" "$vault" "$cfg" >/dev/null 2>&1; then
-    printf 'vaultkeeper: frontmatter-schema seed failed; using default (tags type)\n' >&2
-  fi
+  _kb_seed_schema "$scripts" "$vault" "$cfg"
   # `|| true` here meant a config that never gained keeper_interval_secs ran at
   # the compiled-in default forever with nothing to explain why. Name the key and
   # the consequence, the way the schema seed above names its fallback. Reachable

--- a/scripts/lib/keeper-state.sh
+++ b/scripts/lib/keeper-state.sh
@@ -36,7 +36,7 @@ keeper_write_snapshot() {
   mkdir -p "$(dirname "$f")"
   tmp="$(mktemp "${TMPDIR:-/tmp}/snap-XXXXXX")" || return 1
   sort -u > "$tmp"
-  mv "$tmp" "$f"
+  keeper_swap_or_clean "$tmp" "$f"
 }
 
 keeper_last_scan_file() { printf '%s/last_scan\n' "$(keeper_cache_dir "$1")"; }

--- a/scripts/lib/note-hash.sh
+++ b/scripts/lib/note-hash.sh
@@ -43,3 +43,24 @@ file_mtime() {
 now_epoch() {
   date +%s
 }
+
+# Atomic replace, or clean up after yourself. Every render-to-temp-then-swap site
+# used a bare `mv`, so a failed swap left the temp behind (#43) — and one of them
+# mktemps into the *vault root*, where the leak is visible in Obsidian and Syncthing
+# replicates it to every host. PR #41 fixed one site; a helper is here so a caller
+# cannot opt out by forgetting.
+#
+# Lives in note-hash.sh because it is the one lib every consumer of this pattern
+# already sources first (the tick, and each affected lib's own suite).
+#
+# mv's own stderr is left alone: it names the reason (permissions, full disk, cross
+# device), and this adds which file was being replaced rather than replacing that.
+keeper_swap_or_clean() {
+  local tmp="$1" target="$2"
+  if mv "$tmp" "$target"; then
+    return 0
+  fi
+  rm -f "$tmp" 2>/dev/null || true
+  printf 'keeper: could not replace %s; the staged temp file was discarded\n' "$target" >&2
+  return 1
+}

--- a/scripts/lib/surfacing.sh
+++ b/scripts/lib/surfacing.sh
@@ -35,7 +35,7 @@ surfacing_digest() {
       [ -n "$sel" ] && printf '%s\n' "$sel" | cut -f2- | sed 's/^/- /'
     done
   } > "$tmp"
-  mv "$tmp" "$target"
+  keeper_swap_or_clean "$tmp" "$target"
 }
 
 # surfacing_pending_append <vault>
@@ -77,11 +77,15 @@ surfacing_pending_transition() {
   fi
   snap="$(keeper_read_snapshot "$vault")"
   new="$(comm -23 <(printf '%s\n' "$cur") <(printf '%s\n' "$snap"))"
+  # Through the same deduping appender as the irreversible-row path. The snapshot is
+  # written *after* the append, so a failed snapshot swap leaves the append committed
+  # and the gate un-advanced: every later tick sees the same rows as new. That order is
+  # the right one — it fails toward a duplicate line rather than a lost one — but with
+  # a plain `>>` it grew Pending.md without bound, three lines a tick, in a file the
+  # user hand-edits and Syncthing replicates (#43). Deduping makes the stuck state
+  # idempotent instead; the stalled keeper still shows up through the staleness banner.
   if [ -n "$new" ]; then
-    while IFS=$'\t' read -r kind rest; do
-      [ -z "$kind" ] && continue
-      printf -- '- [ ] %s: %s\n' "$kind" "$rest" >> "$pending"
-    done <<<"$new"
+    printf '%s\n' "$new" | surfacing_pending_append "$vault"
   fi
   printf '%s\n' "$cur" | keeper_write_snapshot "$vault"
 }

--- a/scripts/seed-frontmatter-schema.sh
+++ b/scripts/seed-frontmatter-schema.sh
@@ -4,15 +4,30 @@
 # config, only if absent. NOT run on the tick. Idempotent.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${ROOT}/lib/note-hash.sh"
 . "${ROOT}/lib/frontmatter.sh"
 
 VAULT="${1:?usage: seed-frontmatter-schema.sh <vault_path> <config_file>}"
 CFG="${2:?usage: seed-frontmatter-schema.sh <vault_path> <config_file>}"
 THRESHOLD_PCT="${SCHEMA_THRESHOLD_PCT:-80}"
 
+# Already seeded — but only if it was seeded with something. A present-but-EMPTY
+# `frontmatter_required:` is what this script itself writes when no key clears the
+# threshold (or the vault is empty), and the presence test then short-circuits
+# forever: the tick falls back to a hardcoded `tags type`, so the librarian nudges
+# for keys the vault does not use, permanently, on the one host where a retry can
+# never happen (#46). Empty is treated as not-yet-seeded so such a host self-heals.
+EXISTING=""
+EXISTING_LINE=""
 if grep -q '^frontmatter_required:' "$CFG"; then
-  grep '^frontmatter_required:' "$CFG" | sed 's/frontmatter_required: *//'
-  exit 0
+  EXISTING_LINE=1
+  EXISTING="$(grep '^frontmatter_required:' "$CFG" | head -1 | sed 's/frontmatter_required: *//')"
+  EXISTING="${EXISTING%$'\r'}"
+  EXISTING="${EXISTING%"${EXISTING##*[![:space:]]}"}"
+  if [ -n "$EXISTING" ]; then
+    printf '%s\n' "$EXISTING"
+    exit 0
+  fi
 fi
 
 # NOTE: no associative arrays — the MacBook keeper host runs bash 3.2, which
@@ -39,12 +54,31 @@ if [ "$total" -gt 0 ]; then
 fi
 required="$(printf '%s\n' $required | sort | paste -sd' ' -)"
 
-# Insert into the config frontmatter (after the opening ---).
-tmp="$(mktemp "${TMPDIR:-/tmp}/cfg-XXXXXX")"
-awk -v line="frontmatter_required: ${required}" '
-  NR==1 && $0=="---" { print; print line; inserted=1; next }
-  { print }
-  END { if (!inserted) print line }
-' "$CFG" > "$tmp"
-mv "$tmp" "$CFG"
+# Nothing derived: do NOT write the key. Writing it empty is what stranded hosts on
+# the hardcoded fallback with no way back — and an absent key is exactly what lets a
+# later session, over a vault that has notes by then, try again. Says so on stderr,
+# which the caller now quotes.
+if [ -z "$required" ]; then
+  printf 'seed-frontmatter-schema: no frontmatter key appears in >=%s%% of %s note(s) in %s; leaving frontmatter_required unset so a later session can retry\n' \
+    "$THRESHOLD_PCT" "$total" "$VAULT" >&2
+  exit 1
+fi
+
+# Insert into the config frontmatter (after the opening ---). A present-but-empty key
+# is replaced rather than duplicated: a host healing from the bug above already has
+# the line.
+tmp="$(mktemp "${TMPDIR:-/tmp}/cfg-XXXXXX")" || exit 1
+if [ -n "$EXISTING_LINE" ]; then
+  awk -v line="frontmatter_required: ${required}" '
+    /^frontmatter_required:/ && !done { print line; done=1; next }
+    { print }
+  ' "$CFG" > "$tmp" || { rm -f "$tmp"; exit 1; }
+else
+  awk -v line="frontmatter_required: ${required}" '
+    NR==1 && $0=="---" { print; print line; inserted=1; next }
+    { print }
+    END { if (!inserted) print line }
+  ' "$CFG" > "$tmp" || { rm -f "$tmp"; exit 1; }
+fi
+keeper_swap_or_clean "$tmp" "$CFG" || exit 1
 printf '%s\n' "$required"

--- a/tests/install-watcher.sh
+++ b/tests/install-watcher.sh
@@ -20,4 +20,72 @@ if bash "$SH" frobnicate "$TICK" 900 >/dev/null 2>&1; then
   fail "unknown subcommand should exit non-zero"
 fi
 
+# The rendered plist carries log paths. The 700+ ticks that logged "Too many open
+# files" above "scan complete" (#42) were read out of exactly these, on a plist a
+# human had written; a rendered one recorded nothing.
+grep -q '<key>StandardOutPath</key>' <<<"$PLIST" || fail "plist has no StandardOutPath, so a fault on an unwatched host leaves no record"
+grep -q '<key>StandardErrorPath</key>' <<<"$PLIST" || fail "plist has no StandardErrorPath"
+
+# --- refuse to replace a plist this script did not render (#44) ---------------
+# The live host points ProgramArguments at a hand-written delegator that resolves
+# the newest versioned plugin dir — the local mitigation for #35 — and carries the
+# log redirect. install_watcher rendered neither, so any path reaching it silently
+# swapped the delegator for a version-pinned path and printed "activated", which
+# strands the pin on the next plugin update: #35, reintroduced by the installer.
+HOMEDIR="$(mktemp -d "${TMPDIR:-/tmp}/iw-home-XXXXXX")"
+trap 'rm -rf "$HOMEDIR"' EXIT
+mkdir -p "$HOMEDIR/Library/LaunchAgents" "$HOMEDIR/bin"
+PL="$HOMEDIR/Library/LaunchAgents/com.nhangen.obsidian-vaultkeeper.plist"
+# A launchctl that always succeeds, so the only thing under test is the refusal.
+printf '#!/usr/bin/env bash\nexit 0\n' > "$HOMEDIR/bin/launchctl"; chmod +x "$HOMEDIR/bin/launchctl"
+
+write_delegator_plist() {
+  cat > "$PL" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.nhangen.obsidian-vaultkeeper</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>${HOMEDIR}/.claude/hooks/obsidian-vaultkeeper-tick.sh</string>
+  </array>
+  <key>StandardOutPath</key><string>${HOMEDIR}/keeper.log</string>
+</dict>
+</plist>
+EOF
+}
+
+write_delegator_plist
+BEFORE="$(cat "$PL")"
+IERR="$( HOME="$HOMEDIR" PATH="$HOMEDIR/bin:$PATH" bash "$SH" install "$TICK" 900 2>&1 )" \
+  && fail "install replaced a plist it did not render and reported success: $IERR"
+[ "$(cat "$PL")" = "$BEFORE" ] \
+  || fail "the delegator plist was modified despite the refusal:"$'\n'"$(cat "$PL")"
+grep -q 'did not render' <<<"$IERR" \
+  || fail "the refusal did not say why: [$IERR]"
+grep -qF 'obsidian-vaultkeeper-tick.sh' <<<"$IERR" \
+  || fail "the refusal did not name the program it found: [$IERR]"
+
+# …but a plist WE rendered is replaceable, or the #35 self-heal breaks: our own path
+# is version-pinned into the plugin cache and legitimately changes on every update.
+bash "$SH" render-launchd "/old/version/1.0.0/scripts/vaultkeeper-tick.sh" 900 > "$PL"
+HOME="$HOMEDIR" PATH="$HOMEDIR/bin:$PATH" bash "$SH" install "/new/version/2.0.0/scripts/vaultkeeper-tick.sh" 900 >/dev/null 2>&1 \
+  || fail "install refused to replace a plist it had rendered itself, which blocks the #35 re-install"
+grep -qF '/new/version/2.0.0/scripts/vaultkeeper-tick.sh' "$PL" \
+  || fail "the re-install did not update the pinned tick path: $(cat "$PL")"
+
+# A first install on a host with no plist at all must still work.
+rm -f "$PL"
+HOME="$HOMEDIR" PATH="$HOMEDIR/bin:$PATH" bash "$SH" install "$TICK" 900 >/dev/null 2>&1 \
+  || fail "install failed on a host with no existing plist"
+[ -f "$PL" ] || fail "install wrote no plist on a clean host"
+
+# An existing plist we cannot parse a program out of is not ours to guess about.
+printf 'not a plist at all\n' > "$PL"
+BEFORE2="$(cat "$PL")"
+HOME="$HOMEDIR" PATH="$HOMEDIR/bin:$PATH" bash "$SH" install "$TICK" 900 >/dev/null 2>&1 \
+  && fail "install overwrote an unparseable plist"
+[ "$(cat "$PL")" = "$BEFORE2" ] || fail "an unparseable plist was overwritten anyway"
+
 echo "PASS: install-watcher"

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -211,6 +211,65 @@ KEEPER_OS="Darwin" keeper_ensure_active "$CFG4" "$VAULT4" 900 2>/dev/null \
 [ -s "$CALLS2" ] \
   || fail "keeper_autostart: true did not install"
 
+# --- the seed's reason reaches the user, and it retries (#46) -----------------
+# `>/dev/null 2>&1` meant a degraded seed printed a fallback notice that never said
+# WHY — the one thing needed to fix it. And the seed sat below the installed-gate
+# while documenting itself as one-time, so a seed that produced nothing usable during
+# the single activation session was never retried on that host.
+SDIR="$WORK/seedscripts"; mkdir -p "$SDIR/lib"
+cp "${ROOT_DIR}"/scripts/*.sh "$SDIR/" 2>/dev/null || true
+cp -R "${ROOT_DIR}/scripts/lib/." "$SDIR/lib/"
+cat > "$SDIR/seed-frontmatter-schema.sh" <<'EOF'
+#!/usr/bin/env bash
+printf 'seed-frontmatter-schema: SEED-SAID-THIS\n' >&2
+exit 1
+EOF
+chmod +x "$SDIR/seed-frontmatter-schema.sh"
+SCFG="$WORK/seed.local.md"; SVAULT="$WORK/vaultseed"
+printf -- '---\nvault_path: %s\n---\n' "$SVAULT" > "$SCFG"
+mk_vault "$SVAULT"
+: > "$CALLS2"
+SERR="$(KEEPER_OS="Darwin" bash -c ". '$SDIR/lib/keeper-bootstrap.sh'; keeper_ensure_active '$SCFG' '$SVAULT' 900" 2>&1 >/dev/null)" \
+  || fail "a failing seed must not make ensure_active non-zero"
+grep -q 'SEED-SAID-THIS' <<<"$SERR" \
+  || fail "the seed's own words were discarded, so the notice cannot be acted on: [$SERR]"
+
+# Retry on a host where the scheduler is ALREADY installed: the seed must still run,
+# because that is precisely the host that can never retry otherwise.
+# Drive the suite's existing launchctl stub rather than replacing it: it reads
+# $LAUNCHCTL_STATE, and the predicate matches the label as the LAST field.
+SLABEL="$(bash "${ROOT_DIR}/scripts/install-watcher.sh" label)"
+printf '%s\t%s\t%s\n' 123 0 "$SLABEL" > "$STATE"
+# Clear the install log first: the not-installed call above legitimately installed,
+# and the assertion below is about THIS call.
+: > "$CALLS2"
+SERR2="$(KEEPER_OS="Darwin" bash -c ". '$SDIR/lib/keeper-bootstrap.sh'; keeper_ensure_active '$SCFG' '$SVAULT' 900" 2>&1 >/dev/null)" \
+  || fail "ensure_active went non-zero on an installed host with a failing seed"
+grep -q 'SEED-SAID-THIS' <<<"$SERR2" \
+  || fail "an installed host skipped the seed, so a bad value there is permanent: [$SERR2]"
+# …and it really was the installed path: the gate returned before the installer ran.
+# Without this the arm above passes on a host the gate never recognised as installed,
+# which is not the case #46 is about.
+[ ! -s "$CALLS2" ] \
+  || fail "the launchctl stub did not make this an installed host, so the retry arm proves nothing: $(cat "$CALLS2")"
+
+# …but a config that already HAS a usable value must not spawn the seed at all —
+# that is the per-session cost this ordering has to stay cheap about.
+printf -- '---\nvault_path: %s\nfrontmatter_required: tags type\n---\n' "$SVAULT" > "$SCFG"
+SERR3="$(KEEPER_OS="Darwin" bash -c ". '$SDIR/lib/keeper-bootstrap.sh'; keeper_ensure_active '$SCFG' '$SVAULT' 900" 2>&1 >/dev/null)" \
+  || fail "ensure_active went non-zero on a seeded host"
+grep -q 'SEED-SAID-THIS' <<<"$SERR3" \
+  && fail "a config with a usable frontmatter_required still spawned the seed: [$SERR3]"
+
+# A present-but-empty value is NOT usable, and must retry.
+printf -- '---\nvault_path: %s\nfrontmatter_required:\n---\n' "$SVAULT" > "$SCFG"
+SERR4="$(KEEPER_OS="Darwin" bash -c ". '$SDIR/lib/keeper-bootstrap.sh'; keeper_ensure_active '$SCFG' '$SVAULT' 900" 2>&1 >/dev/null)" \
+  || fail "ensure_active went non-zero on an empty-value host"
+grep -q 'SEED-SAID-THIS' <<<"$SERR4" \
+  || fail "a present-but-empty frontmatter_required was treated as seeded, so the host stays broken: [$SERR4]"
+# Leave the shared stub in place for anything after this; just clear its state.
+: > "$STATE"
+
 # --- wiring: the Stop hook actually invokes the bootstrap ---
 SAVE="${ROOT_DIR}/scripts/session-save.sh"
 grep -q 'keeper-bootstrap.sh' "$SAVE" || fail "session-save.sh does not source keeper-bootstrap.sh"

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -111,6 +111,12 @@ RCFG="$ROD/obsidian.local.md"; RVAULT="$WORK/vaultro"
 printf -- '---\nvault_path: %s\n---\n' "$RVAULT" > "$RCFG"
 mk_vault "$RVAULT"
 export VAULTKEEPER_INSTALL="$WORK/stub-install.sh"
+# Root writes straight through a read-only directory, so under root this arm and the
+# one below it would assert on a write that SUCCEEDED and pass without testing
+# anything (#47). Skipped loudly rather than left to pass vacuously.
+if [ "$(id -u)" = "0" ]; then
+  echo "note: running as root, skipping the read-only-config arms" >&2
+else
 chmod a-w "$ROD"
 RERR="$(KEEPER_OS="Darwin" keeper_ensure_active "$RCFG" "$RVAULT" 900 2>&1 >/dev/null)" \
   || { chmod u+w "$ROD"; fail "ensure_active must return 0 when a config write fails"; }
@@ -133,6 +139,25 @@ fi
 chmod u+w "$ROD"
 LEFT="$(find "$LEAK" -name 'kbcfg-*' -type f | wc -l | tr -d ' ')"
 [ "$LEFT" = "0" ] || fail "_kb_cfg_ensure leaked $LEFT temp file(s) into $LEAK"
+fi
+
+# --- _kb_cfg_ensure when mktemp itself cannot resolve TMPDIR (#47) ---
+# The other half of the same failure, and the genuinely silent one: with an
+# unresolvable TMPDIR there is no temp to leak and no `mv` to fail, so the write
+# simply does not happen. Root-safe — no permission bit is involved — which is why
+# this arm carries the invariant on hosts where the two above are skipped.
+UCFG="$WORK/unresolvable.local.md"; UVAULT="$WORK/vaultunres"
+printf -- '---\nvault_path: %s\n---\n' "$UVAULT" > "$UCFG"
+mk_vault "$UVAULT"
+if ( TMPDIR="$WORK/no/such/dir"; _kb_cfg_ensure unres_probe 1 "$UCFG" ); then
+  fail "_kb_cfg_ensure reported success when mktemp could not resolve TMPDIR"
+fi
+grep -q 'unres_probe' "$UCFG" \
+  && fail "_kb_cfg_ensure claims to have failed but the key is in the config: $(cat "$UCFG")"
+UERR="$( TMPDIR="$WORK/no/such/dir" KEEPER_OS="Darwin" keeper_ensure_active "$UCFG" "$UVAULT" 900 2>&1 >/dev/null )" \
+  || fail "ensure_active must stay non-zero-free when mktemp fails; a Stop hook cannot abort"
+grep -q 'keeper_interval_secs' <<<"$UERR" \
+  || fail "an unwritable-because-no-TMPDIR config write was silent: [$UERR]"
 
 # --- opt-out: keeper_autostart: false skips install entirely ---
 CFG2="$WORK/optout.local.md"; VAULT2="$WORK/vault2"

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -174,6 +174,43 @@ KEEPER_OS="Darwin" keeper_ensure_active "$CFG2" "$VAULT2" 900 \
   || fail "ensure_active returned non-zero on opt-out config"
 [ ! -s "$CALLS2" ] || fail "keeper_autostart:false still installed: $(cat "$CALLS2")"
 
+# --- the opt-out survives a broken pipeline stage (#45) ----------------------
+# The single `|| autostart=""` had to absorb grep's exit 1 on a config without the
+# key, but it absorbed a failure in `head` or `sed` too — and an empty autostart
+# means "not false", so a broken stage silently overrode a documented opt-out and
+# installed the scheduler. Break `sed` on PATH and the opt-out must still hold.
+BSED="$WORK/brokensed"; mkdir -p "$BSED"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$BSED/sed"; chmod +x "$BSED/sed"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$BSED/head"; chmod +x "$BSED/head"
+: > "$CALLS2"
+PATH="$BSED:$PATH" KEEPER_OS="Darwin" keeper_ensure_active "$CFG2" "$VAULT2" 900 2>/dev/null \
+  || fail "a broken pipeline stage must not make ensure_active non-zero"
+[ ! -s "$CALLS2" ] \
+  || fail "a broken sed/head overrode keeper_autostart:false and installed anyway: $(cat "$CALLS2")"
+
+# …and the same for a value that is neither true nor false. Guessing "install"
+# there installs a scheduler against something the user typed on purpose.
+CFG3="$WORK/typo.local.md"; VAULT3="$WORK/vault3"
+printf -- '---\nvault_path: %s\nkeeper_autostart: flase\n---\n' "$VAULT3" > "$CFG3"
+mk_vault "$VAULT3"
+: > "$CALLS2"
+TERR="$(KEEPER_OS="Darwin" keeper_ensure_active "$CFG3" "$VAULT3" 900 2>&1 >/dev/null)" \
+  || fail "an unrecognised keeper_autostart made ensure_active non-zero"
+[ ! -s "$CALLS2" ] \
+  || fail "an unrecognised keeper_autostart was treated as consent to install: $(cat "$CALLS2")"
+grep -q 'keeper_autostart' <<<"$TERR" \
+  || fail "an unrecognised keeper_autostart was skipped silently: [$TERR]"
+
+# An explicit true still installs — the refusal above must not swallow the yes.
+CFG4="$WORK/explicit.local.md"; VAULT4="$WORK/vault4"
+printf -- '---\nvault_path: %s\nkeeper_autostart: true\n---\n' "$VAULT4" > "$CFG4"
+mk_vault "$VAULT4"
+: > "$CALLS2"
+KEEPER_OS="Darwin" keeper_ensure_active "$CFG4" "$VAULT4" 900 2>/dev/null \
+  || fail "ensure_active returned non-zero on an explicit keeper_autostart: true"
+[ -s "$CALLS2" ] \
+  || fail "keeper_autostart: true did not install"
+
 # --- wiring: the Stop hook actually invokes the bootstrap ---
 SAVE="${ROOT_DIR}/scripts/session-save.sh"
 grep -q 'keeper-bootstrap.sh' "$SAVE" || fail "session-save.sh does not source keeper-bootstrap.sh"

--- a/tests/seed-frontmatter-schema.sh
+++ b/tests/seed-frontmatter-schema.sh
@@ -33,4 +33,60 @@ printf -- '---\nvault_path: %s\nfrontmatter_required: project\n---\n' "$VAULT" >
 bash "${ROOT_DIR}/scripts/seed-frontmatter-schema.sh" "$VAULT" "$CFG2" >/dev/null
 [ "$(grep '^frontmatter_required:' "$CFG2" | sed 's/.*: *//')" = "project" ] || fail "existing value overwritten"
 
+# --- nothing derivable: leave the key UNSET, and say so (#46) ----------------
+# Writing `frontmatter_required:` empty is what stranded a host: readers fall back to
+# a hardcoded `tags type`, so the librarian nudges for keys the vault does not use,
+# and the seed's own presence check then short-circuits forever — on the one host
+# where a retry can never happen. An absent key is what lets a later session retry.
+EV="$TMP/emptyvault"; mkdir -p "$EV"
+printf -- '---\nunique1: a\n---\n\nbody\n' > "$EV/a.md"
+printf -- '---\nunique2: b\n---\n\nbody\n' > "$EV/b.md"
+printf -- '---\nunique3: c\n---\n\nbody\n' > "$EV/c.md"
+CFG3="$TMP/cfg3.md"
+printf -- '---\nvault_path: %s\n---\n' "$EV" > "$CFG3"
+EERR="$(bash "${ROOT_DIR}/scripts/seed-frontmatter-schema.sh" "$EV" "$CFG3" 2>&1 >/dev/null)" \
+  && fail "the seed reported success when it derived nothing"
+grep -q '^frontmatter_required:' "$CFG3" \
+  && fail "the seed wrote an empty frontmatter_required, which no later run can undo: $(cat "$CFG3")"
+[ -n "$EERR" ] \
+  || fail "the seed derived nothing and said nothing; the caller has no reason to quote"
+
+# An empty vault is the same case, not a crash.
+EV2="$TMP/novault"; mkdir -p "$EV2"
+CFG4="$TMP/cfg4.md"; printf -- '---\nvault_path: %s\n---\n' "$EV2" > "$CFG4"
+bash "${ROOT_DIR}/scripts/seed-frontmatter-schema.sh" "$EV2" "$CFG4" >/dev/null 2>&1 \
+  && fail "an empty vault must not report a successful seed"
+grep -q '^frontmatter_required:' "$CFG4" \
+  && fail "an empty vault seeded an empty frontmatter_required: $(cat "$CFG4")"
+
+# --- a host already stranded with an empty value heals (#46) ------------------
+# Present-but-empty must read as not-yet-seeded, or the hosts that already have the
+# bad line stay broken forever.
+CFG5="$TMP/cfg5.md"
+printf -- '---\nvault_path: %s\nfrontmatter_required:\n---\n' "$VAULT" > "$CFG5"
+bash "${ROOT_DIR}/scripts/seed-frontmatter-schema.sh" "$VAULT" "$CFG5" >/dev/null \
+  || fail "the seed refused to re-derive over a present-but-empty value"
+HEALED="$(grep '^frontmatter_required:' "$CFG5" | sed 's/frontmatter_required: *//')"
+grep -qw tags <<<"$HEALED" || fail "an empty value was not healed: [$HEALED]"
+[ "$(grep -c '^frontmatter_required:' "$CFG5")" -eq 1 ] \
+  || fail "healing duplicated the frontmatter_required line: $(cat "$CFG5")"
+
+# --- a failed swap discards the staged temp (#43 sibling site) ----------------
+# This script had its own unguarded mktemp → render → bare `mv`, which the #43 audit
+# did not list.
+if [ "$(id -u)" = "0" ]; then
+  echo "note: running as root, skipping the seed's failed-swap arm" >&2
+else
+  CFG6D="$TMP/rocfg"; mkdir -p "$CFG6D"
+  CFG6="$CFG6D/obsidian.local.md"
+  printf -- '---\nvault_path: %s\n---\n' "$VAULT" > "$CFG6"
+  LEAKD="$TMP/seedleak"; mkdir -p "$LEAKD"
+  chmod a-w "$CFG6D"
+  ( TMPDIR="$LEAKD" bash "${ROOT_DIR}/scripts/seed-frontmatter-schema.sh" "$VAULT" "$CFG6" >/dev/null 2>&1 ) \
+    && { chmod u+w "$CFG6D"; fail "the seed reported success when it could not write the config"; }
+  chmod u+w "$CFG6D"
+  LEFT="$(find "$LEAKD" -name 'cfg-*' -type f | wc -l | tr -d ' ')"
+  [ "$LEFT" = "0" ] || fail "the seed leaked $LEFT temp file(s) when the swap failed"
+fi
+
 echo "PASS: seed-frontmatter-schema"

--- a/tests/temp-swap.sh
+++ b/tests/temp-swap.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# The render-to-temp-then-swap invariant (#43): when the swap fails, the staged temp
+# is discarded and the caller hears about it. One of these sites stages into the vault
+# root, so a leak is visible in Obsidian and Syncthing replicates it to every host.
+#
+# Each arm makes the *swap* fail while mktemp still succeeds — the target is a
+# directory the process cannot write into, so `mv file dir/file` is refused — because a
+# failed mktemp returns before there is anything to leak, which is a different (already
+# handled) path. Note a *writable* directory is no good: `mv f d` succeeds by moving f
+# into d.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "${ROOT_DIR}/scripts/lib/note-hash.sh"
+. "${ROOT_DIR}/scripts/lib/keeper-state.sh"
+. "${ROOT_DIR}/scripts/lib/base-views.sh"
+. "${ROOT_DIR}/scripts/lib/surfacing.sh"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/temp-swap-XXXXXX")"; trap 'chmod -R u+w "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
+V="$TMP/vault"; mkdir -p "$V/.obsidian"
+
+leaked() { find "$1" -maxdepth 1 -name "$2" 2>/dev/null | head -5; }
+
+# 1. surfacing_digest stages into the VAULT ROOT, so its leak is the one users see.
+mkdir -p "$V/Librarian.md"; chmod 500 "$V/Librarian.md"
+if printf 'GAP\ta.md\ttype\n' | surfacing_digest "$V" 2>/dev/null; then
+  fail "surfacing_digest reported success though the swap could not happen"
+fi
+L="$(leaked "$V" '.Librarian-*')"
+[ -z "$L" ] || fail "a failed digest swap left a temp file in the vault root, which Syncthing replicates:"$'\n'"$L"
+chmod 755 "$V/Librarian.md"; rmdir "$V/Librarian.md"
+
+# 2. base_view_write.
+mkdir -p "$V/_vaultkeeper.base"; chmod 500 "$V/_vaultkeeper.base"
+if base_view_write "$V/_vaultkeeper.base" 2>/dev/null; then
+  fail "base_view_write reported success though the swap could not happen"
+fi
+B="$(leaked "$V" '.base-*')"
+[ -z "$B" ] || fail "a failed base-view swap left a temp file behind:"$'\n'"$B"
+chmod 755 "$V/_vaultkeeper.base"; rmdir "$V/_vaultkeeper.base"
+
+# 3. keeper_write_snapshot — the consequential one, and the only site whose temp is
+#    staged in TMPDIR while the swap targets somewhere else. Uses the issue's own
+#    repro: the snapshot cache dir read-only, so mktemp succeeds and the mv is refused.
+export XDG_CACHE_HOME="$TMP/cache"
+keeper_state_init "$V" >/dev/null
+CDIR="$(keeper_cache_dir "$V")"
+chmod 500 "$CDIR"
+BEFORE="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'snap-*' 2>/dev/null | wc -l | tr -d ' ')"
+if printf 'UNFILED\tInbox/a.md\n' | keeper_write_snapshot "$V" 2>/dev/null; then
+  chmod 700 "$CDIR"
+  fail "keeper_write_snapshot reported success though the swap could not happen"
+fi
+AFTER="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'snap-*' 2>/dev/null | wc -l | tr -d ' ')"
+if [ "$AFTER" -gt "$BEFORE" ]; then
+  chmod 700 "$CDIR"
+  fail "a failed snapshot swap leaked a temp into TMPDIR (before=$BEFORE after=$AFTER)"
+fi
+chmod 700 "$CDIR"
+
+# 4. A stuck snapshot must not grow Pending.md. surfacing_pending_transition appends
+#    before it writes the snapshot — deliberately, since a failure then costs a
+#    duplicated line rather than a lost one — so with the gate stuck every later tick
+#    re-sees the same rows as new. With a plain `>>` that was two lines a tick, forever,
+#    in a file the user hand-edits and Syncthing replicates.
+printf 'GAP\tseed.md\ttype\n' | keeper_write_snapshot "$V" \
+  || fail "could not seed a snapshot to make the gate stuck"
+keeper_has_snapshot "$V" || fail "the seeded snapshot is not there; arm 4 would test the cold-start path"
+chmod 500 "$CDIR"
+for _i in 1 2 3 4; do
+  printf 'UNFILED\tInbox/a.md\nGAP\tb.md\ttype\n' | surfacing_pending_transition "$V" 2>/dev/null || true
+done
+chmod 700 "$CDIR"
+[ -f "$V/Pending.md" ] || fail "the transition appended nothing at all with a stuck snapshot"
+grep -q 'UNFILED: Inbox/a.md' "$V/Pending.md" \
+  || fail "the new row never reached Pending.md:"$'\n'"$(cat "$V/Pending.md")"
+DUPS="$(grep '^- \[ \]' "$V/Pending.md" | sort | uniq -d | wc -l | tr -d ' ')"
+[ "$DUPS" = "0" ] \
+  || fail "a stuck snapshot duplicated $DUPS Pending.md line(s) over four ticks:"$'\n'"$(cat "$V/Pending.md")"
+
+echo "PASS: temp-swap"


### PR DESCRIPTION
Closes #43
Closes #44
Closes #45
Closes #46
Closes #47

The bootstrap/installer cluster. Five commits, one concern each. No version bump — releases are batched until the backlog run is done.

Two of these did not go the way the issue proposed, and one had a different root cause than the issue guessed; details below.

### #43 — one swap helper the remaining sites cannot opt out of (`ec185aa`)

PR #41 fixed `_kb_cfg_ensure`; the same `mktemp` → render → bare `mv` shape was still unguarded in `keeper_write_snapshot`, `surfacing_digest`, and `base_view_write`. The middle one stages into the **vault root**, so its leak is visible in Obsidian and Syncthing replicates it everywhere.

`keeper_swap_or_clean` lives in `note-hash.sh` — the one lib every consumer of the pattern already sources first — so a caller cannot opt out by forgetting. A **fourth** site the audit did not list turned up while reading: `seed-frontmatter-schema.sh` has its own unguarded swap. It's fixed in the #46 commit.

The snapshot site had a consequence the leak alone doesn't explain. `surfacing_pending_transition` appends before writing the snapshot, so a failed swap leaves the append committed and the gate un-advanced: every later tick re-saw the same rows as new and appended them again, forever, into a file the user hand-edits. The order is right — it fails toward a duplicated line rather than a lost one — so the fix is to make the append idempotent, reusing the deduping appender from #58.

### #46 — the schema seed's real failure (`70c88cf`)

Not a partial failure. The seed writes `frontmatter_required:` **empty** whenever no key clears its 80% threshold (or the vault has no notes), and its own presence check then short-circuits on that line forever. That is the live symptom exactly: the key present but empty, the tick falling back to a hardcoded `tags type`, the librarian nudging for keys the vault doesn't use.

Three links cut: derived nothing → don't write the key (and say why); present-but-empty reads as not-yet-seeded in both the seed and the caller, so stranded hosts heal; and the seed moves above the installed-gate — the activated host was the only one that could never retry — but runs only when the config has no usable value, so an installed host pays one grep per session, not a spawn.

The caller also quotes what the seed said instead of `2>&1 >/dev/null`, bounded and control-stripped like the installer's stderr.

### #45 — test the key's presence apart from parsing its value (`f915958`)

`autostart="$(grep … | head -1 | sed …)" || autostart=""` needed the `||` for the ordinary no-key case, but it also absorbed a `head`/`sed` failure — and an empty autostart means "not false", so a broken stage silently overrode a documented `keeper_autostart: false`. The grep now stands alone as the presence test.

The issue notes the obvious patch (`{ grep || true; } | head | sed`) is wrong; agreed, and the value is validated while it's being read properly: `false` skips, `true` proceeds, anything else is refused **by name** rather than guessed at, since a value the user typed on purpose must not read as consent to install a scheduler.

### #44 — don't replace an entry this script did not render (`678cd3d`)

**The obvious check is wrong.** Comparing the full program path would refuse whenever our own path changed — and it changes on every plugin update, because it's version-pinned into the cache — which blocks the re-install that heals a stranded pin, i.e. #35. Mutant `m2` is that exact fix and it fails the suite.

The discriminator is the **basename**. Everything we render ends in `vaultkeeper-tick.sh`; the live host's hand-written delegator (`~/.claude/hooks/obsidian-vaultkeeper-tick.sh`, resolving the newest versioned dir with `sort -V`) does not. Same basename → ours, replace it. Anything else, or a plist we can't parse a program out of → refuse and name what was found. The cron branch gets the same check.

The rendered plist now carries `StandardOutPath`/`StandardErrorPath` too. #42's evidence came from exactly those, on a plist a human wrote; a rendered one kept no record of a fault on an unwatched host.

### #47 — added rather than swapped (`5bcb21e`)

The issue proposed replacing the two `chmod a-w` arms with an unresolvable `TMPDIR`. That loses coverage: `TMPDIR` makes **mktemp** fail, so there is no temp to leak and no `mv` to fail — which is what the cleanup arm is about. So: both. A new root-safe arm covers the mktemp path (the genuinely silent one, previously untested), and the chmod arms stay but now skip loudly under root, where they would otherwise assert on a write that succeeded.

### Testing

1. `bash tests/temp-swap.sh` — new suite. Each of the three sites reports failure and leaves no temp when the swap is refused, using the issue's own repro (read-only snapshot cache dir) for the snapshot site; plus four transitions against a stuck snapshot leaving no duplicated `Pending.md` line.
2. `bash tests/seed-frontmatter-schema.sh` — nothing-derivable leaves the key unset and says why; an empty vault likewise; a host already carrying an empty value heals without duplicating the line; a failed swap discards the temp.
3. `bash tests/keeper-bootstrap.sh` — opt-out survives a broken `sed`/`head`; an unrecognised value is refused by name; an explicit `true` still installs; the seed's words reach the user; the seed retries on an installed host (and that arm asserts the gate really was reached), skips when the value is usable, and retries on a present-but-empty one; the new unresolvable-`TMPDIR` arm.
4. `bash tests/install-watcher.sh` — a delegator plist is left untouched and the refusal names the program; a plist we rendered is still replaceable with a new pinned path; a clean host still installs; an unparseable plist is not overwritten; the log-path keys are present.
5. `bash tests/run-all.sh` and `/bin/bash tests/run-all.sh` (3.2.57) — all suites pass.
6. 17 targeted reverts, each caught by the assertion written for it.

Two of my own test bugs turned up on the way, both worth naming: a `CALLS2` log still holding a line from the previous call, which made the seed-retry arm pass vacuously (now asserted explicitly), and a launchctl stub I hand-rolled instead of driving the suite's existing `$LAUNCHCTL_STATE` one.
