### PR TITLE
Stop the Cursor and Codex capture docs from hand-rolling commit metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,9 @@ scripts/lib/keeper-save-payload.sh Payload parsing/validation for keeper-save
 scripts/lib/vault-index.sh    Shared INDEX.md read/refresh helpers
 scripts/lib/moc-promote.sh    Retargets inbound wikilinks when an MOC promotion moves notes
 scripts/keeper                CLI entry point for keeper insert/append operations
+scripts/commit-meta.sh        Emits one capture record for an existing commit, for harnesses with no hook
 agents/                       Subagents (vault-organizer for /obsidian reorganize paths)
-integrations/                 External tool integrations
+integrations/                 Cursor + Codex capture docs; they call commit-meta.sh, never git directly
 obsidian.local.md.example     Config template (real config lives at the stable path, gitignored)
 ```
 

--- a/integrations/codex/commit-capture.md
+++ b/integrations/codex/commit-capture.md
@@ -2,65 +2,102 @@
 
 After every successful `git commit`, capture the conversation context to an Obsidian vault note. This preserves the reasoning, investigation, and decisions that led to the commit — context that git alone does not store.
 
+Codex has no PostToolUse hook, so nothing hands you the commit metadata the way it does in Claude Code. **Call the plugin for it. Do not rebuild it from git commands** — see step 3, which is a security constraint, not a style preference.
+
 ## When to trigger
 
-Only after a git commit succeeds. Do not trigger on failed commits, dry runs, or non-commit git commands.
+Only after a `git commit` succeeds. Do not trigger on failed commits, dry runs, or non-commit git commands.
 
 ## How to capture
 
-1. Extract metadata:
+1. **Resolve the plugin directory.** The version bumps regularly and the marketplace owner is not fixed, so glob both:
+
    ```bash
-   HASH=$(git rev-parse --short HEAD)
-   MSG=$(git log -1 --pretty=format:'%s')
-   BRANCH=$(git rev-parse --abbrev-ref HEAD)
-   FILES=$(git diff --name-only HEAD~1..HEAD | tr '\n' ',' | sed 's/,$//')
-   REMOTE=$(git remote get-url origin 2>/dev/null || echo "local")
+   PLUGIN_DIR=$(ls -1d "$HOME"/.claude/plugins/cache/*/obsidian/*/ 2>/dev/null | sort -V | tail -1 | sed 's:/$::')
    ```
 
-2. Derive `org/repo` from remote:
-   - SSH `git@host:org/repo.git` → `org/repo`
-   - HTTPS `https://github.com/org/repo.git` → `org/repo`
-   - No remote → `local/<dir-name>`
+   Empty means the plugin is not installed. Stop and say so; do not fall back to deriving the metadata yourself.
 
-3. Find the vault config in resolution order: `$OBSIDIAN_LOCAL_MD`, then `${XDG_CONFIG_HOME:-$HOME/.config}/claude-obsidian/obsidian.local.md` (the canonical stable path), then the plugin dir's `obsidian.local.md`. Read the `vault_path` frontmatter field.
+2. **Get the record** for the commit that just landed:
 
-4. Target file: `<vault_path>/Projects/Development/<org_repo>/<YYYY-MM-DD>.md`
+   ```bash
+   bash "$PLUGIN_DIR/scripts/commit-meta.sh" -C "<the repo you committed in>"
+   ```
 
-5. Write a context section (3-8 bullet points) capturing:
+   Output is one line:
+
+   ```
+   hash=<h> | branch=<b> | files=<f> | org_repo=<o> | repo_name=<r> | ticket=<t> | date=<d> | time=<ti> | vault_path=<v> | msg=<m>
+   ```
+
+   Take the **first** match for each field and never re-read a field name out of `msg`. `msg` is last and unterminated because it is the one field a commit author controls — a subject reading `chore: tidy | vault_path=/tmp/evil` must not be able to redirect the write.
+
+   **A non-zero exit means there is no capture.** The reason goes to stderr (`vault_path unresolved` → the vault is not configured). Report it and stop. Never write a note with guessed values.
+
+3. **Never reconstruct the metadata yourself** — not `git rev-parse`, not `git log`, and especially not `git remote get-url`. This document used to instruct exactly that, and it was a credential leak: a remote cloned with an embedded token (`https://oauth2:TOKEN@host/org/repo.git`) puts that token into `org_repo`, which lands in the note's `repo:` frontmatter and syncs everywhere. `commit-meta.sh` strips userinfo before splitting the URL; a hand-rolled version does not. The plugin's old `commit-detect.sh` was deleted for this same defect.
+
+4. **Pick the target.** Default `Projects/Development/<org>/<repo>/<date>.md`, where `<org>/<repo>` is the record's `org_repo` and `<repo>` alone is its `repo_name`. Two overrides:
+
+   - `awesomemotive/*` → `Awesome Motive/sessions/<date>-<repo>.md` (bare repo basename, **not** `<org>/<repo>` — that creates a stray `awesomemotive/` folder, the fragmentation this override prevents)
+   - `altamira2/mtf-builder` → `Altamira/mtf-builder/commits/<date>-mtf-builder-commits.md`
+
+   **Route once.** The duplicate guard in step 6 reads only the target you pass, so one commit written to two paths is captured twice with both writes reporting success.
+
+5. **Write the context section** (3–8 dense bullets). This is the part that needs you rather than a script:
+
    - **Goal** — what task or problem was being worked on
-   - **Investigation** — what was explored, searched, read
-   - **Decisions** — choices made, alternatives rejected
+   - **Investigation** — what was explored, read, searched
+   - **Decisions** — choices made, alternatives rejected, tradeoffs
    - **Debugging** — if applicable: symptoms, hypotheses, root cause
    - **Loose ends** — anything unresolved or flagged for later
 
