### PR TITLE
Key the never-completed banner on a recorded attempt, not the cache dir

### DIFF
--- a/obsidian.local.md.example
+++ b/obsidian.local.md.example
@@ -88,9 +88,12 @@ unfiled notes / open `[ask]`s / promotable clusters into the machine-owned
   keeper-owned files are quarantined under `.vaultkeeper-quarantine/`, never
   deleted.
 - `keeper_interval_secs` — tick cadence; the `/obsidian:ask` staleness banner
-  fires past `2x` this.
+  fires past `2x` this. It also fires, regardless of cadence, when this host has
+  attempted a scan but never completed one — the state a faulting scanner leaves
+  behind. A host that only ever defers to the elected owner attempts nothing, so
+  it stays quiet.
 
-State (`.state`, snapshots, `last_scan`) lives under
+State (`.state`, snapshots, `last_scan`, `last_attempt`) lives under
 `${XDG_CACHE_HOME:-$HOME/.cache}/vaultkeeper/<vault-id>/`, never in the vault.
 
 ## Session Intent Inference

--- a/scripts/lib/keeper-state.sh
+++ b/scripts/lib/keeper-state.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # keeper-state.sh — non-synced per-host state: cache dir, prior-scan snapshot,
-# last_scan, cold-start detection, staleness banner. Requires note-hash.sh.
+# last_scan, last_attempt, cold-start detection, staleness banner. Requires
+# note-hash.sh.
 
 keeper_vault_id() {
   local out
@@ -43,22 +44,49 @@ keeper_last_scan_file() { printf '%s/last_scan\n' "$(keeper_cache_dir "$1")"; }
 keeper_record_scan()    { local f; f="$(keeper_last_scan_file "$1")"; mkdir -p "$(dirname "$f")"; now_epoch > "$f"; }
 keeper_last_scan()      { local f; f="$(keeper_last_scan_file "$1")"; [ -f "$f" ] && cat "$f" || true; }
 
+# An attempt is recorded by the elected owner immediately before it scans, whether or
+# not that scan goes on to complete. It is what makes an absent last_scan legible: with
+# no attempt nothing has tried from this host, and with one every try faulted.
+keeper_last_attempt_file() { printf '%s/last_attempt\n' "$(keeper_cache_dir "$1")"; }
+keeper_record_attempt()    { local f; f="$(keeper_last_attempt_file "$1")"; mkdir -p "$(dirname "$f")"; now_epoch > "$f"; }
+keeper_last_attempt()      { local f; f="$(keeper_last_attempt_file "$1")"; [ -f "$f" ] && cat "$f" || true; }
+
 # The banner is the only place a user hears that the index is not being
 # maintained. It used to return silently when last_scan was absent, which is
 # indistinguishable from a fresh successful scan — and absent is exactly what a
 # host whose *first* scan faulted has, because the tick withholds last_scan on a
 # fault. Such a host reported nothing wrong, permanently (#52).
 #
-# The cache dir is the "has the keeper ever run here" test: it is created by
-# keeper_state_init at the top of every tick. Without that condition the banner
-# would nag on any vault where the keeper was never installed, which is not a
-# fault and not this warning's business.
+# The "has anything tried here" test is a recorded attempt, not the presence of the
+# cache dir. keeper_state_init creates that dir at the top of every tick — above the
+# ownership gate — so on a two-host vault it exists on the host that only ever defers,
+# and keying off it warned there on every ask, forever, about a vault the elected owner
+# was scanning perfectly well. A banner that always fires carries no information, which
+# is a worse failure than the silence #52 removed. The attempt file is written below
+# that gate, so only a host that actually scans has one.
 staleness_banner() {
-  local vault="$1" interval="$2" last now
+  local vault="$1" interval="$2" last attempted now
   last="$(keeper_last_scan "$vault")"
   if [ -z "$last" ]; then
-    [ -d "$(keeper_cache_dir "$vault")" ] || return 0
-    printf '⚠ index has never completed a scan on this host\n'
+    attempted="$(keeper_last_attempt "$vault")"
+    [ -n "$attempted" ] || return 0
+    # Same reasoning as the last_scan guard below: this branch does arithmetic on the
+    # value, and a truncated write here would abort the caller in the one state this
+    # warning exists to describe.
+    case "$attempted" in
+      *[!0-9]*)
+        printf '⚠ index last_attempt is unreadable on this host\n'
+        return 0
+        ;;
+    esac
+    # No aging grace here, deliberately: one recorded attempt with no completed scan
+    # already means the index has never been fully built on this host. The window
+    # between the attempt and the scan is however long one tick's scanners take, so on
+    # a first-ever tick over a large vault a healthy in-progress scan can show this
+    # line until it finishes — accepted, because a grace window is what let a latched
+    # fault hide in the first place.
+    printf '⚠ index has never completed a scan on this host (last attempt %ss ago)\n' \
+      "$(( $(now_epoch) - attempted ))"
     return 0
   fi
   # A last_scan that is not a number cannot be compared, and the arithmetic below

--- a/scripts/vaultkeeper-tick.sh
+++ b/scripts/vaultkeeper-tick.sh
@@ -35,13 +35,31 @@ if ! keeper_is_owner "$LEASE" "$HOST" "$PRIORITY" "$MAXAGE"; then
   exit 0
 fi
 
+SCAN_FAULT=""
+# Record the attempt here — below the ownership gate, above the scanners. It is what
+# lets staleness_banner read a missing last_scan: no attempt means nothing has tried
+# from this host, an attempt with no scan means every try faulted. It must stay below
+# the gate, or a host that only ever defers claims an attempt it never makes and warns
+# on every ask forever (keeper_state_init, and so the cache dir the banner used to key
+# off, runs above the gate — which is exactly how that false alarm got shipped).
+#
+# Guarded rather than called bare: unchecked under `set -e` a failed write kills the
+# tick right here, above the scan, the base view and the digest, so a full or unwritable
+# cache dir would cost a degraded host the Librarian.md it can still produce. ENOSPC
+# here is the same correlated failure class as the mktemp buffer below, so it takes the
+# same route — fold into SCAN_FAULT and carry on. A scan whose attempt could not be
+# recorded is not one we can account for.
+if ! keeper_record_attempt "$VAULT"; then
+  SCAN_FAULT="cannot record the scan attempt (cache dir unwritable); scan not accountable"
+  printf 'vaultkeeper: %s\n' "$SCAN_FAULT" >&2
+fi
+
 # Capture the scanners' stderr instead of letting it fly past. Every scanner
 # returns 0 unconditionally, so a truncated scan was indistinguishable from a
 # complete one and got recorded as complete — for every one of 700+ consecutive
 # ticks on the maintainer's host, each logging `Too many open files` immediately
 # above `scan complete`. A scan whose scanners complained is not a scan we can
 # describe as done; the gate below sits between the digest and the snapshot.
-SCAN_FAULT=""
 SCAN_ERR="$(mktemp "${TMPDIR:-/tmp}/kbscan-XXXXXX" 2>/dev/null)" || SCAN_ERR=""
 if [ -n "$SCAN_ERR" ]; then
   :
@@ -163,9 +181,11 @@ if [ -n "$SCAN_FAULT" ]; then
   # this check sat below it, in a file the user hand-edits and Syncthing replicates.
   # keeper_record_scan is withheld for the ordinary reason: last_scan's consumer is
   # staleness_banner (scripts/ask-staleness.sh), and a partial scan recorded as
-  # complete tells it the vault was fully examined. Note the banner only fires once a
-  # PREVIOUS last_scan ages out — a host that has never recorded one stays silent, so
-  # a latched fault here is invisible rather than loud. That gap is filed separately.
+  # complete tells it the vault was fully examined. Withholding it reaches that consumer
+  # even on a host that has never recorded one: the attempt written above the scanners
+  # lets the banner tell a host whose every tick faulted from one that has never tried,
+  # so a fault latched from the very first tick reads as "never completed a scan"
+  # rather than as silence.
   #
   # One exception, and only one: rows whose side effect already happened and cannot be
   # re-derived (#58). keeper_quarantine_conflicts has already `mv`d the conflict file

--- a/tests/ask-staleness.sh
+++ b/tests/ask-staleness.sh
@@ -20,4 +20,16 @@ keeper_record_scan "$V"
 printf '1000\n' > "$(keeper_cache_dir "$V")/last_scan"
 [ -n "$(run)" ] || fail "stale index should warn"
 
+# never-completed, through the real script. tests/keeper-state.sh covers the branch at
+# the library level; this is the only test that runs what /obsidian:ask actually
+# invokes — config resolution, interval default and all — so the state #52 exists to
+# surface should be visible from here, and the cache-dir-only case should not be.
+rm -f "$(keeper_last_scan_file "$V")"
+[ -z "$(run)" ] || fail "a cache dir with no attempt must not warn through the real entrypoint"
+keeper_record_attempt "$V"
+case "$(run)" in
+  *"never completed"*) : ;;
+  *) fail "entrypoint did not surface the never-completed state: $(run)" ;;
+esac
+
 echo "PASS: ask-staleness"

