### PR TITLE
Upgrade repair, tokenizer folding, Pending dedup, refusal codes, fixture realism (#35–#39)

### DIFF
--- a/agents/vault-librarian.md
+++ b/agents/vault-librarian.md
@@ -68,8 +68,10 @@ and `create-note` pass `folder_hint` today and must keep getting routed +
 deduped.)
 
 1. Route the content to a target folder. **Always state the chosen folder.** Call
-   `allowlist_validate "<target>"` — if it fails, do not write. It refuses for two
-   different reasons, and only one of them is a question for the user:
+   `allowlist_validate "<target>"` — if it fails, do not write. It refuses for
+   several different reasons, and only one of them is a question for the user. Each
+   also carries a distinct exit code (1 not allow-listed, 2 no config, 3 no taxonomy,
+   4 broken install) if you would rather branch on that than on the wording:
    - The refusal mentions **`/obsidian:setup`** → the *config* is the problem (none
      resolved, or its taxonomy table has no rows). Surface it, tell the user to run
      `/obsidian:setup`, and stop. Do **not** ask where to file: no folder answer
@@ -82,6 +84,12 @@ deduped.)
      beside itself) → neither the config nor the target. Surface it and stop; setup
      will not fix a lib that lost its own path. Same rule as the config case: do not
      ask where to file.
+   - The refusal says the config **exists but cannot be read** → also "the install is
+     broken", not a missing config: the file is there, its permissions are wrong.
+     Surface it verbatim (it names the path) and stop. Do not send the user to
+     `/obsidian:setup` to re-create a config they already have, and do not ask where
+     to file. This state used to escape as a raw `awk: can't open file …` with no
+     refusal line at all, matching none of these branches.
 
    If routing confidence is low, do **not** commit silently — append an
    `[ask:where should this go?]` entry to `$VAULT_PATH/Pending.md` and ask the user once.

--- a/scripts/install-watcher.sh
+++ b/scripts/install-watcher.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 LABEL="com.nhangen.obsidian-vaultkeeper"
 
-usage() { echo "usage: install-watcher.sh {label|render-launchd|render-cron|install} <tick_abs_path> [interval_secs]" >&2; exit 2; }
+usage() { echo "usage: install-watcher.sh {label|installed-program|state|render-launchd|render-cron|install} <tick_abs_path> [interval_secs]" >&2; exit 2; }
 
 # Did WE render what is installed? The discriminator is the program's basename, not
 # its full path (#44).
@@ -78,6 +78,22 @@ render_cron() {
   printf '*/%s * * * * /bin/bash "%s" >/dev/null 2>&1 # %s\n' "$minutes" "$tick" "$LABEL"
 }
 