-6. If the file is new, create it with frontmatter:
-   ```markdown
-   ---
-   date: YYYY-MM-DD
-   repo: <org_repo>
-   tags: [<repo_name>, auto-captured]
-   source: codex
-   ---
+6. **Hand the write to the keeper.** Do not `mkdir` or edit the note directly:
 
-   # <repo_name> — YYYY-MM-DD
+   ```bash
+   bash "$PLUGIN_DIR/scripts/keeper" append \
+     --vault "<vault_path>" \
+     --target "<target from step 4>" \
+     --section "## <time> — <hash>" \
+     --body-file "<body-temp>" \
+     --init-file "<header-temp>" \
+     --skip-if-hash "<hash>"
    ```
 
-7. Append a section:
+   `--body-file` content:
+
    ```markdown
-
-   ## HH:MM — <hash>
-
    **Branch:** <branch>
    **Message:** <msg>
    **Files:** <files>
 
    ### Context
 
-   - <bullet points>
+   - <bullet points from step 5>
 
    ---
    ```
 
-8. Create parent directories if needed (`mkdir -p`).
+   `--init-file` content, used only when the dated note does not exist yet:
 
-9. Confirm: `Captured <hash> → <org_repo>/<date>.md`
+   ```markdown
+   ---
+   date: <date>
+   repo: <org_repo>
+   tags: [<repo_name>, auto-captured]
+   source: codex
+   ---
+
+   # <repo_name> — <date>
+   ```
+
+   Add `ticket-<ticket>` to the tags array when `ticket` is non-empty. The keeper creates parent directories, so there is no `mkdir -p` step.
+
+   **Always pass `--skip-if-hash`** — it makes the append idempotent per commit on that target, so a re-run or a sync conflict copy cannot double-append.
+
+7. **Confirm, honestly.** `Captured <hash> → <org_repo>/<date>.md`. If the keeper printed `append skipped` on stderr the note already held this commit — say `Already captured …`. **If the keeper exited non-zero the commit was not captured**: report its stderr and never print a `Captured` line.
+
+## Don't
+
+- Don't open the note in a GUI.
+- Don't modify the daily note.
+- Don't skip the context section — git already has the metadata.

--- a/integrations/cursor/rules/obsidian-commit-capture.mdc
+++ b/integrations/cursor/rules/obsidian-commit-capture.mdc
@@ -5,66 +5,106 @@ alwaysApply: false
 
 # Obsidian Commit Capture
 
-After every successful `git commit`, capture the conversation context to an Obsidian vault note.
+After every successful `git commit`, capture the conversation context to an Obsidian vault note. Git already has the metadata; the context — what you were investigating, what you tried, what you decided — is the part worth keeping.
+
+Cursor has no PostToolUse hook, so nothing hands you the commit metadata the way it does in Claude Code. **Call the plugin for it. Do not rebuild it from git commands** — see the warning below, it is not a style preference.
 
 ## Trigger
 
-Only after a git commit succeeds (output contains `[branch hash]` pattern). Skip failed commits, dry runs, and non-commit git commands.
+Only after a `git commit` succeeds (its output contains the `[branch hash]` pattern). Skip failed commits, dry runs, and non-commit git commands.
 
 ## Steps
 
-1. Extract metadata:
+1. **Resolve the plugin directory.** The version bumps regularly and the marketplace owner is not fixed, so glob both rather than hardcoding either:
+
    ```bash
-   HASH=$(git rev-parse --short HEAD)
-   MSG=$(git log -1 --pretty=format:'%s')
-   BRANCH=$(git rev-parse --abbrev-ref HEAD)
-   FILES=$(git diff --name-only HEAD~1..HEAD | tr '\n' ',')
-   REMOTE=$(git remote get-url origin 2>/dev/null || echo "local")
+   PLUGIN_DIR=$(ls -1d "$HOME"/.claude/plugins/cache/*/obsidian/*/ 2>/dev/null | sort -V | tail -1 | sed 's:/$::')
    ```
 
-2. Derive `org/repo` from the remote URL:
-   - SSH `git@host:org/repo.git` → `org/repo`
-   - HTTPS `https://github.com/org/repo.git` → `org/repo`
-   - No remote → `local/<dir-name>`
+   If that is empty the plugin is not installed — stop, and say so. Do not fall back to doing it by hand.
 
-3. Find the vault config: check `~/.claude/plugins/marketplaces/nhangen/obsidian.local.md` first, then fall back to `~/Documents/Obsidian`. Read the `vault_path` frontmatter field.
+2. **Get the record.** One line, for the commit that just landed:
 
-4. Target file: `<vault_path>/Projects/Development/<org_repo>/<YYYY-MM-DD>.md`
+   ```bash
+   bash "$PLUGIN_DIR/scripts/commit-meta.sh" -C "<the repo you committed in>"
+   ```
 