--- a/tests/keeper-state.sh
+++ b/tests/keeper-state.sh
@@ -34,14 +34,24 @@ keeper_has_snapshot "$VAULT" || fail "snapshot should exist after write"
 
 # last_scan + staleness
 [ -z "$(keeper_last_scan "$VAULT")" ] || fail "last_scan should be empty"
-# An absent last_scan is NOT healthy (#52). The tick withholds last_scan when a
-# scan faults, so a host whose first scan ever faulted has none — and the old
-# behaviour (silence) made that indistinguishable from a fresh successful scan,
-# permanently. The cache dir exists here because keeper_state_init ran above,
-# which is the same condition a real tick establishes.
+# The cache dir alone is not evidence that anything tried to scan. keeper_state_init
+# creates it at the top of every tick — above the ownership gate — so it exists on a
+# host that only ever defers to the elected owner. Keying the warning off it warned
+# there on every ask, forever, about a vault the owner was scanning fine.
+[ -z "$(keeper_last_attempt "$VAULT")" ] || fail "last_attempt should be empty"
+[ -d "$(keeper_cache_dir "$VAULT")" ] || fail "fixture precondition: cache dir should exist here"
+[ -z "$(staleness_banner "$VAULT" 900)" ] \
+  || fail "warned with only a cache dir to go on: $(staleness_banner "$VAULT" 900)"
+
+# An absent last_scan IS a fault once something has attempted a scan (#52). The tick
+# withholds last_scan when a scan faults, so a host whose first scan ever faulted has
+# an attempt and no scan — and the old behaviour (silence) made that indistinguishable
+# from a fresh successful scan, permanently.
+keeper_record_attempt "$VAULT"
+[ -n "$(keeper_last_attempt "$VAULT")" ] || fail "last_attempt not recorded"
 COLD="$(staleness_banner "$VAULT" 900)"
 [ -n "$COLD" ] \
