### PR TITLE
Retarget inbound wikilinks on MOC promotion; release 1.20.0 (#18)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.19.4",
+  "version": "1.20.0",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ scripts/lib/allowlist-validate.sh Frontmatter/path allowlist validation shared b
 scripts/lib/dedup-scan.sh     Shared dedup-against-existing-notes scan
 scripts/lib/keeper-save-payload.sh Payload parsing/validation for keeper-save
 scripts/lib/vault-index.sh    Shared INDEX.md read/refresh helpers
+scripts/lib/moc-promote.sh    Retargets inbound wikilinks when an MOC promotion moves notes
 scripts/keeper                CLI entry point for keeper insert/append operations
 agents/                       Subagents (vault-organizer for /obsidian reorganize paths)
 integrations/                 External tool integrations
@@ -212,7 +213,7 @@ The plugin root is resolved by Claude Code via `${CLAUDE_PLUGIN_ROOT}` — scrip
 ## Known Limitations
 
 - The Stop hook requires `claude` on `PATH` for background summarization. If absent, the session save no-ops with a logged warning.
-- Commit capture relies on parsing `git` output; very large commits are truncated to keep the note readable.
+- Commit capture asks `git` about a HEAD snapshot taken before the call, so a failed or dry-run commit is not captured. A call that makes more than `OBSIDIAN_COMMIT_MAX_RECORDS` commits (20 by default) captures the oldest of them and names the shas it skipped rather than truncating silently. The append is idempotent per commit sha, read from the note itself, so a re-run or a second host does not duplicate a record.
 - Routing is keyword-based, not semantic. Intent inference records confidence and evidence, but folder placement still depends on taxonomy/routing rules; ambiguous sessions can still land in `Inbox/`.
 
 ## License

--- a/obsidian.local.md.example
+++ b/obsidian.local.md.example
@@ -10,6 +10,7 @@ strict_domains: true
 dedup_jaccard_threshold: 0.4
 moc_promotion: true
 moc_promotion_threshold: 3
+moc_promotion_fix_links: true
 frontmatter_required: tags type
 keeper_host_priority: ml-1 mbp
 keeper_interval_secs: 900

--- a/scripts/lib/moc-promote.sh
+++ b/scripts/lib/moc-promote.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# moc-promote.sh — retarget inbound wikilinks after an MOC promotion moves notes
+# into a subfolder. Requires note-hash.sh (keeper_swap_or_clean).
+#
+# Obsidian's "Update internal links on rename" only fires inside the running app's
+# rename UI. The promotion flow moves files with a shell `mv`, which bypasses it, so
+# the skill used to warn about the broken links and hand the repair back to the user
+# (#18). Once the user has accepted the promotion they have already accepted the link
+# churn, and the repair is mechanical: the pre-move scan already knows which files
+# reference the moved notes.
+#
+# Matching is exact on the link TARGET, and done by string scanning rather than a
+# regex, because a note filename is not a safe regex: this vault has names with `.`,
+# `+`, `(`, `[` and spaces in them, and escaping each for sed is how a "safe minimum"
+# rewrite starts corrupting notes. The target is compared literally.
+#
+# `[[stem]]`, `[[stem|alias]]` and `[[stem#heading]]` are all retargeted — same link,
+# extras preserved. `[[Some/Path/stem]]` is left alone: it already resolves, and
+# prefixing it again would break it.
+
+# moc_retarget_wikilinks <vault> <new-prefix> <stem> [<stem>...]
+# Rewrites `[[<stem>]]` to `[[<new-prefix>/<stem>]]` across every .md in the vault.
+# Prints `<links-updated> <files-changed>`; returns 1 if nothing could be scanned.
+moc_retarget_wikilinks() {
+  local vault="$1" prefix="$2"; shift 2
+  [ -d "$vault" ] || { printf 'moc-promote: not a directory: %s\n' "$vault" >&2; return 1; }
+  [ -n "$prefix" ] || { printf 'moc-promote: empty target prefix; refusing to rewrite links to a bare "/"\n' >&2; return 1; }
+  [ $# -gt 0 ] || { printf '0 0\n'; return 0; }
+
+  # Strip any leading/trailing slash so the rendered link cannot end up with `//`
+  # or a leading `/` (which Obsidian does not resolve).
+  prefix="${prefix#/}"; prefix="${prefix%/}"
+
+  local stems_file total_links=0 total_files=0 f out changed
+  stems_file="$(mktemp "${TMPDIR:-/tmp}/mocstems-XXXXXX")" || return 1
+  printf '%s\n' "$@" > "$stems_file"
+
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    out="$(mktemp "${TMPDIR:-/tmp}/mocrw-XXXXXX")" || { rm -f "$stems_file"; return 1; }
+    changed="$(_moc_rewrite_file "$f" "$prefix" "$stems_file" "$out")" || changed=0
+    case "$changed" in ''|*[!0-9]*) changed=0 ;; esac
+    if [ "$changed" -gt 0 ]; then
+      if keeper_swap_or_clean "$out" "$f"; then
+        total_links=$(( total_links + changed ))
+        total_files=$(( total_files + 1 ))
+      fi
+    else
+      rm -f "$out"
+    fi
+  done <<EOF
+$(find "$vault" -type f -name '*.md' \
+    ! -path '*/.obsidian/*' ! -path '*/.trash/*' ! -path '*/.git/*' \
+    ! -path '*/.vaultkeeper-quarantine/*' ! -path '*/.vaultkeeper/*' 2>/dev/null)
+EOF
+
+  rm -f "$stems_file"
+  printf '%s %s\n' "$total_links" "$total_files"
+}
+
+# Writes the rewritten file to <out> and prints how many links it changed.
+_moc_rewrite_file() {
+  awk -v prefix="$2" -v stemfile="$3" -v outfile="$4" '
+    BEGIN {
+      while ((getline s < stemfile) > 0) { if (s != "") stems[s] = 1 }
+      close(stemfile)
+      n = 0
+    }
+    {
+      line = $0
+      rebuilt = ""
+      rest = line
+      while (1) {
+        o = index(rest, "[[")
+        if (o == 0) { rebuilt = rebuilt rest; break }
+        c = index(substr(rest, o + 2), "]]")
+        if (c == 0) { rebuilt = rebuilt rest; break }
+        inner = substr(rest, o + 2, c - 1)
+        head = substr(rest, 1, o + 1)
+        rest = substr(rest, o + 2 + c + 1)
+
+        # Split the target off any |alias or #heading; whichever comes first wins.
+        extra = ""
+        target = inner
+        pipe = index(inner, "|"); hash = index(inner, "#")
+        cut = 0
+        if (pipe > 0 && (hash == 0 || pipe < hash)) cut = pipe
+        else if (hash > 0) cut = hash
+        if (cut > 0) { target = substr(inner, 1, cut - 1); extra = substr(inner, cut) }
+
+        # Already carries a path — leave it, prefixing again would break it.
+        if (index(target, "/") == 0 && (target in stems)) {
+          inner = prefix "/" target extra
+          n++
+        }
+        rebuilt = rebuilt head inner "]]"
+      }
+      print rebuilt > outfile
+    }
+    END { close(outfile); print n }
+  ' "$1"
+}

--- a/skills/save-conversation/SKILL.md
+++ b/skills/save-conversation/SKILL.md
@@ -339,7 +339,7 @@ After a successful new-file write, check whether the parent folder has grown a c
      > Promoting will break the following wikilinks (Obsidian will not auto-update them via shell `mv`):
      > - `<note-with-link>` → `[[<broken-target>]]`
      >
-     > Continue anyway? (yes/no — recommend running Obsidian's "Update links on rename" manually after if you proceed)
+     > Continue? The links will be retargeted to the new location automatically. (yes/no)
 
      If the user declines on the link-warning prompt, treat as an MOC decline (cache it) and stop.
    - `mkdir -p "<parent>/<Stem>/notes"` — these writes operate under the already-validated parent folder and bypass the Step 7 allow-list check by design.
@@ -364,7 +364,32 @@ After a successful new-file write, check whether the parent folder has grown a c
 
      -
      ```
-   - Confirm to user with the new paths.
+   - **Retarget the inbound wikilinks** — after the `mv`s and before confirming. The
+     user accepting the promotion already accepted the link churn, and the repair is
+     mechanical, so it does not go back to them (#18):
+
+         . "${CLAUDE_PLUGIN_ROOT}/scripts/lib/note-hash.sh"
+         . "${CLAUDE_PLUGIN_ROOT}/scripts/lib/moc-promote.sh"
+         moc_retarget_wikilinks "<vault_path>" "<Stem>/notes" "<file-1>" "<file-2>" "<file-3>"
+
+     Pass the filename **stems** (no `.md`), not paths. It rewrites `[[<stem>]]`,
+     `[[<stem>|alias]]` and `[[<stem>#heading]]` to the new relative path across the
+     vault, leaves links that already carry a path alone, and echoes
+     `<links-updated> <files-changed>`.
+
+     Skip this step when `moc_promotion_fix_links: false` is set in
+     `obsidian.local.md` frontmatter — for the case where the user would rather do it
+     through Obsidian's own rename UI. Then keep the old advice: tell them to run
+     "Update links on rename" manually.
+
+     Why not leave it to Obsidian: its "Update internal links on rename" only fires
+     inside the running app's rename UI, and this flow moves files with a shell `mv`.
+     Without this step the user has to hunt each broken link down by hand, which is
+     the friction the soft-prompt flow exists to remove.
+   - Confirm to user with the new paths, and name the link repair — e.g. *"Promoted 3
+     notes to `Panel/` — also retargeted 4 inbound wikilinks across 3 files."* Say so
+     even when the count is 0, so "no links needed fixing" is distinguishable from
+     "the step did not run".
 
 5. **On decline**: write `moc-declined:<stem>` to the session cache and move on. Do not ask again this session.
 

--- a/tests/moc-promote.sh
+++ b/tests/moc-promote.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Retargeting inbound wikilinks after an MOC promotion (#18).
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "${ROOT_DIR}/scripts/lib/note-hash.sh"
+. "${ROOT_DIR}/scripts/lib/moc-promote.sh"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/moc-XXXXXX")"; trap 'rm -rf "$TMP"' EXIT
+V="$TMP/vault"; mkdir -p "$V/Projects/Foo/Panel/notes"
+
+# The issue's repro: B and C promoted into Panel/notes/, D links to B by bare name.
+printf 'moved b\n'  > "$V/Projects/Foo/Panel/notes/B.md"
+printf 'moved c\n'  > "$V/Projects/Foo/Panel/notes/C.md"
+printf 'see [[B]] and also [[C]] here\n' > "$V/Projects/Foo/D.md"
+# Two occurrences in one file — the issue measured exactly this (4 links, 1 file with 2).
+printf 'first [[B]]\nsecond [[B]]\n' > "$V/Projects/Foo/E.md"
+# Forms that must be retargeted but keep their extras.
+printf 'alias [[B|the b note]] and heading [[C#Findings]]\n' > "$V/Projects/Foo/F.md"
+# Forms that must NOT be touched.
+printf 'already pathed [[Panel/notes/B]]\nunrelated [[Bravo]]\nsubstring [[BB]]\n' > "$V/Projects/Foo/G.md"
+printf 'no links at all\n' > "$V/Projects/Foo/H.md"
+H_BEFORE="$(cat "$V/Projects/Foo/H.md")"
+G_BEFORE="$(cat "$V/Projects/Foo/G.md")"
+
+OUT="$(moc_retarget_wikilinks "$V" "Panel/notes" B C)" || fail "retarget returned non-zero"
+LINKS="${OUT%% *}"; FILES="${OUT##* }"
+
+grep -qxF -- 'see [[Panel/notes/B]] and also [[Panel/notes/C]] here' "$V/Projects/Foo/D.md" \
+  || fail "bare inbound links were not retargeted: $(cat "$V/Projects/Foo/D.md")"
+[ "$(grep -c 'Panel/notes/B' "$V/Projects/Foo/E.md")" = "2" ] \
+  || fail "only one of two occurrences in a file was rewritten: $(cat "$V/Projects/Foo/E.md")"
+grep -qF -- '[[Panel/notes/B|the b note]]' "$V/Projects/Foo/F.md" \
+  || fail "an aliased link lost or kept the wrong target: $(cat "$V/Projects/Foo/F.md")"
+grep -qF -- '[[Panel/notes/C#Findings]]' "$V/Projects/Foo/F.md" \
+  || fail "a heading link lost or kept the wrong target: $(cat "$V/Projects/Foo/F.md")"
+
+# No double-prefixing, no fuzzy matching. `[[Bravo]]` and `[[BB]]` merely start with
+# the stem; rewriting either would point at a file that does not exist.
+[ "$(cat "$V/Projects/Foo/G.md")" = "$G_BEFORE" ] \
+  || fail "an already-pathed or unrelated link was rewritten:"$'\n'"$(cat "$V/Projects/Foo/G.md")"
+[ "$(cat "$V/Projects/Foo/H.md")" = "$H_BEFORE" ] \
+  || fail "a file with no matching links was rewritten anyway"
+
+# The count is what the confirmation message reports, so it has to be right:
+# D has 2, E has 2, F has 2 → 6 links across 3 files.
+[ "$LINKS" = "6" ] || fail "reported $LINKS links updated, expected 6"
+[ "$FILES" = "3" ] || fail "reported $FILES files changed, expected 3"
+
+# Idempotent: everything is pathed now, so a second run changes nothing.
+OUT2="$(moc_retarget_wikilinks "$V" "Panel/notes" B C)"
+[ "$OUT2" = "0 0" ] || fail "a second run rewrote something: [$OUT2]"
+
+# --- filenames that are not safe regexes --------------------------------------
+# A sed-based rewrite would need every one of these escaped; matching the target
+# literally means there is nothing to escape. Note what is NOT in this list: `[`, `]`,
+# `#`, `^` and `|` cannot appear in a linkable note name — Obsidian forbids them
+# precisely because they make `[[...]]` ambiguous — so a name containing them is not a
+# case this has to handle.
+V2="$TMP/vault2"; mkdir -p "$V2/notes"
+for _n in 'a.b+c' 'x(1)' 'with space' 'dots...many' '100%-done'; do
+  printf 'moved\n' > "$V2/notes/${_n}.md"
+  printf 'ref [[%s]] end\n' "$_n" > "$V2/src-${_n}.md"
+done
+OUT3="$(moc_retarget_wikilinks "$V2" "notes" 'a.b+c' 'x(1)' 'with space' 'dots...many' '100%-done')" \
+  || fail "retarget failed on regex-unsafe names"
+[ "${OUT3%% *}" = "5" ] || fail "regex-unsafe names: reported ${OUT3%% *} links, expected 5"
+grep -qxF -- 'ref [[notes/a.b+c]] end' "$V2/src-a.b+c.md" \
+  || fail "a name with . and + was not retargeted: $(cat "$V2/src-a.b+c.md")"
+grep -qxF -- 'ref [[notes/100%-done]] end' "$V2/src-100%-done.md" \
+  || fail "a name with % was not retargeted: $(cat "$V2/src-100%-done.md")"
+grep -qxF -- 'ref [[notes/with space]] end' "$V2/src-with space.md" \
+  || fail "a name with a space was not retargeted: $(cat "$V2/src-with space.md")"
+
+# --- guards -------------------------------------------------------------------
+moc_retarget_wikilinks "$TMP/nope" "x" B 2>/dev/null \
+  && fail "a missing vault must be refused"
+moc_retarget_wikilinks "$V" "" B 2>/dev/null \
+  && fail "an empty prefix must be refused rather than rewriting links to a bare /"
+[ "$(moc_retarget_wikilinks "$V" "Panel/notes")" = "0 0" ] \
+  || fail "no stems should be a no-op, not an error"
+
+# A leading or trailing slash in the prefix must not produce `//` or a leading `/`,
+# neither of which Obsidian resolves.
+V3="$TMP/vault3"; mkdir -p "$V3"
+printf 'ref [[Z]]\n' > "$V3/s.md"
+moc_retarget_wikilinks "$V3" "/Deep/Path/" Z >/dev/null
+grep -qxF -- 'ref [[Deep/Path/Z]]' "$V3/s.md" \
+  || fail "prefix slashes were not normalised: $(cat "$V3/s.md")"
+
+echo "PASS: moc-promote"


### PR DESCRIPTION
Closes #18

Two commits: the link repair, then the release bump for the whole backlog run.

### #18 — retarget inbound wikilinks on promotion (`20bbad2`)

The MOC-promotion flow warned that its `mv` would break inbound wikilinks and handed the repair back to the user. Obsidian's "Update links on rename" only fires inside the app's rename UI, so that left them hunting each broken link by hand — the friction the soft prompt exists to remove. By the time they accept the promotion they have already accepted the link churn, and the pre-move scan already knows which files reference the moved notes.

`moc_retarget_wikilinks` rewrites `[[stem]]`, `[[stem|alias]]` and `[[stem#heading]]` to the new relative path, leaves anything already carrying a path alone, and echoes `<links> <files>` so the confirmation can name the repair.

**Matching is exact on the link target and done by string scanning, not a regex.** A note filename is not a safe regex — this vault has names with `.`, `+`, `(` and spaces — and escaping each for sed is how a "safe minimum" rewrite starts corrupting notes. With a literal comparison there is nothing to escape. (`[`, `]`, `#`, `^`, `|` are not cases to handle: Obsidian forbids them in note names precisely because they make `[[…]]` ambiguous. I had a fixture asserting behaviour for `note [draft]` and removed it for that reason.)

`moc_promotion_fix_links: false` opts out and restores the old advice.

### Release 1.20.0 (`7cfb3d7`)

One bump for the whole run rather than one per PR, as asked. README gains the new lib in its file map, and its commit-capture "known limitation" is replaced — it described parsing `git` output and silent truncation, neither of which is true any more.

### Testing

1. `bash tests/moc-promote.sh` — new suite: the issue's exact repro (D → `[[B]]`), two occurrences in one file, alias and heading forms keeping their extras, already-pathed and merely-prefix-matching links (`[[Bravo]]`, `[[BB]]`) left untouched, the reported counts, idempotence on a second run, regex-unsafe filenames, and the guards (missing vault, empty prefix, no stems, prefix slash normalisation).
2. `bash tests/run-all.sh` and `/bin/bash tests/run-all.sh` (3.2.57) — all suites pass.
3. Five targeted reverts, each caught: prefix-matching instead of exact, double-prefixing a pathed link, dropping the alias/heading split, unnormalised prefix slashes, and allowing an empty prefix.

### Backlog run summary

This closes the last open issue. Across PRs #84–#90 and this one: #18, #35, #36, #37, #38, #39, #43, #44, #45, #46, #47, #51, #52, #53, #54, #55, #56, #57, #58, #62, #63, #64 — plus a `$RANDOM` test-fixture flake that had been recorded as an unexplained loose end on #84.