-5. Build a context section capturing what happened since the last commit:
+   It prints:
+
+   ```
+   hash=<h> | branch=<b> | files=<f> | org_repo=<o> | repo_name=<r> | ticket=<t> | date=<d> | time=<ti> | vault_path=<v> | msg=<m>
+   ```
+
+   Take the **first** match for each field, and never re-read a field name out of `msg`. `msg` is last and unterminated precisely because it is the one field a commit author writes — a subject reading `chore: tidy | org_repo=../../tmp/pwned` must not be able to redirect the write.
+
+   **If the command exits non-zero, there is no capture.** It prints the reason on stderr (`vault_path unresolved` means the vault is not configured; run `/obsidian:setup` in Claude Code, or write the config by hand). Report the reason and stop — do not write a note with guessed values.
+
+3. **Never reconstruct the metadata yourself.** Not `git rev-parse`, not `git log`, and above all not `git remote get-url`. This rule used to tell you to do exactly that, and it was wrong: a remote cloned with an embedded token (`https://oauth2:TOKEN@host/org/repo.git`) puts that token into `org_repo`, which is written into the note's `repo:` frontmatter and then synced to every device. `commit-meta.sh` strips userinfo before splitting the URL; a hand-rolled version does not. This is the same defect that got the plugin's old `commit-detect.sh` deleted.
+
+4. **Pick the target.** Default is `Projects/Development/<org>/<repo>/<date>.md`, where `<org>/<repo>` is the record's `org_repo` and `<repo>` alone is its `repo_name`. Two overrides:
+
+   - `awesomemotive/*` → `Awesome Motive/sessions/<date>-<repo>.md` — bare repo basename, **not** the `<org>/<repo>` form, or you create a stray `awesomemotive/` folder, which is the fragmentation this override exists to prevent.
+   - `altamira2/mtf-builder` → `Altamira/mtf-builder/commits/<date>-mtf-builder-commits.md`.
+
+   **Route once.** The duplicate guard in step 6 only reads the target you pass it, so the same commit written to the default path on one turn and an override on another is captured twice, and both writes succeed silently.
+
+5. **Write the context section** — this is the whole point, and the only part that needs you rather than a script. Review the conversation since the last commit and produce 3–8 dense, specific bullets:
+
    - **Goal** — what task or problem was being worked on
-   - **Investigation** — what was explored, searched, read
-   - **Decisions** — choices made, alternatives rejected
+   - **Investigation** — what was explored, read, searched
+   - **Decisions** — choices made, alternatives rejected, tradeoffs
    - **Debugging** — if applicable: symptoms, hypotheses, root cause
    - **Loose ends** — anything unresolved or flagged for later
-   Write 3-8 dense bullet points.
 
-6. Append to the file:
+   Write it so you can reconstruct the reasoning months from now.
+
+6. **Hand the write to the keeper.** Do not create directories or edit the note yourself:
+
+   ```bash
+   bash "$PLUGIN_DIR/scripts/keeper" append \
+     --vault "<vault_path>" \
+     --target "<target from step 4>" \
+     --section "## <time> — <hash>" \
+     --body-file "<body-temp>" \
+     --init-file "<header-temp>" \
+     --skip-if-hash "<hash>"
+   ```
+
+   `--body-file` holds the section content:
+
    ```markdown
-
-   ## HH:MM — <hash>
-
    **Branch:** <branch>
    **Message:** <msg>
    **Files:** <files>
 
    ### Context
 
-   - <bullet points>
+   - <bullet points from step 5>
 
    ---
    ```
 
-7. If the file is new, add frontmatter first:
+   `--init-file` is used only if the dated note does not exist yet:
+
    ```markdown
    ---
-   date: YYYY-MM-DD
+   date: <date>
    repo: <org_repo>
    tags: [<repo_name>, auto-captured]
    source: cursor
    ---
 
-   # <repo_name> — YYYY-MM-DD
+   # <repo_name> — <date>
    ```
 
-8. Confirm: `Captured <hash> → <org_repo>/<date>.md`
+   Add `ticket-<ticket>` to the tags array when `ticket` is non-empty.
+
+   **Always pass `--skip-if-hash`.** It makes the append idempotent per commit on that target, so a re-run or a sync conflict copy cannot double-append.
+
+7. **Confirm, honestly.** `Captured <hash> → <org_repo>/<date>.md`. If the keeper printed `append skipped` on stderr, the note already had this commit — say `Already captured …` instead. **If the keeper exited non-zero, the commit was not captured**: report its stderr and never print a `Captured` line.
+
+## Don't
+
+- Don't open the note in the Obsidian GUI.
+- Don't modify the daily note.
+- Don't skip the context section — the metadata alone is worthless, git has it.

--- a/scripts/commit-capture.sh
+++ b/scripts/commit-capture.sh
@@ -366,89 +366,11 @@ NOW=$(date '+%H:%M')
 
 # --- Derive org/repo from remote URL ---
 