-  || fail "a host that has never recorded a scan reported nothing wrong"
+  || fail "a host that attempted a scan and never completed one reported nothing wrong"
 case "$COLD" in
   *never*) : ;;
   *) fail "cold start must say it has never scanned, not reuse the stale wording: $COLD" ;;
@@ -64,6 +74,17 @@ BAD="$(staleness_banner "$VAULT" 900)" || fail "an unreadable last_scan aborted 
 case "$BAD" in
   *unreadable*) : ;;
   *) fail "an unreadable last_scan produced no distinct warning: ${BAD:-<empty>}" ;;
+esac
+
+# Same for last_attempt, which the absent-last_scan branch now does arithmetic on.
+# A truncated or partially-written epoch there would otherwise abort the caller in the
+# one state this warning exists to describe.
+rm -f "$(keeper_last_scan_file "$VAULT")"
+printf 'not-a-number\n' > "$(keeper_last_attempt_file "$VAULT")"
+BADA="$(staleness_banner "$VAULT" 900)" || fail "an unreadable last_attempt aborted staleness_banner"
+case "$BADA" in
+  *unreadable*) : ;;
+  *) fail "an unreadable last_attempt produced no distinct warning: ${BADA:-<empty>}" ;;
 esac
 
 echo "PASS: keeper-state"

--- a/tests/vaultkeeper-tick.sh
+++ b/tests/vaultkeeper-tick.sh
@@ -40,6 +40,26 @@ rm -f "$V/Librarian.md"
 run_tick "mbp"
 [ ! -f "$V/Librarian.md" ] || fail "non-owner must not write Librarian.md"
 