+installed_program() {
+  local prog=""
+  case "$(uname -s)" in
+    Darwin)
+      prog="$(_program_of "$HOME/Library/LaunchAgents/${LABEL}.plist")"
+      ;;
+    *)
+      # The tick path is the double-quoted field of the rendered cron line.
+      prog="$(crontab -l 2>/dev/null | grep -F "# ${LABEL}" | head -1 \
+        | sed -n 's/.*"\([^"]*\)".*/\1/p')"
+      ;;
+  esac
+  [ -n "$prog" ] || return 1
+  printf '%s\n' "$prog"
+}
+
 install_watcher() {
   local tick="$1" interval="${2:-900}"
   case "$(uname -s)" in
@@ -113,6 +129,15 @@ install_watcher() {
 
 case "${1:-}" in
   label)          printf '%s\n' "$LABEL" ;;
+  # What program is the installed entry actually pointing at? Prints nothing and
+  # exits 1 when there is no entry. Lives here, beside `label`, so plist and cron
+  # layout stay in one file — keeper-bootstrap reads this rather than parsing XML
+  # itself (#35).
+  installed-program) installed_program ;;
+  # label + installed program in ONE invocation. keeper_ensure_active needs both, and
+  # an installed host is meant to cost exactly one installer spawn per session — the
+  # thing the label/predicate split already went to trouble to keep at one.
+  state)          printf '%s\t%s\n' "$LABEL" "$(installed_program || true)" ;;
   render-launchd) [ $# -ge 3 ] || usage; render_launchd "$2" "$3" ;;
   render-cron)    [ $# -ge 3 ] || usage; render_cron "$2" "$3" ;;
   install)        [ $# -ge 2 ] || usage; install_watcher "$2" "${3:-900}" ;;

--- a/scripts/lib/allowlist-validate.sh
+++ b/scripts/lib/allowlist-validate.sh
@@ -1,6 +1,28 @@
 #!/usr/bin/env bash
 # allowlist-validate.sh — Project Taxonomy allow-list parsing + target validation.
 # The taxonomy table in the config is the single source of valid top-level folders.
+#
+# EXIT CODES (#38). Every refusal used to return 1, distinguishable only by parsing
+# English from stderr. That is fine for today's consumers — vault-librarian.md and the
+# SKILL.md files are prose read by a model — and the prose is unchanged. It stops being
+# fine the moment a shell caller needs to branch, and the design has `keeper insert`
+# calling this as a guard; a shell script cannot switch on a sentence. One token per
+# `return`, nothing lost for the LLM callers:
+#
+#   1  the target's top-level folder is not on the allow-list (a closest match is offered)
+#   2  no config resolved — run /obsidian:setup
+#   3  a config with no readable ## Project Taxonomy table
+#   4  the install is broken (a sibling lib is missing, or the config cannot be read)
+#
+# 4 covers "present but unreadable" (chmod 000), which previously escaped as a raw
+# `awk: can't open file …` and no `Refusing to write` line at all — a message matching
+# none of the librarian's branches, so an LLM consumer had no defined behaviour for it.
+# It belongs with "the install is broken" rather than "no config": the reader should not
+# be sent to /obsidian:setup to re-create a config that is already there.
+AV_E_NOT_ALLOWED=1
+AV_E_NO_CONFIG=2
+AV_E_NO_TAXONOMY=3
+AV_E_BROKEN=4
 
 # Captured at source time, not inside a function: `BASH_SOURCE` is a bashism that
 # zsh leaves unset, and zsh's `$0` is the sourced file only while it is being
@@ -20,16 +42,25 @@ _allowlist_config() {
     # install — the same misdirection this file's own refusal was fixed for.
     if [ ! -f "${_av_lib_dir}/resolve-config.sh" ]; then
       printf 'allowlist: cannot find resolve-config.sh beside this lib (looked in "%s") — the install is broken, not the config\n' "$_av_lib_dir" >&2
-      return 1
+      return "$AV_E_BROKEN"
     fi
     cfg="$(bash "${_av_lib_dir}/resolve-config.sh" 2>/dev/null || true)"
   fi
-  [ -n "$cfg" ] && [ -f "$cfg" ] || { printf 'allowlist: no config resolved — run /obsidian:setup\n' >&2; return 1; }
+  [ -n "$cfg" ] && [ -f "$cfg" ] || { printf 'allowlist: no config resolved — run /obsidian:setup\n' >&2; return "$AV_E_NO_CONFIG"; }
+  # Present but unreadable is a third state, and the one that used to escape as a raw
+  # awk error with no refusal line (#38). Named here, before awk ever runs, so the
+  # message is ours and matches a branch a consumer knows.
+  if [ ! -r "$cfg" ]; then
+    printf 'allowlist: the config at %s exists but cannot be read (check its permissions) — the install is broken, not the config\n' "$cfg" >&2
+    return "$AV_E_BROKEN"
+  fi
   printf '%s\n' "$cfg"
 }
 
 allowlist_list() {
-  local cfg; cfg="$(_allowlist_config "${1:-}")" || return 1
+  local cfg rc=0
+  cfg="$(_allowlist_config "${1:-}")" || rc=$?
+  [ "$rc" -eq 0 ] || return "$rc"
   awk -F'|' '
     /^## Project Taxonomy/ { inseg=1; next }
     inseg && /^## / { inseg=0 }
@@ -46,13 +77,15 @@ allowlist_validate() {
   # An empty list means no valid taxonomy rows parsed — a missing heading, or a
   # table with only a header. Distinct from "the target is not on the list", which
   # offers a closest match; reporting the former as the latter points the reader at
-  # a typo in a target that was fine. A config that is present but unreadable does
-  # not arrive here: awk fails, allowlist_list propagates, and the `|| return 1`
-  # below short-circuits.
-  list="$(allowlist_list "$cfg")" || return 1
+  # a typo in a target that was fine. The status is propagated rather than flattened
+  # to 1, so "no config", "unreadable config" and "no taxonomy" stay distinguishable
+  # to a shell caller (#38).
+  local lrc=0
+  list="$(allowlist_list "$cfg")" || lrc=$?
+  [ "$lrc" -eq 0 ] || return "$lrc"
   if [ -z "$list" ]; then
     printf 'Refusing to write to %s — the config has no readable ## Project Taxonomy allow-list. Run /obsidian:setup or add the table.\n' "$target" >&2
-    return 1
+    return "$AV_E_NO_TAXONOMY"
   fi
 
   ntarget="$(printf '%s' "$target" | tr 'A-Z' 'a-z')"; ntarget="${ntarget%/}"
@@ -76,7 +109,7 @@ $list
 EOF
 
   printf 'Refusing to write to %s — top-level folder is not in the allow-list. Closest match: %s. Add it to ## Project Taxonomy or correct the target.\n' "$target" "$best" >&2
-  return 1
+  return "$AV_E_NOT_ALLOWED"
 }
 
 _lev() {

--- a/scripts/lib/dedup-scan.sh
+++ b/scripts/lib/dedup-scan.sh
@@ -2,9 +2,16 @@
 # dedup-scan.sh — slug tokenization + same-day duplicate detection for the vault keeper.
 # Sourced by save-conversation, create-note, vault-librarian (dedup) and MOC-promotion (tokenizer).
 
+# Splits on `-`, ` ` and `_` alike. It used to split on `-` only, and the two callers
+# disagreed as a result: scan_clusters folded spaces to hyphens before calling in, but
+# dedup_same_day passed the raw basename straight through — so `beta note one` and
+# `beta-note-two` scored 0.00 while `beta-note-one` and `beta-note-two` scored 0.50, and
+# any note saved with spaces in its name was invisible to same-day dedup against its
+# hyphenated twin (#36). Folding here makes the tokenizer own its contract instead of
+# each caller pre-normalising, which is what let them drift.
 tokenize_slug() {
   local slug="${1%.md}" tok
-  printf '%s\n' "$slug" | tr 'A-Z' 'a-z' | tr '-' '\n' | while IFS= read -r tok; do
+  printf '%s\n' "$slug" | tr 'A-Z' 'a-z' | tr ' _-' '\n\n\n' | while IFS= read -r tok; do
     [ -z "$tok" ] && continue
     case "$tok" in
       *[!0-9]*) : ;;

--- a/scripts/lib/keeper-bootstrap.sh
+++ b/scripts/lib/keeper-bootstrap.sh
@@ -170,8 +170,15 @@ keeper_ensure_active() {
   # `|| label=""` is load-bearing, not defensive: a broken installer exits
   # non-zero, that status becomes the assignment's, and an errexit caller would
   # die right here — before the refusal below could print a word.
-  local label lblerr=""
-  label="$(keeper_label 2>/dev/null)" || label=""
+  # `state` rather than `label`: it answers both questions in one spawn (see the
+  # gate below, which needs the installed program too), and an installed host is
+  # meant to cost exactly one installer spawn per session.
+  local label lblerr="" kstate="" installed_prog=""
+  kstate="$(bash "$scripts/install-watcher.sh" state 2>/dev/null)" || kstate=""
+  label="${kstate%%$'\t'*}"
+  case "$kstate" in
+    *$'\t'*) installed_prog="${kstate#*$'\t'}" ;;
+  esac
   if [ -z "$label" ]; then
     # Only now is the installer's stderr worth a temp file. Capturing it on every
     # call put a mktemp + rm on the session-end path of every working host to
@@ -197,6 +204,8 @@ keeper_ensure_active() {
     return 0
   fi
 
+  # Resolved before the gate below, which compares it against what is installed.
+  local tick="$scripts/vaultkeeper-tick.sh"
   # The seed used to sit BELOW this gate, and it documents itself as one-time, so a
   # seed that produced nothing usable during the single activation session was never
   # retried on that host — the wrong value was permanent (#46). It runs above the gate
@@ -208,9 +217,30 @@ keeper_ensure_active() {
 
   # Pass the label we already resolved: the predicate would otherwise spawn the
   # installer a second time, every session, to ask what we just asked it.
-  keeper_scheduler_installed "$label" && return 0
+  if keeper_scheduler_installed "$label"; then
+    # Installed is not the same as pointing at code that exists (#35). The plist and
+    # the cron line bake in an ABSOLUTE, version-pinned tick path
+    # (…/cache/nhangen/obsidian/<version>/scripts/vaultkeeper-tick.sh), and a plugin
+    # update replaces that directory wholesale. `launchctl list` still shows the
+    # label, so this gate returned forever while the program it names no longer
+    # existed: the keeper stopped ticking after every upgrade, on every host, and
+    # self-activation never repaired it. resolve-config.sh documents exactly this
+    # hazard for the config; nothing did for the scheduler.
+    if [ -z "$installed_prog" ] || [ "$installed_prog" = "$tick" ]; then
+      return 0
+    fi
+    # A program whose basename is not ours is a deliberate wrapper — the delegator
+    # that resolves the newest versioned dir is exactly the right answer to this
+    # problem, and re-pinning over it would undo it (#44). Silent: it is a working
+    # setup, not a fault, and this runs every session.
+    if [ "${installed_prog##*/}" != "vaultkeeper-tick.sh" ]; then
+      return 0
+    fi
+    printf 'vaultkeeper: the installed scheduler still points at %s, but this plugin version ticks from %s — reinstalling\n' \
+      "$installed_prog" "$tick" >&2
+    # Fall through to the install below.
+  fi
 
-  local tick="$scripts/vaultkeeper-tick.sh"
   _kb_seed_schema "$scripts" "$vault" "$cfg"
   # `|| true` here meant a config that never gained keeper_interval_secs ran at
   # the compiled-in default forever with nothing to explain why. Name the key and

--- a/scripts/lib/surfacing.sh
+++ b/scripts/lib/surfacing.sh
@@ -53,14 +53,20 @@ surfacing_digest() {
 # left alone, and because the row can never be re-derived, the next healthy tick's
 # `comm -23` cannot see it as new and re-append it.
 surfacing_pending_append() {
-  local vault="$1" pending="$1/Pending.md" line out
+  local vault="$1" pending="$1/Pending.md" line out payload
   while IFS= read -r line; do
     [ -n "$line" ] || continue
-    out="- [ ] $(printf '%s' "$line" | sed 's/'$'\t''/: /')"
-    # Idempotent against what is already there. The move happens once so a repeat is
-    # not reachable today, but Pending.md is hand-edited and Syncthing-replicated —
-    # a duplicated checklist line is exactly the damage #49 went to lengths to avoid.
-    if [ -f "$pending" ] && grep -qxF -- "$out" "$pending"; then
+    payload="$(printf '%s' "$line" | sed 's/'$'\t''/: /')"
+    out="- [ ] ${payload}"
+    # Idempotent against what is already there — and against the box being TICKED
+    # (#37). Comparing whole lines missed `- [x] …`, so a candidate that dropped out
+    # of one scan and came back later got a fresh unchecked line appended next to the
+    # one the user had already ticked. Pending.md is hand-edited and
+    # Syncthing-replicated, which makes this the one path where a bug touches notes a
+    # person is working in. Compare the payload with the checkbox stripped, so any box
+    # state counts as present.
+    if [ -f "$pending" ] \
+      && sed -n 's/^- \[[^]]*\] //p' "$pending" | grep -qxF -- "$payload"; then
       continue
     fi
     printf '%s\n' "$out" >> "$pending"

--- a/scripts/lib/vault-scan.sh
+++ b/scripts/lib/vault-scan.sh
@@ -185,10 +185,11 @@ scan_clusters() {
   while IFS= read -r f; do
     dir="${f%/*}"
     base="${f##*/}"; base="${base%.md}"
-    # Spaces are folded to the same separator before tokenizing: tokenize_slug
-    # splits on `-` only, and this vault has filenames with spaces. `sort -u`
-    # keeps the count "distinct files containing the token", not total occurrences.
-    slug="${base// /-}"
+    # No pre-folding: tokenize_slug splits on `-`, ` ` and `_` itself now (#36). Doing
+    # it here was what let this caller and dedup_same_day disagree about the same
+    # filename. `sort -u` below keeps the count "distinct files containing the token",
+    # not total occurrences.
+    slug="$base"
     rel="$(_scan_rel "$vault" "$dir")"
     tokenize_slug "$slug" | sort -u | while IFS= read -r tok; do
       [ -n "$tok" ] && printf '%s\t%s\n' "$rel" "$tok"

--- a/tests/allowlist-validate.sh
+++ b/tests/allowlist-validate.sh
@@ -115,4 +115,45 @@ grep -q 'the install is broken, not the config' "$TMP/orpherr" \
 grep -q 'no config resolved' "$TMP/orpherr" \
   && fail "orphaned lib blamed the config: $(cat "$TMP/orpherr")"
 
+# --- refusals are distinguishable without reading English (#38) ---------------
+# All three refusal kinds returned 1, so a shell caller — the design has `keeper
+# insert` calling this as a guard — could only branch by parsing a sentence. The
+# prose is unchanged for the LLM consumers; the codes are additive.
+AVTMP="$(mktemp -d "${TMPDIR:-/tmp}/av-codes-XXXXXX")"
+avrc() { local rc=0; allowlist_validate "$1" "$2" 2>/dev/null || rc=$?; printf '%s' "$rc"; }
+
+# 1 — a real config, target simply not on the list.
+GOODCFG="$AVTMP/good.md"
+printf '%s\n' '---' 'vault_path: /tmp/v' '---' '' '## Project Taxonomy' '' '| Domain | Vault path | Notes |' '|---|---|---|' '| Dev | Projects/Development/ | code |' > "$GOODCFG"
+[ "$(avrc 'Nope/x.md' "$GOODCFG")" = "1" ] \
+  || fail "a not-allow-listed target should exit 1, got $(avrc 'Nope/x.md' "$GOODCFG")"
+allowlist_validate 'Projects/Development/x.md' "$GOODCFG" \
+  || fail "an allow-listed target was refused"
+
+# 2 — no config at all.
+[ "$(avrc 'Projects/Development/x.md' "$AVTMP/absent.md")" = "2" ] \
+  || fail "a missing config should exit 2, got $(avrc 'Projects/Development/x.md' "$AVTMP/absent.md")"
+
+# 3 — a config with no taxonomy table.
+NOTAX="$AVTMP/notax.md"; printf '%s\n' '---' 'vault_path: /tmp/v' '---' > "$NOTAX"
+[ "$(avrc 'Projects/Development/x.md' "$NOTAX")" = "3" ] \
+  || fail "a config with no taxonomy should exit 3, got $(avrc 'Projects/Development/x.md' "$NOTAX")"
+
+# 4 — present but UNREADABLE. This used to escape as a raw `awk: can't open file …`
+# with no `Refusing to write` line at all, matching none of the librarian's branches.
+if [ "$(id -u)" = "0" ]; then
+  echo "note: running as root, skipping the unreadable-config arm" >&2
+else
+  UNREAD="$AVTMP/unreadable.md"; cp "$GOODCFG" "$UNREAD"; chmod 000 "$UNREAD"
+  URC=0
+  UAERR="$(allowlist_validate 'Projects/Development/x.md' "$UNREAD" 2>&1 >/dev/null)" || URC=$?
+  chmod 644 "$UNREAD"
+  [ "$URC" = "4" ] || fail "an unreadable config should exit 4, got $URC"
+  grep -q 'awk' <<<"$UAERR" \
+    && fail "the raw awk error is still what reaches the consumer: [$UAERR]"
+  grep -qi 'cannot be read' <<<"$UAERR" \
+    || fail "an unreadable config was not named as such: [$UAERR]"
+fi
+rm -rf "$AVTMP"
+
 echo "PASS: allowlist-validate"

--- a/tests/dedup-scan.sh
+++ b/tests/dedup-scan.sh
@@ -51,4 +51,23 @@ grep -Eq 'for[[:space:]]+[A-Za-z_]+[[:space:]]+in[^;]*\*\.md' "$ROOT_DIR/scripts
   && fail "same-day scan must use find, not a glob-for (breaks under zsh nomatch)"
 grep -q 'find .* -name' "$ROOT_DIR/scripts/lib/dedup-scan.sh" \
   || fail "dedup_same_day should scan via find"
+# --- the tokenizer folds spaces and underscores itself (#36) ------------------
+# It split on `-` only, and the two callers disagreed as a result: scan_clusters
+# pre-folded spaces, dedup_same_day did not. So a note saved with spaces in its name
+# was invisible to same-day dedup against its hyphenated twin — the exact filenames
+# this vault contains. The issue measured 0.00 vs 0.50 for this pair.
+J1="$(jaccard "beta note one" "beta-note-two")"
+J2="$(jaccard "beta-note-one" "beta-note-two")"
+[ "$J1" = "$J2" ] \
+  || fail "a space-named note scores $J1 against a hyphenated sibling while its hyphenated twin scores $J2; dedup cannot see it"
+case "$J1" in
+  0|0.00|0.0) fail "the space-named pair still scores zero: $J1" ;;
+esac
+# Underscores too — the other separator a filename arrives with.
+J3="$(jaccard "beta_note_one" "beta-note-two")"
+[ "$J3" = "$J2" ] || fail "an underscore-named note scores $J3, hyphenated twin scores $J2"
+# Mixed separators in one name must tokenize the same as any other spelling.
+[ "$(tokenize_slug "alpha beta_gamma-delta" | sort | paste -sd, -)" = "alpha,beta,delta,gamma" ] \
+  || fail "mixed separators did not tokenize: $(tokenize_slug "alpha beta_gamma-delta" | sort | paste -sd, -)"
+
 echo "PASS: dedup-scan"

--- a/tests/install-watcher.sh
+++ b/tests/install-watcher.sh
@@ -88,4 +88,21 @@ HOME="$HOMEDIR" PATH="$HOMEDIR/bin:$PATH" bash "$SH" install "$TICK" 900 >/dev/n
   && fail "install overwrote an unparseable plist"
 [ "$(cat "$PL")" = "$BEFORE2" ] || fail "an unparseable plist was overwritten anyway"
 
+# --- `state` answers label + installed program in one spawn (#35) -------------
+# keeper_ensure_active needs both, and an installed host is meant to cost exactly one
+# installer spawn per session.
+ST_HOME="$(mktemp -d "${TMPDIR:-/tmp}/iw-state-XXXXXX")"
+mkdir -p "$ST_HOME/Library/LaunchAgents"
+ST_PL="$ST_HOME/Library/LaunchAgents/com.nhangen.obsidian-vaultkeeper.plist"
+# No entry at all: the label is still first, the program field empty.
+ST_OUT="$(HOME="$ST_HOME" bash "$SH" state)"
+[ "${ST_OUT%%$'	'*}" = "com.nhangen.obsidian-vaultkeeper" ]   || fail "state did not put the label first: [$ST_OUT]"
+[ -z "${ST_OUT#*$'	'}" ]   || fail "state reported a program when nothing is installed: [$ST_OUT]"
+# With an entry, the program is the tick path from ProgramArguments — not /bin/bash.
+bash "$SH" render-launchd "/some/version/scripts/vaultkeeper-tick.sh" 900 > "$ST_PL"
+ST_OUT2="$(HOME="$ST_HOME" bash "$SH" state)"
+[ "${ST_OUT2#*$'	'}" = "/some/version/scripts/vaultkeeper-tick.sh" ]   || fail "state did not report the installed program: [$ST_OUT2]"
+HOME="$ST_HOME" bash "$SH" installed-program | grep -qF '/some/version/scripts/vaultkeeper-tick.sh'   || fail "installed-program disagreed with state"
+rm -rf "$ST_HOME"
+
 echo "PASS: install-watcher"

--- a/tests/keeper-bootstrap.sh
+++ b/tests/keeper-bootstrap.sh
@@ -270,6 +270,79 @@ grep -q 'SEED-SAID-THIS' <<<"$SERR4" \
 # Leave the shared stub in place for anything after this; just clear its state.
 : > "$STATE"
 
+# --- a plugin upgrade must not orphan the scheduler (#35) ---------------------
+# The plist bakes in an ABSOLUTE, version-pinned tick path
+# (…/cache/nhangen/obsidian/<version>/scripts/vaultkeeper-tick.sh) and a plugin update
+# replaces that directory wholesale. `launchctl list` still shows the label, so the
+# installed-gate returned forever while the program it named no longer existed: the
+# keeper stopped ticking after every upgrade, on every host, and self-activation never
+# repaired it.
+UHOME="$WORK/uphome"; mkdir -p "$UHOME/Library/LaunchAgents"
+UPL="$UHOME/Library/LaunchAgents/${LABEL}.plist"
+UCFG2="$WORK/upgrade.local.md"; UVAULT2="$WORK/vaultupgrade"
+printf -- '---\nvault_path: %s\nfrontmatter_required: tags type\n---\n' "$UVAULT2" > "$UCFG2"
+mk_vault "$UVAULT2"
+printf '%s\n' "$LABEL" > "$STATE"   # launchctl lists the label: "installed"
+UTICK="${ROOT_DIR}/scripts/vaultkeeper-tick.sh"
+
+# 1. Stale pin: the plist points into a version directory that is not this one.
+bash "$INSTALLER" render-launchd "/cache/nhangen/obsidian/1.0.0/scripts/vaultkeeper-tick.sh" 900 > "$UPL"
+: > "$CALLS2"
+UERR2="$(HOME="$UHOME" KEEPER_OS="Darwin" keeper_ensure_active "$UCFG2" "$UVAULT2" 900 2>&1 >/dev/null)" \
+  || fail "ensure_active went non-zero repairing a stale pin"
+[ -s "$CALLS2" ] \
+  || fail "an installed-but-stale scheduler was left alone; the keeper stays dead after every upgrade"
+grep -q '1.0.0' <<<"$UERR2" \
+  || fail "the repair did not name the stale path it found: [$UERR2]"
+
+# 2. Current pin: nothing to do, and no reinstall.
+bash "$INSTALLER" render-launchd "$UTICK" 900 > "$UPL"
+: > "$CALLS2"
+HOME="$UHOME" KEEPER_OS="Darwin" keeper_ensure_active "$UCFG2" "$UVAULT2" 900 2>/dev/null \
+  || fail "ensure_active went non-zero on a correctly pinned host"
+[ ! -s "$CALLS2" ] \
+  || fail "a correctly pinned scheduler was reinstalled anyway: $(cat "$CALLS2")"
+
+# 3. A deliberate wrapper is the right answer to this problem, not a stale pin.
+#    Re-pinning over it would undo the very mitigation (#44), and it must be silent —
+#    this runs every session, and a working setup is not a fault to report.
+cat > "$UPL" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>${UHOME}/.claude/hooks/obsidian-vaultkeeper-tick.sh</string>
+  </array>
+</dict>
+</plist>
+EOF
+: > "$CALLS2"
+WERR="$(HOME="$UHOME" KEEPER_OS="Darwin" keeper_ensure_active "$UCFG2" "$UVAULT2" 900 2>&1 >/dev/null)" \
+  || fail "ensure_active went non-zero on a wrapper host"
+[ ! -s "$CALLS2" ] \
+  || fail "a deliberate delegator was re-pinned over, undoing the #35 mitigation: $(cat "$CALLS2")"
+[ -z "$WERR" ] \
+  || fail "a working wrapper setup was reported as a problem every session: [$WERR]"
+# 4. Listed, but no program is readable — no plist, or one we cannot parse. That is
+#    not evidence of a stale pin, and reinstalling on it would clobber whatever is
+#    actually there on a guess.
+rm -f "$UPL"
+: > "$CALLS2"
+NERR="$(HOME="$UHOME" KEEPER_OS="Darwin" keeper_ensure_active "$UCFG2" "$UVAULT2" 900 2>&1 >/dev/null)" \
+  || fail "ensure_active went non-zero when no plist was readable"
+[ ! -s "$CALLS2" ] \
+  || fail "an unreadable installed program was guessed to be stale and reinstalled: $(cat "$CALLS2")"
+printf 'not a plist\n' > "$UPL"
+: > "$CALLS2"
+HOME="$UHOME" KEEPER_OS="Darwin" keeper_ensure_active "$UCFG2" "$UVAULT2" 900 2>/dev/null \
+  || fail "ensure_active went non-zero on an unparseable plist"
+[ ! -s "$CALLS2" ] \
+  || fail "an unparseable plist was treated as a stale pin: $(cat "$CALLS2")"
+: > "$STATE"
+
 # --- wiring: the Stop hook actually invokes the bootstrap ---
 SAVE="${ROOT_DIR}/scripts/session-save.sh"
 grep -q 'keeper-bootstrap.sh' "$SAVE" || fail "session-save.sh does not source keeper-bootstrap.sh"

--- a/tests/surfacing.sh
+++ b/tests/surfacing.sh
@@ -39,4 +39,39 @@ printf '%s\n' "$C2" | surfacing_pending_transition "$V"
 [ "$(grep -c '^- \[ \]' "$V/Pending.md")" -eq 1 ] || fail "exactly one new item expected"
 grep -q 'Projects/new.md' "$V/Pending.md" || fail "new ASK item not appended"
 
+# --- a returning candidate must not land next to a ticked line (#37) ----------
+# The transition diffs only against the persisted snapshot, and that snapshot is
+# overwritten unconditionally. So a candidate that drops out of one scan and returns
+# in a later one got a fresh `- [ ]` appended right beside the `- [x]` the user had
+# already ticked. Pending.md is hand-edited, which makes this the one path where a bug
+# touches notes somebody is working in.
+RV="$TMP/returnvault"; mkdir -p "$RV/.obsidian"
+export XDG_CACHE_HOME="$TMP/rcache"
+keeper_state_init "$RV" >/dev/null
+
+t() { printf '%s' "$1" | surfacing_pending_transition "$RV"; }
+
+t $'UNFILED\tInbox/a.md\n'          # first call only seeds the snapshot
+t ''                                 # a drops out
+t $'UNFILED\tInbox/a.md\n'         # …and returns: appended once, correctly
+grep -qxF -- '- [ ] UNFILED: Inbox/a.md' "$RV/Pending.md" \
+  || fail "the returning candidate was never appended: $(cat "$RV/Pending.md" 2>/dev/null)"
+
+# The user ticks it.
+sed 's/^- \[ \] UNFILED/- [x] UNFILED/' "$RV/Pending.md" > "$RV/Pending.tmp" && mv "$RV/Pending.tmp" "$RV/Pending.md"
+grep -qxF -- '- [x] UNFILED: Inbox/a.md' "$RV/Pending.md" || fail "the fixture did not tick the line"
+
+t ''                                 # drops out again
+t $'UNFILED\tInbox/a.md\n'         # and returns again
+COUNT="$(grep -c 'UNFILED: Inbox/a.md' "$RV/Pending.md" | tr -d ' ')"
+[ "$COUNT" = "1" ] \
+  || fail "a returning candidate was appended beside the line the user had already ticked ($COUNT lines):"$'\n'"$(cat "$RV/Pending.md")"
+grep -qxF -- '- [x] UNFILED: Inbox/a.md' "$RV/Pending.md" \
+  || fail "the user's tick was lost:"$'\n'"$(cat "$RV/Pending.md")"
+
+# A genuinely different candidate still gets its own line.
+t $'UNFILED\tInbox/b.md\n'
+grep -qxF -- '- [ ] UNFILED: Inbox/b.md' "$RV/Pending.md" \
+  || fail "a new candidate was suppressed by the dedup:"$'\n'"$(cat "$RV/Pending.md")"
+
 echo "PASS: surfacing"

--- a/tests/vault-scan.sh
+++ b/tests/vault-scan.sh
@@ -28,12 +28,37 @@ printf 'a\n' > "$V/Projects/weekly-review-1.md"
 printf 'a\n' > "$V/Projects/weekly-review-2.md"
 printf 'a\n' > "$V/Projects/weekly-sync-3.md"
 
+# The real vault's dominant shapes, which the flat fixture did not reproduce (#39):
+# nested per-repo folders, `YYYY-MM-DD-<slug>` filenames (which drive essentially every
+# real CLUSTER row), a keeper quarantine directory, and a claim file. Without these the
+# `.vaultkeeper*` exclusion arms below were asserted against directories that did not
+# exist — green, but never exercised.
+mkdir -p "$V/Projects/Development/nhangen/claude-obsidian-plugin"
+for _d in 2026-07-28 2026-07-29 2026-07-30; do
+  printf -- '---\ntags: [x]\ntype: session\n---\n\nbody\n' \
+    > "$V/Projects/Development/nhangen/claude-obsidian-plugin/${_d}-keeper-notes.md"
+done
+mkdir -p "$V/.vaultkeeper-quarantine" "$V/.vaultkeeper"
+printf -- '---\ntags: [x]\n---\n\nquarantined body has [ask:merge me?] in it\n' \
+  > "$V/.vaultkeeper-quarantine/Pending.sync-conflict-20260730-000000-ABCDEFG.md"
+printf -- '---\n---\n\nkeeper internals\n' > "$V/.vaultkeeper/notes.md"
+printf 'ml-1\n' > "$V/.keeper-claim-ml-1"
+mkdir -p "$V/Templates"; printf -- '---\n---\n\ntemplate body\n' > "$V/Templates/session.md"
+
 GAPS="$(scan_frontmatter_gaps "$V" "tags type")"
 has  "GAP"$'\t'"Projects/gap.md"$'\t'"type" "$GAPS"
 lacks "GAP"$'\t'"Projects/good.md" "$GAPS"
 lacks ".obsidian" "$GAPS"
 lacks ".trash" "$GAPS"
 lacks ".base" "$GAPS"
+# Now genuinely exercised: these directories exist in the fixture (#39).
+lacks ".vaultkeeper-quarantine" "$GAPS"
+lacks ".vaultkeeper/" "$GAPS"
+lacks ".keeper-claim" "$GAPS"
+# A dated per-repo note is the vault's dominant shape and must be scanned normally.
+# A dated per-repo note carrying tags+type is complete, so it must not be a gap.
+lacks "2026-07-28-keeper-notes.md" "$GAPS"
+
 
 UNFILED="$(scan_unfiled "$V")"
 has "UNFILED"$'\t'"Inbox/unfiled.md" "$UNFILED"
@@ -48,6 +73,23 @@ has "CLUSTER"$'\t'"Projects"$'\t'"weekly"$'\t'"3" "$CLUSTERS"
 # "review" appears in only 2 files (below threshold 3) -> must NOT be emitted.
 lacks "CLUSTER"$'\t'"Projects"$'\t'"review" "$CLUSTERS"
 grep -q '\.base' <<<"$CLUSTERS" && fail ".base leaked into clusters"
+
+# The dominant real filename shape, `YYYY-MM-DD-<slug>`, drives essentially every real
+# CLUSTER row and was untested (#39). Three dated notes in one per-repo folder share
+# `keeper` and `notes`; the date components must not become tokens of their own — they
+# are numeric, and the tokenizer drops numeric tokens.
+DATED="$(scan_clusters "$V" 3)"
+has "CLUSTER"$'\t'"Projects/Development/nhangen/claude-obsidian-plugin"$'\t'"keeper"$'\t'"3" "$DATED"
+has "CLUSTER"$'\t'"Projects/Development/nhangen/claude-obsidian-plugin"$'\t'"notes"$'\t'"3" "$DATED"
+printf '%s\n' "$DATED" | grep -qE $'\t'"(2026|07|28|29|30)"$'\t' \
+  && fail "a date component became a cluster token:"$'\n'"$(printf '%s\n' "$DATED" | grep -E '2026|07')"
+lacks ".vaultkeeper" "$DATED"
+
+# The quarantine directory holds a note with an [ask] marker, so the ASK scanner's
+# exclusion is now exercised rather than asserted against a directory that is absent.
+ASKS2="$(scan_open_asks "$V")"
+lacks ".vaultkeeper-quarantine" "$ASKS2"
+lacks ".keeper-claim" "$ASKS2"
 
 # Clustering routes through the shared tokenize_slug, so it agrees with dedup and
 # MOC promotion instead of carrying a third inline tokenizer. The visible effect
@@ -75,10 +117,10 @@ CRC=0; ( set -e; scan_clusters "$V" 3 >/dev/null ) || CRC=$?
 [ "$CRC" = "0" ] || fail "scan_clusters returned $CRC with a below-threshold trailing folder"
 GRC=0; ( set -e; scan_frontmatter_gaps "$V" "tags type" >/dev/null ) || GRC=$?
 [ "$GRC" = "0" ] || fail "scan_frontmatter_gaps returned $GRC"
-URC=0; ( set -e; scan_unfiled "$V" >/dev/null ) || URC=$?
-[ "$URC" = "0" ] || fail "scan_unfiled returned $URC"
-ARC=0; ( set -e; scan_open_asks "$V" >/dev/null ) || ARC=$?
-[ "$ARC" = "0" ] || fail "scan_open_asks returned $ARC"
+# scan_unfiled and scan_open_asks are NOT checked here on purpose (#39). Neither can
+# return non-zero — one has a bare `printf` body, the other an `if` body — so the
+# assertions that used to sit here could not fail, while reading as four symmetric
+# guards when only the two above are load-bearing.
 rm -rf "$V/ZZlast"
 
 # The GRC arm above cannot fail on this fixture: $V always contains a gap file, so
@@ -139,11 +181,10 @@ has "CLUSTER"$'\t'"SpaceTest"$'\t'"weekly" "$SPACE_CLUSTERS"
 # With the fix, "review" is split from "weekly review.md" via space→hyphen
 # normalization, so it also counts across all 3 files — threshold met, emitted.
 has "CLUSTER"$'\t'"SpaceTest"$'\t'"review" "$SPACE_CLUSTERS"
-# Verify no cluster entry in SpaceTest shows count 1 (threshold is 2; all
-# tokens should meet it — no spurious single-file tokens from word-splitting).
-if printf '%s\n' "$SPACE_CLUSTERS" | grep "SpaceTest" | awk -F'\t' '{print $4}' | grep -q '^1$'; then
-  fail "space-filename produced a spurious count-1 cluster token"
-fi
+# A count-1 row is NOT asserted against here (#39): the printf is gated on
+# `[ cnt -ge threshold ]` and this block passes threshold=2, so no count-1 row can be
+# emitted whatever the tokenizer does. What actually pins the space-folding is the
+# `review` row above — it only appears if "weekly review.md" tokenizes into two words.
 
 # The canonical tokenizer wins over whatever the caller already had in scope. The
 # old `command -v tokenize_slug ||` guard adopted the caller's definition instead,


### PR DESCRIPTION
Closes #35
Closes #36
Closes #37
Closes #38
Closes #39

Five commits, one concern each. No version bump — releases are batched until the backlog run is done.

### #35 — repair the scheduler when an upgrade moves the tick (`ccaa5f0`)

`keeper_scheduler_installed` matched only the label, but the plist and cron line bake in an absolute, version-pinned tick path. A plugin update replaces that directory wholesale: `launchctl list` still shows the label, so the gate returned forever while the program it named no longer existed. **The keeper stopped ticking after every upgrade, on every host, and self-activation never repaired it.**

The gate now compares the installed program against this version's tick and falls through to a reinstall on mismatch, naming the stale path. Two deliberate non-actions:

- A program whose basename isn't ours is a **deliberate wrapper** — the delegator that resolves the newest versioned dir is the *right* answer to this problem, and re-pinning over it would undo it (#44). Left alone, silently: this runs every session and a working setup isn't a fault to report.
- No readable program (no plist, or one that doesn't parse) isn't evidence of a stale pin, so nothing is reinstalled on a guess.

Reading the installed program goes through a new `install-watcher.sh state` returning label and program together, so plist/cron layout stays in the file that owns it **and** an installed host still costs exactly one installer spawn per session — which an existing test pins, and which my first attempt broke.

### #36 — fold spaces in the tokenizer itself (`a80fc18`)

`tokenize_slug` split on `-` only and the two callers compensated differently: `scan_clusters` pre-folded spaces, `dedup_same_day` didn't. `beta note one` vs `beta-note-two` scored 0.00 where the hyphenated twin scored 0.50 — any space-named note was invisible to same-day dedup, which is the filename shape this vault actually contains.

Folding moves inside the tokenizer and `scan_clusters` drops its pre-normalisation; each caller normalising separately is what let them drift. Underscores too. (The hyphen goes last in the `tr` set — a leading `-` is parsed as an option by BSD tr.)

### #37 — dedup against a ticked box (`a0316ae`)

**This one wasn't closed by the earlier work, contrary to what I first assumed.** The append guard from #58 compared whole lines, so it matched `- [ ] UNFILED: x` and missed `- [x] UNFILED: x`. A candidate that dropped out and returned still got a fresh unchecked line beside the one the user had ticked. The comparison now strips the checkbox and matches the payload.

The issue's second half — nothing checked `find`'s status — *is* closed by the `_scan_walk` classification from #51, surfacing as `scan_status: INCOMPLETE` / `paths_unreadable:` in the digest, which is the SCANERR record it asked for.

### #38 — name the unreadable-config refusal, and code the refusals (`f0e3edf`)

A `chmod 000` config escaped as a raw `awk: can't open file …` with no `Refusing to write` line at all. It's now checked before awk runs and reported as ours, classified with **"the install is broken"** rather than "no config": the file is there and its permissions are wrong, so sending the reader to `/obsidian:setup` to re-create a config they already have is the wrong instruction. `agents/vault-librarian.md` gains the matching branch.

The related decision, taken at the same time: refusals now carry distinct codes (1 not-allow-listed, 2 no config, 3 no taxonomy, 4 broken install) as named constants. The prose is unchanged for the LLM consumers; the design has `keeper insert` calling this as a guard, and a shell script cannot switch on a sentence.

### #39 — the fixture becomes the vault, and two dead arms go (`c1db874`)

The fixture was flat, so the `.vaultkeeper*` exclusion arms were asserted against directories that didn't exist, and `YYYY-MM-DD-<slug>` — the shape driving essentially every real CLUSTER row — was untested. It now carries `Projects/Development/nhangen/<repo>/` with three dated notes, `.vaultkeeper-quarantine/` (holding an `[ask]` note, so the ASK exclusion is exercised too), `.vaultkeeper/`, a claim file and `Templates/`. Dropping the quarantine exclusion now fails the suite; before, it passed.

Two assertions deleted because they could not fail: the FIX D count-1 check (the printf is threshold-gated, so no count-1 row can be emitted) and the `URC`/`ARC` exit-status checks (neither function can return non-zero).

**Not** doing the cluster-exclusion config knob the issue also floats — new config surface plus a behaviour change for every host wants its own issue, not a ride-along in a test-fixture commit.

### Testing

1. `bash tests/keeper-bootstrap.sh` — a stale pin is repaired and the stale path named; a current pin is left alone; a wrapper is left alone **and silent**; no readable program (missing or unparseable plist) reinstalls nothing.
2. `bash tests/install-watcher.sh` — `state` puts the label first with an empty program field when nothing is installed, and reports the tick path (not `/bin/bash`) when it is; `installed-program` agrees with it.
3. `bash tests/dedup-scan.sh` — space- and underscore-named notes now score the same as their hyphenated twin; mixed separators tokenize identically.
4. `bash tests/surfacing.sh` — a returning candidate lands once, the user's tick survives, and a genuinely new candidate still gets its own line.
5. `bash tests/allowlist-validate.sh` — each of the four refusal states returns its own code, and the unreadable one no longer leaks `awk` text.
6. `bash tests/vault-scan.sh` — dated per-repo clusters, date components not becoming tokens, and the keeper-directory exclusions on real directories.
7. `bash tests/run-all.sh` and `/bin/bash tests/run-all.sh` (3.2.57) — all suites pass.
8. Targeted reverts for each fix, each caught by the assertion written for it. One honest note: the `-z "$installed_prog"` clause in #35 is redundant belt-and-braces — the basename check already covers the empty case — so no mutant distinguishes it, and I'm not claiming one does.