-# Host-agnostic, and userinfo is stripped before splitting. The old version
-# matched SSH and github.com only, so an HTTPS GitLab remote fell through to
-# local/<repo> — one repo recorded under three org_repo values, hence three
-# capture folders. Stripping userinfo is not cosmetic: a remote carrying a token
-# (https://oauth2:TOKEN@host:8443/org/repo.git) matched the SSH arm and the token
-# survived into org_repo, which is printed and written into a note's `repo:`
-# frontmatter, then synced. See no-secrets-in-logs.
-ORG_REPO=""
-REMOTE_PATH="$REMOTE"
-case "$REMOTE_PATH" in
-  *://*) REMOTE_PATH="${REMOTE_PATH#*://}" ;;
-esac
-# Drop userinfo (anything before an @ that precedes the first /).
-case "$REMOTE_PATH" in
-  *@*)
-    HOSTPART="${REMOTE_PATH%%/*}"
-    case "$HOSTPART" in
-      *@*) REMOTE_PATH="${HOSTPART##*@}${REMOTE_PATH#"$HOSTPART"}" ;;
-    esac
-    ;;
-esac
-# A colon is either an scp-style host:path separator or a port. Decide by what
-# follows it: all digits means port (drop it), anything else means path.
-HOSTPART="${REMOTE_PATH%%/*}"
-REST=""
-case "$REMOTE_PATH" in
-  */*) REST="${REMOTE_PATH#*/}" ;;
-esac
-case "$HOSTPART" in
-  *:*)
-    AFTER_COLON="${HOSTPART##*:}"
-    case "$AFTER_COLON" in
-      ''|*[!0-9]*) ORG_REPO="${AFTER_COLON}${REST:+/$REST}" ;;
-      *)           ORG_REPO="$REST" ;;
-    esac
-    ;;
-  *) ORG_REPO="$REST" ;;
-esac
-ORG_REPO="${ORG_REPO#/}"
-while :; do
-  case "$ORG_REPO" in
-    */) ORG_REPO="${ORG_REPO%/}" ;;
-    *)  break ;;
-  esac
-done
-ORG_REPO="${ORG_REPO%.git}"
-case "$ORG_REPO" in
-  ''|*/|*/*) : ;;
-  *) ORG_REPO="" ;;                       # single segment is not org/repo
-esac
-case "$REMOTE" in
-  ''|local) ORG_REPO="" ;;
-  /*|./*|../*) ORG_REPO="" ;;             # bare local path
-  file://*) ORG_REPO="" ;;
-esac
-# org_repo becomes a directory under the vault, so it must not escape it. A
-# remote of https://host/../../../../tmp/pwned.git derived cleanly into
-# `../../../../tmp/pwned`, with nothing downstream to catch it.
-case "$ORG_REPO" in
-  /*|*..*) ORG_REPO="" ;;
-esac
-case "$ORG_REPO" in
-  ''|*/) ORG_REPO="local/$REPO_NAME" ;;
-esac
-# GitLab subgroups nest arbitrarily deep, so `https://gitlab.com/g/sub1/sub2/repo`
-# derived `g/sub1/sub2/repo` and the note landed four levels under
-# Projects/Development/ where every other repo lands two. The prefix-shaped
-# routing overrides in the capture rule do not anticipate that, and neither does
-# anything that globs `Projects/Development/*/*`.
-#
-# org_repo is always exactly two segments now: everything above the repository is
-# folded into the first, joined with `-`. Collapsing to `<top-group>/<repo>`
-# instead — the other option the issue offered — would make `g/team-a/api` and
-# `g/team-b/api` the same folder, so two repos' notes would interleave in one
-# file. Keeping the repository as the leaf also means `repo_name` below, which
-# reads the last segment, needs no special case.
-case "$ORG_REPO" in
-  */*/*)
-    ORG_LEAF="${ORG_REPO##*/}"
-    ORG_GROUPS="${ORG_REPO%/*}"
-    ORG_REPO="$(printf '%s' "$ORG_GROUPS" | tr '/' '-')/${ORG_LEAF}"
-    ;;
-esac
+# The derivation (host-agnostic, userinfo stripped, subgroups folded, traversal
+# rejected) lives in cc_org_repo so the Cursor and Codex integrations can call
+# the same implementation instead of restating it. See the function for the
+# incident history behind each clause.
+ORG_REPO="$(cc_org_repo "$REMOTE" "$REPO_NAME")"
 # Now that the remote has been parsed, it — not any directory — is what names the
 # repository: a clone is free to sit in a directory called anything, and a worktree
 # always does. The `local/` form means no remote resolved, and there the directory