+# ...and it must not claim a scan ATTEMPT either. The attempt is what staleness_banner
+# reads to decide whether an absent last_scan is a fault, so a deferring host that
+# records one warns on every ask, forever, about a vault the elected owner is scanning
+# fine — the false alarm that keying off the cache dir produced. Needs its own vault:
+# $V already carries ml-1's last_scan, so the banner there takes the aging branch and
+# never reaches the never-completed one.
+NV="$TMP/nonownervault"; mkdir -p "$NV/Inbox"
+printf -- '---\ntags: [x]\ntype: note\n---\nbody\n' > "$NV/n.md"
+NCFG="$TMP/nonowner.local.md"
+sed "s|^vault_path: .*|vault_path: $NV|" "$CFG" > "$NCFG"
+OBSIDIAN_LOCAL_MD="$NCFG" run_tick "ml-1" >/dev/null    # ml-1 takes the lease
+rm -f "$(keeper_last_scan_file "$NV")" "$(keeper_last_attempt_file "$NV")"
+OBSIDIAN_LOCAL_MD="$NCFG" run_tick "mbp" >/dev/null     # mbp defers, scans nothing
+[ -d "$(keeper_cache_dir "$NV")" ] \
+  || fail "fixture precondition: the deferring tick should still have created the cache dir"
+[ ! -f "$(keeper_last_attempt_file "$NV")" ] \
+  || fail "a deferring host claimed an attempt it never made — the banner will cry wolf forever"
+[ -z "$(staleness_banner "$NV" 900)" ] \
+  || fail "deferring host must stay silent, got: $(staleness_banner "$NV" 900)"
+
 # --- a scan whose scanners complained is not recorded as complete (#42) ---
 # 700+ consecutive ticks on the maintainer's host logged `Too many open files`
 # from vault-scan.sh and then `scan complete`, so last_scan advanced on a
@@ -74,6 +94,18 @@ grep -q 'scan complete' "$FOUT" \
   && fail "a faulted scan reported itself complete; got: $(cat "$FOUT")"
 [ -f "$(keeper_last_scan_file "$SV")" ] \
   && fail "a faulted scan recorded last_scan, so the staleness banner will lie"
+# ...and withholding it has to reach the consumer. This host faults on its very first
+# tick, so it has no previous last_scan to age out; before the attempt file existed the
+# banner had nothing to distinguish it from a fresh install and stayed silent. The gate
+# was honest and no reader could hear it.
+[ -f "$(keeper_last_attempt_file "$SV")" ] \
+  || fail "a faulted tick recorded no attempt, so the banner cannot tell it from a fresh install"
+FBANNER="$(staleness_banner "$SV" 900)"
+[ -n "$FBANNER" ] || fail "a host whose only scans faulted still looks healthy to the banner"
+case "$FBANNER" in
+  *"never completed"*) : ;;
+  *) fail "banner did not name the real state: $FBANNER" ;;
+esac
 
 # --- a faulted tick must not touch the snapshot or Pending.md (#42, panel) ---
 # The first cut of the scan-fault gate sat BELOW surfacing_pending_transition, so a
@@ -364,5 +396,31 @@ grep -q 'scan complete' "$MOUT" \
   && fail "a tick with no fault buffer reported itself complete: $(cat "$MOUT")"
 [ -f "$(keeper_last_scan_file "$MV")" ] \
   && fail "a tick with no fault buffer recorded last_scan"
+
+# --- an unwritable cache dir degrades the tick, it does not abort it ---
+# keeper_record_attempt is the first write after the ownership gate, so calling it
+# unchecked under `set -e` would kill the run there — above the scan, the base view AND
+# the digest — and a host with a full or unwritable cache dir would lose the
+# Librarian.md it can still produce. ENOSPC is the same correlated failure class as the
+# mktemp case above, so it takes the same route: fold into SCAN_FAULT, say so, keep the
+# digest, withhold last_scan.
+UV="$TMP/unwritablevault"; mkdir -p "$UV/Inbox"
+printf -- '---\ntags: [x]\n---\nbody\n' > "$UV/n.md"
+UCFG="$TMP/unwritable.local.md"; sed "s|^vault_path: .*|vault_path: $UV|" "$CFG" > "$UCFG"
+UCACHE="$(keeper_cache_dir "$UV")"; mkdir -p "$UCACHE"; chmod 555 "$UCACHE"
+UOUT="$TMP/unwritable.out"
+set +e
+OBSIDIAN_LOCAL_MD="$UCFG" VAULTKEEPER_HOST="ml-1" \
+  bash "${ROOT_DIR}/scripts/vaultkeeper-tick.sh" >"$UOUT" 2>&1
+URC=$?
+set -e
+chmod 755 "$UCACHE"
+[ "$URC" -eq 0 ] || fail "an unwritable cache dir aborted the tick (rc=$URC); got: $(cat "$UOUT")"
+[ -f "$UV/Librarian.md" ] \
+  || fail "the digest was lost when the cache dir was unwritable; got: $(cat "$UOUT")"
+grep -q 'scan INCOMPLETE' "$UOUT" \
+  || fail "an unaccountable scan did not name itself incomplete; got: $(cat "$UOUT")"
+grep -q 'scan complete' "$UOUT" \
+  && fail "a scan it could not account for reported itself complete: $(cat "$UOUT")"
 
 echo "PASS: vaultkeeper-tick"