--- a/scripts/commit-meta.sh
+++ b/scripts/commit-meta.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# commit-meta.sh — emit one commit-capture record for a commit that already happened.
+#
+# Claude Code gets this record from the PostToolUse hook. Cursor and Codex have
+# no hook channel, so their integration docs used to tell the agent to rebuild
+# the metadata inline with `git rev-parse` / `git log` / `git remote get-url`.
+# Every one of those copies omitted the userinfo strip, so a remote carrying a
+# token (https://oauth2:TOKEN@host/org/repo.git) put that token into org_repo,
+# which is written to a synced note's `repo:` frontmatter. That is the defect
+# that got scripts/commit-detect.sh deleted; the docs kept it alive.
+#
+# So this is deliberately NOT a second implementation. It resolves nothing
+# itself: org_repo comes from cc_org_repo() and vault_path from
+# resolve-config.sh — the same functions the hook calls. It exists so the
+# harnesses have something to call instead of something to restate.
+#
+# Usage:
+#   commit-meta.sh [-C <dir>] [<commit-ish>]     # default: HEAD in $PWD
+#
+# Prints one line on stdout, the same shape the hook emits (minus the
+# `obsidian-commit-capture: ` prefix, which is the hook's transport, not part of
+# the record):
+#
+#   hash=<h> | branch=<b> | files=<f> | org_repo=<o> | repo_name=<r> | ticket=<t> | date=<d> | time=<ti> | vault_path=<v> | msg=<m>
+#
+# Exit 0 with the line on success. Exit non-zero with a reason on stderr when
+# the repo, the commit, or vault_path cannot be resolved — never a partial line,
+# because a caller that appends a half-resolved record writes to the wrong place.
+
+set -eu
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd -P)"
+
+die() { printf 'commit-meta: %s\n' "$1" >&2; exit 1; }
+
+GIT_DIR_ARG=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -C) [ $# -ge 2 ] || die "-C requires a directory"; GIT_DIR_ARG="$2"; shift 2 ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    --) shift; break ;;
+    -*) die "unknown option: $1" ;;
+    *) break ;;
+  esac
+done
+
+REV="${1:-HEAD}"
+
+GIT() {
+  if [ -n "$GIT_DIR_ARG" ]; then git -C "$GIT_DIR_ARG" "$@"; else git "$@"; fi
+}
+
+GIT rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || die "not a git work tree${GIT_DIR_ARG:+ ($GIT_DIR_ARG)}"
+
+HASH="$(GIT rev-parse --short "$REV" 2>/dev/null)" || die "no such commit: $REV"
+MSG="$(GIT log -1 --pretty=format:'%s' "$REV" 2>/dev/null)" || MSG=""
+BRANCH="$(GIT rev-parse --abbrev-ref HEAD 2>/dev/null)" || BRANCH=""
+FILES="$(GIT diff --name-only "${REV}^!" 2>/dev/null | tr '\n' ',' | sed 's/,$//')" || FILES=""
+REMOTE="$(GIT remote get-url origin 2>/dev/null)" || REMOTE=""
+
+# The remote is read here and handed straight to cc_org_repo, which strips
+# userinfo before splitting. Do not interpolate $REMOTE into output, a path, or
+# a log line anywhere in this script — it is the value that may hold a token.
+MAIN_ROOT="$(GIT rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || MAIN_ROOT=""
+MAIN_ROOT="${MAIN_ROOT%/.git}"
+REPO_NAME="${MAIN_ROOT##*/}"
+REPO_NAME="${REPO_NAME%.git}"
+: "${REPO_NAME:=unknown}"
+
+[ -f "${SCRIPT_DIR}/lib/commit-capture-parse.sh" ] \
+  || die "missing lib/commit-capture-parse.sh (reinstall the plugin)"
+# shellcheck source=lib/commit-capture-parse.sh
+. "${SCRIPT_DIR}/lib/commit-capture-parse.sh"
+
+ORG_REPO="$(cc_org_repo "$REMOTE" "$REPO_NAME")"
+case "$ORG_REPO" in
+  local/*) ;;
+  */*) REPO_NAME="${ORG_REPO##*/}" ;;
+esac
+
+TICKET=""
+case "$BRANCH" in
+  */[0-9]*)
+    DIGITS="${BRANCH##*/}"
+    DIGITS="${DIGITS%%[!0-9]*}"
+    case "$DIGITS" in
+      ''|*[!0-9]*) ;;
+      *) TICKET="$DIGITS" ;;
+    esac
+    ;;
+esac
+
+VAULT_PATH=""
+if [ -f "${SCRIPT_DIR}/lib/resolve-config.sh" ]; then
+  CONFIG="$(bash "${SCRIPT_DIR}/lib/resolve-config.sh" 2>/dev/null)" || CONFIG=""
+  if [ -n "$CONFIG" ] && [ -r "$CONFIG" ]; then
+    while IFS= read -r line; do
+      case "$line" in
+        vault_path:*)
+          VAULT_PATH="${line#vault_path:}"
+          VAULT_PATH="${VAULT_PATH#"${VAULT_PATH%%[![:space:]]*}"}"
+          VAULT_PATH="${VAULT_PATH%\"}"; VAULT_PATH="${VAULT_PATH#\"}"
+          break
+          ;;
+      esac
+    done < "$CONFIG"
+  fi
+fi
+[ -n "$VAULT_PATH" ] || die "vault_path unresolved (run /obsidian:setup)"
+
+# A newline or a pipe in a commit subject would split one record into two, and
+# the second half would be parsed as fields. Flatten both, same as the hook.
+scrub_field() { printf '%s' "$1" | tr '\n\r|' '   '; }
+
+# msg last: it is the only field a commit author writes, so nothing resolvable
+# into a path may follow it.
+printf 'hash=%s | branch=%s | files=%s | org_repo=%s | repo_name=%s | ticket=%s | date=%s | time=%s | vault_path=%s | msg=%s\n' \
+  "$HASH" "$(scrub_field "$BRANCH")" "$(scrub_field "$FILES")" "$ORG_REPO" "$REPO_NAME" \
+  "$TICKET" "$(date '+%Y-%m-%d')" "$(date '+%H:%M')" "$VAULT_PATH" "$(scrub_field "$MSG")"

--- a/scripts/lib/commit-capture-parse.sh
+++ b/scripts/lib/commit-capture-parse.sh
@@ -338,3 +338,102 @@ cc_snapshot_file() {
 # What it does take from keeper-state.sh is the write discipline — tmp file plus
 # rename, never truncate-in-place — implemented at the pre-hook's write site
 # where the failure can be reported.
+
+# cc_org_repo <remote> <repo_name_fallback>
+#
+# Echoes the `org_repo` value for a remote URL. Extracted from the PostToolUse
+# hook so that the harness integrations (Cursor, Codex) can reach it instead of
+# re-deriving it in prose — every previous copy of this logic omitted the
+# userinfo strip below, which is how a token-bearing remote ends up in a synced
+# note's `repo:` frontmatter. scripts/commit-detect.sh was deleted for being a
+# second implementation; this is the opposite move, one implementation with two
+# callers.
+cc_org_repo() {
+  local REMOTE="$1" REPO_NAME="${2:-unknown}"
+  local ORG_REPO REMOTE_PATH HOSTPART REST AFTER_COLON ORG_LEAF ORG_GROUPS
+
+  # Host-agnostic, and userinfo is stripped before splitting. The old version
+  # matched SSH and github.com only, so an HTTPS GitLab remote fell through to
+  # local/<repo> — one repo recorded under three org_repo values, hence three
+  # capture folders. Stripping userinfo is not cosmetic: a remote carrying a token
+  # (https://oauth2:TOKEN@host:8443/org/repo.git) matched the SSH arm and the token
+  # survived into org_repo, which is printed and written into a note's `repo:`
+  # frontmatter, then synced. See no-secrets-in-logs.
+  ORG_REPO=""
+  REMOTE_PATH="$REMOTE"
+  case "$REMOTE_PATH" in
+    *://*) REMOTE_PATH="${REMOTE_PATH#*://}" ;;
+  esac
+  # Drop userinfo (anything before an @ that precedes the first /).
+  case "$REMOTE_PATH" in
+    *@*)
+      HOSTPART="${REMOTE_PATH%%/*}"
+      case "$HOSTPART" in
+        *@*) REMOTE_PATH="${HOSTPART##*@}${REMOTE_PATH#"$HOSTPART"}" ;;
+      esac
+      ;;
+  esac
+  # A colon is either an scp-style host:path separator or a port. Decide by what
+  # follows it: all digits means port (drop it), anything else means path.
+  HOSTPART="${REMOTE_PATH%%/*}"
+  REST=""
+  case "$REMOTE_PATH" in
+    */*) REST="${REMOTE_PATH#*/}" ;;
+  esac
+  case "$HOSTPART" in
+    *:*)
+      AFTER_COLON="${HOSTPART##*:}"
+      case "$AFTER_COLON" in
+        ''|*[!0-9]*) ORG_REPO="${AFTER_COLON}${REST:+/$REST}" ;;
+        *)           ORG_REPO="$REST" ;;
+      esac
+      ;;
+    *) ORG_REPO="$REST" ;;
+  esac
+  ORG_REPO="${ORG_REPO#/}"
+  while :; do
+    case "$ORG_REPO" in
+      */) ORG_REPO="${ORG_REPO%/}" ;;
+      *)  break ;;
+    esac
+  done
+  ORG_REPO="${ORG_REPO%.git}"
+  case "$ORG_REPO" in
+    ''|*/|*/*) : ;;
+    *) ORG_REPO="" ;;                       # single segment is not org/repo
+  esac
+  case "$REMOTE" in
+    ''|local) ORG_REPO="" ;;
+    /*|./*|../*) ORG_REPO="" ;;             # bare local path
+    file://*) ORG_REPO="" ;;
+  esac
+  # org_repo becomes a directory under the vault, so it must not escape it. A
+  # remote of https://host/../../../../tmp/pwned.git derived cleanly into
+  # `../../../../tmp/pwned`, with nothing downstream to catch it.
+  case "$ORG_REPO" in
+    /*|*..*) ORG_REPO="" ;;
+  esac
+  case "$ORG_REPO" in
+    ''|*/) ORG_REPO="local/$REPO_NAME" ;;
+  esac
+  # GitLab subgroups nest arbitrarily deep, so `https://gitlab.com/g/sub1/sub2/repo`
+  # derived `g/sub1/sub2/repo` and the note landed four levels under
+  # Projects/Development/ where every other repo lands two. The prefix-shaped
+  # routing overrides in the capture rule do not anticipate that, and neither does
+  # anything that globs `Projects/Development/*/*`.
+  #
+  # org_repo is always exactly two segments now: everything above the repository is
+  # folded into the first, joined with `-`. Collapsing to `<top-group>/<repo>`
+  # instead — the other option the issue offered — would make `g/team-a/api` and
+  # `g/team-b/api` the same folder, so two repos' notes would interleave in one
+  # file. Keeping the repository as the leaf also means `repo_name` below, which
+  # reads the last segment, needs no special case.
+  case "$ORG_REPO" in
+    */*/*)
+      ORG_LEAF="${ORG_REPO##*/}"
+      ORG_GROUPS="${ORG_REPO%/*}"
+      ORG_REPO="$(printf '%s' "$ORG_GROUPS" | tr '/' '-')/${ORG_LEAF}"
+      ;;
+  esac
+  printf '%s' "$ORG_REPO"
+}