### PR DESCRIPTION
Closes #96

Supersedes #59, which was written before the #52 fix landed on master and could not be rebased cleanly onto it. Rebuilt on current master.

## Description

The #52 fix keyed "has anything tried to scan here" off the presence of the cache dir. `keeper_state_init` creates that dir at the top of every tick — **above** the ownership gate — so it exists on a host that only ever defers to the elected owner. The banner therefore warned there on every ask, forever, about a vault the owner was scanning perfectly well:

```
ml-1 (owner) tick:   scan complete (ml-1)
ml-1 banner:         []
mbp tick:            mbp defers to ml-1
mbp banner:          [⚠ index has never completed a scan on this host]
```

A banner that always fires carries no information — it trains you to ignore the one channel that reports a faulting index, which is a worse failure than the silence #52 removed. On a two-host setup the deferring host is usually the one you're asking from.

So record an **attempt** and read that instead. It is written below the ownership gate, immediately before the scanners run:

- **no attempt** → nothing has tried from this host (fresh install, or a host that defers). Silence is right, and `tests/keeper-state.sh`'s untouched-vault case still covers it.
- **an attempt with no completed scan** → every try faulted, which is exactly what the fault gate withholds `last_scan` to signal. Warn, and say how long ago the attempt was.

The unreadable-value guard master added for `last_scan` is extended to the new epoch file, since this branch does arithmetic on it too.

Also closes #96: the attempt write is guarded rather than bare. Unchecked under `set -e` it aborts the tick above the scan, the base view *and* the digest, so an unwritable or full cache dir would cost a degraded host the `Librarian.md` it can still produce. ENOSPC there is the same correlated failure class as the mktemp buffer below it, so it takes the same route — fold into `SCAN_FAULT`, keep the digest, withhold `last_scan`.

No aging grace on the never-completed branch, deliberately: one recorded attempt with no completed scan already means the index was never fully built here. The window between the attempt and the scan is however long one tick's scanners take, so on a first-ever tick over a large vault a healthy in-progress scan can show the line until it finishes. Accepted — a grace window is what let a latched fault hide in the first place.

## Testing Procedure

1. Check out this branch. Run the full suite: `for t in tests/*.sh; do bash "$t" >/dev/null || echo "FAIL $t"; done` — 36 suites, no output.
2. Reproduce the false alarm this fixes, against `master`: tick as `ml-1` (owner) on a vault, then tick as `mbp` with a *separate* `XDG_CACHE_HOME`, then run `scripts/ask-staleness.sh`. On `master` the deferring host prints the never-completed banner; on this branch it prints nothing.
3. Confirm each assertion binds, one mutation at a time:
   - Restore the cache-dir heuristic (`[ -d "$(keeper_cache_dir "$vault")" ] || return 0` in place of the attempt read) → fails `tests/keeper-state.sh` (`warned with only a cache dir to go on`), `tests/ask-staleness.sh`, and `tests/vaultkeeper-tick.sh` (`deferring host must stay silent`).
   - Hoist `keeper_record_attempt` above the ownership gate → fails `tests/vaultkeeper-tick.sh` (`a deferring host claimed an attempt it never made`).
   - Replace the guarded attempt write with a bare call → fails `tests/vaultkeeper-tick.sh` (`an unwritable cache dir aborted the tick (rc=1)`).
   - Drop the unreadable-`last_attempt` case → fails `tests/keeper-state.sh` (`an unreadable last_attempt aborted staleness_banner`).
4. Confirm the faulted-tick path still reaches the consumer: the scanner-shadowing fixture in `tests/vaultkeeper-tick.sh` asserts the tick records an attempt, withholds `last_scan`, and that `staleness_banner` then says `never completed`.

## Notes

#95 (a deferring host has no signal that the *owner* is faulting) is now the remaining gap and is unchanged by this PR — it needs the cross-host signal already in the vault (`Librarian.md`'s `scan_status`, plus the lease owner), not local state. Fixing it by recording an attempt on every host is precisely the false alarm this PR removes; the new fixture will fail anyone who tries.

#94's non-numeric half is already fixed on master for `last_scan` and extended here to `last_attempt`. The empty-file-reads-as-absent half remains open.