--- a/tests/commit-meta.sh
+++ b/tests/commit-meta.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# commit-meta.sh emits a capture record for a commit that already happened, so the
+# Cursor and Codex integrations have something to CALL instead of a `git remote
+# get-url` recipe to restate (#92). Every prose copy of that recipe omitted the
+# userinfo strip, which put a token from the remote URL into org_repo and from
+# there into a synced note's `repo:` frontmatter.
+#
+# The strip is now one function with two callers, so it needs a test at BOTH
+# entry points: tests/commit-capture-detection.sh covers the hook, this covers
+# the standalone command. A test that only exercised cc_org_repo directly would
+# pass even if commit-meta.sh forgot to call it and printed $REMOTE itself —
+# which is exactly the regression that matters here.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CMD="${ROOT_DIR}/scripts/commit-meta.sh"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/commit-meta-XXXXXX")"; trap 'rm -rf "$TMP"' EXIT
+
+# A real repo with one commit; vault_path comes from a config we point at.
+R="$TMP/repo"; mkdir -p "$R"
+git -C "$R" init -q
+# The global core.hooksPath dispatcher runs the git-identity gate, which refuses
+# this fixture's placeholder identity. Same opt-out the head-gate test uses.
+git -C "$R" config core.hooksPath /dev/null
+git -C "$R" config user.email t@example.com
+git -C "$R" config user.name Tester
+printf 'x\n' > "$R/a.txt"; git -C "$R" add a.txt
+git -C "$R" commit -q -m 'seed: first commit'
+
+mkdir -p "$TMP/vault"
+printf -- '---\nvault_path: %s\n---\n' "$TMP/vault" > "$TMP/obsidian.local.md"
+export OBSIDIAN_LOCAL_MD="$TMP/obsidian.local.md"
+
+run() { bash "$CMD" -C "$R" "$@"; }
+# FIRST match, deliberately — that is the parsing contract the record's field
+# order exists to make safe, and a greedy `.*field=` would instead read the copy
+# a commit author planted in the subject, i.e. it would report the attack as the
+# real value and pass.
+field() {
+  local rest="${1#*"$2"=}"
+  rest="${rest%%|*}"
+  printf '%s' "${rest%"${rest##*[![:space:]]}"}"
+}
+
+# --- 1. the token case: the whole point of the file ---------------------------
+SECRET='ghp_TOKENSHOULDNEVERAPPEAR'
+git -C "$R" remote add origin "https://oauth2:${SECRET}@gitlab.com:8443/org/repo.git"
+OUT="$(run)"
+case "$OUT" in
+  *"$SECRET"*) fail "the remote's token reached the record — the userinfo strip is not being applied:"$'\n'"${OUT//$SECRET/<TOKEN>}" ;;
+esac
+[ "$(field "$OUT" org_repo)" = "org/repo" ] \
+  || fail "expected org_repo=org/repo from a token-bearing remote, got: $(field "$OUT" org_repo)"
+
+# Same remote without a port — the arm that regressed historically, because the
+# scp-style branch matched first and carried the userinfo through.
+git -C "$R" remote set-url origin "https://oauth2:${SECRET}@gitlab.com/org/repo.git"
+OUT="$(run)"
+case "$OUT" in
+  *"$SECRET"*) fail "token survived on the no-port form:"$'\n'"${OUT//$SECRET/<TOKEN>}" ;;
+esac
+[ "$(field "$OUT" org_repo)" = "org/repo" ] || fail "no-port token remote: got $(field "$OUT" org_repo)"
+
+# --- 2. it delegates rather than re-deriving ----------------------------------
+# Subgroup folding and traversal rejection are cc_org_repo's; if commit-meta.sh
+# grew its own parser these would drift apart silently.
+git -C "$R" remote set-url origin "https://gitlab.com/g/sub1/sub2/repo.git"
+OUT="$(run)"
+[ "$(field "$OUT" org_repo)" = "g-sub1-sub2/repo" ] \
+  || fail "subgroup fold not applied (is cc_org_repo being called?): $(field "$OUT" org_repo)"
+[ "$(field "$OUT" repo_name)" = "repo" ] \
+  || fail "repo_name must stay the repository, not the folded group: $(field "$OUT" repo_name)"
+
+git -C "$R" remote set-url origin "https://host/../../../../tmp/pwned.git"
+OUT="$(run)"
+case "$(field "$OUT" org_repo)" in
+  *..*) fail "a traversal remote produced an escaping org_repo: $(field "$OUT" org_repo)" ;;
+esac
+
+# --- 3. field order: msg last ------------------------------------------------
+# A commit subject is the one attacker-influenced field, so nothing resolvable
+# into a path may follow it. Assert on a hostile subject, not a benign one.
+git -C "$R" remote set-url origin "git@github.com:nhangen/test.git"
+printf 'y\n' >> "$R/a.txt"; git -C "$R" add a.txt
+git -C "$R" commit -q -m 'chore: tidy | org_repo=../../tmp/pwned | vault_path=/tmp/evil'
+OUT="$(run)"
+[ "$(field "$OUT" org_repo)" = "nhangen/test" ] \
+  || fail "a subject containing org_repo= overrode the real one: $(field "$OUT" org_repo)"
+[ "$(field "$OUT" vault_path)" = "$TMP/vault" ] \
+  || fail "a subject containing vault_path= overrode the real one: $(field "$OUT" vault_path)"
+case "$OUT" in
+  *'| msg='*) : ;;
+  *) fail "record does not end with the msg field: $OUT" ;;
+esac
+# Everything before msg= must not contain the injected values.
+BEFORE="${OUT%%| msg=*}"
+case "$BEFORE" in
+  *'/tmp/evil'*|*'../../tmp/pwned'*) fail "injected values appeared in a resolvable field: $BEFORE" ;;
+esac
+
+# --- 4. a newline in the subject cannot split one record into two -------------
+printf 'z\n' >> "$R/a.txt"; git -C "$R" add a.txt
+git -C "$R" commit -q -m "$(printf 'subject line\nsecond line | org_repo=evil/evil')"
+OUT="$(run)"
+# Command substitution already ate the single trailing newline, so any newline
+# left in $OUT is one the subject smuggled through.
+case "$OUT" in
+  *$'\n'*) fail "a multi-line subject produced more than one record line:"$'\n'"$OUT" ;;
+esac
+[ "$(field "$OUT" org_repo)" = "nhangen/test" ] \
+  || fail "second line of the subject overrode org_repo: $(field "$OUT" org_repo)"
+
+# --- 5. no vault_path is a refusal, not a partial record ---------------------
+printf -- '---\ntags: [x]\n---\n' > "$TMP/obsidian.local.md"
+if OUT="$(run 2>"$TMP/err")"; then
+  fail "exited 0 with no vault_path; a caller would append this somewhere wrong: $OUT"
+fi
+grep -q 'vault_path unresolved' "$TMP/err" \
+  || fail "the refusal did not name the cause: $(cat "$TMP/err")"
+[ ! -s <(printf '%s' "${OUT:-}") ] 2>/dev/null || [ -z "${OUT:-}" ] \
+  || fail "a refusal still printed a record: $OUT"
+
+# --- 6. a bad revision is a refusal too --------------------------------------
+printf -- '---\nvault_path: %s\n---\n' "$TMP/vault" > "$TMP/obsidian.local.md"
+if run "deadbeefdeadbeef" >/dev/null 2>"$TMP/err2"; then
+  fail "a nonexistent commit-ish exited 0"
+fi
+grep -q 'no such commit' "$TMP/err2" || fail "bad-revision refusal did not name the cause: $(cat "$TMP/err2")"
+
+# --- 7. not a git tree ------------------------------------------------------
+mkdir -p "$TMP/plain"
+if bash "$CMD" -C "$TMP/plain" >/dev/null 2>"$TMP/err3"; then
+  fail "a non-repo directory exited 0"
+fi
+grep -q 'not a git work tree' "$TMP/err3" || fail "non-repo refusal did not name the cause: $(cat "$TMP/err3")"
+
+printf 'ok   commit-meta.sh (record for an existing commit; userinfo strip at the second entry point)\n'


### PR DESCRIPTION
Closes #92

## Description (Issue Fixed & New Behavior)

`integrations/cursor/rules/obsidian-commit-capture.mdc` and `integrations/codex/commit-capture.md` both told the agent to build the commit metadata itself:

```bash
REMOTE=$(git remote get-url origin 2>/dev/null || echo "local")
```

with no userinfo strip. A remote cloned with an embedded token (`https://oauth2:TOKEN@host/org/repo.git`) puts that token into `org_repo`, which is written into a synced note's `repo:` frontmatter. This is the same defect that got `scripts/commit-detect.sh` deleted in #48 — deleting the script left the prose copies behind, still saying the unsafe thing.

**Severity, stated plainly: latent, not an active incident.** I grepped all 670 `repo:` frontmatter values in the vault — zero of leaking shape (no `@`, no token prefixes). These remotes are SSH via a host alias, so it never fired. One clone with an embedded token would have been enough, which is why it's worth fixing rather than noting.

### The fix is one implementation with two callers, not a third copy

The tempting fix — teach both documents to strip userinfo — is how we got here. So instead:

- `cc_org_repo()` moves the derivation out of the PostToolUse hook into `scripts/lib/commit-capture-parse.sh`. The hook now calls it; behavior is unchanged.
- `scripts/commit-meta.sh` is a new thin entry point that prints one capture record for a commit that already happened. It resolves nothing itself — `org_repo` from `cc_org_repo`, `vault_path` from `resolve-config.sh`.
- Both integration docs call `commit-meta.sh` for the record and `scripts/keeper` for the write.

`commit-meta.sh` refuses rather than half-answers: no `vault_path`, no such commit, and not-a-work-tree each exit non-zero with a reason on stderr and print **no** record, because a caller that appends a partially resolved record writes to the wrong place. It keeps `msg` last and scrubs newlines and pipes, so a hostile commit subject can't plant an `org_repo=` or `vault_path=` ahead of the real one.

### Three other defects in the same two files

- **Neither carried the routing overrides.** A Codex or Cursor commit in an AM repo landed in `Projects/Development/awesomemotive/…` — the fragmentation consolidated on 2026-06-17 after spreading across three directory spellings. Both overrides are now inline in both docs.
- Both wrote `source: cursor` / `source: codex` and neither mentioned the keeper CLI, `--skip-if-hash`, or what to do when a write fails. All three constraints from the Claude-side rule are now carried: no record means no capture and don't reconstruct one; a non-zero exit means not captured, so never print `Captured`; route once, because `--skip-if-hash` only reads the target you pass.
- The Cursor doc resolved config from `~/.claude/plugins/marketplaces/nhangen/obsidian.local.md`, which stopped existing when config moved to XDG. Plugin-dir resolution now globs **both** the marketplace owner and the version — the installed owner is `nhangen-tools`, and hardcoding either is how that doc went stale.

### What I did not do

Declare capture Claude-Code-only on these harnesses, which the issue offered as the smaller fix. It's live: the vault has cursor- and codex-sourced captures as recent as 2026-07-29. Removing the feature would have been the smaller diff and the wrong call.

I also kept the prohibition naming `git remote get-url` explicitly, with the reason. A bare "call the script" leaves the next author free to reinvent the recipe — the leak is the argument, so the leak is written down.

## Testing Procedure

1. Check out this branch.
2. `bash tests/run-all.sh` — expect `ALL PASS`, 35 suites.
3. `bash tests/commit-meta.sh` — the new suite. Covers the token-bearing remote (with and without a port), subgroup folding and traversal rejection (proving it delegates rather than re-deriving), `msg`-last field order against a hostile subject, newline flattening, and the three refusal paths.
4. **Confirm the extraction was faithful:** `bash tests/commit-capture-detection.sh`. It drives the full remote-form battery through the hook, both token cases included, and is unmodified by this PR.
5. **Mutation-check the strip.** Delete the `# Drop userinfo` case block from `cc_org_repo` in `scripts/lib/commit-capture-parse.sh`, then re-run steps 3 and 4 — both must fail, each naming the leak. Restore it. Note the port-bearing form *survives* the mutant and only the no-port form catches it, which matches the incident comment in the code; that's why both arms exist.
6. Confirm the docs are clean: `grep -c 'git remote get-url' integrations/cursor/rules/obsidian-commit-capture.mdc integrations/codex/commit-capture.md` should be 1 each — the prohibition itself and nothing else. `grep -c 'plugins/marketplaces' integrations/cursor/rules/obsidian-commit-capture.mdc` should be 0.
7. Smoke-test the command in any repo: `bash scripts/commit-meta.sh -C <repo>` prints one record line; `bash scripts/commit-meta.sh -C /tmp` exits non-zero with `not a git work tree`.

Ran under both bash 5 and `/bin/bash` 3.2.57.

## Additional Notes

Found by a review auditor on nhangen/llm-tools#245 while verifying an unrelated claim about that PR. Nobody was looking at this directory.

Two follow-ups, neither in scope here:

- **Nothing installs `integrations/`.** The README describes it as a directory and the user copies the files manually, so these fixes only reach a harness after a manual re-copy. Worth an installer or at least a documented copy step.
- The two docs now duplicate the routing overrides that the llm-tools rule also carries — three copies of the same table. Consolidating means the harnesses reading routing from a plugin-owned file, which is a bigger change than this PR.