### PR TITLE
Add safe Codex commit capture skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "nhangen-codex-plugins",
+  "interface": {
+    "displayName": "nhangen Codex Plugins"
+  },
+  "plugins": [
+    {
+      "name": "obsidian",
+      "source": {
+        "source": "local",
+        "path": "./packages/codex"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,15 +1,15 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "nhangen",
-  "description": "nhangen's Claude Code plugins",
+  "description": "nhangen's agent plugins",
   "owner": {
     "name": "nhangen"
   },
   "plugins": [
     {
       "name": "obsidian",
-      "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, query past work with /recall, export conversations, create/retrieve notes, and auto-organize content.",
-      "version": "1.16.4",
+      "description": "Obsidian vault integration with automatic commit-context capture for Claude Code and an installed safe capture skill for Codex.",
+      "version": "1.22.0",
       "author": {
         "name": "nhangen"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "Obsidian vault integration for Claude Code. Auto-capture git commit context, auto-save sessions via background claude CLI summarizer, export conversations, create/retrieve notes, and auto-organize content.",
   "author": {
     "name": "nhangen"

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # obsidian
 
-**Obsidian vault integration for Claude Code — auto-save sessions, capture git commit context, and create/recall notes from the CLI.**
+**Obsidian vault integration for Claude Code and Codex — auto-save Claude sessions, capture git commit context, and create/recall notes from the CLI.**
 
 ## Why
 
-Long Claude sessions and the commits they produce hold context that's gone the moment the session ends: why a decision was made, what was investigated and rejected, loose ends flagged for later. Pasting that into Obsidian by hand is the kind of chore that doesn't get done. This plugin captures it automatically — sessions on stop, commit context on every `git commit` — and routes notes to the right folder by domain.
+Long agent sessions and the commits they produce hold context that's gone the moment the session ends: why a decision was made, what was investigated and rejected, loose ends flagged for later. Pasting that into Obsidian by hand is the kind of chore that doesn't get done. This plugin captures Claude Code sessions on stop, captures commit context automatically in Claude Code and through an installed post-commit skill in Codex, and routes notes to the right folder by domain.
 
 ## How it works
 
 - A **Stop hook** runs at session end; if the session is significant, a background `claude --print` summarizer writes a structured note to your vault.
 - Session capture infers `session_intent`, `capture_action`, and `research_state_change` with confidence scores and evidence bullets, so routing can distinguish execution, research, planning, operations, reflection, scratch work, and claim/evidence changes that should land in the Research Substrate.
-- A **PreToolUse/PostToolUse hook pair** on `Bash` notices when a `git commit` actually moved `HEAD` and appends goal / investigation / decision / loose-ends bullets to a per-repo daily file.
+- In Claude Code, a **PreToolUse/PostToolUse hook pair** on `Bash` notices when a `git commit` actually moved `HEAD` and appends goal / investigation / decision / loose-ends bullets to a per-repo daily file.
+- In Codex, the installed **`commit-capture` skill** runs after a successful commit, obtains the same sanitized record through `commit-meta.sh`, and appends through the same keeper primitive. Current Codex CLI sessions do not deliver this plugin's bundled hooks, so the skill is instruction-driven rather than hook-driven.
 - **Slash commands** (skills) cover the manual paths: save, find, recall, daily, new, bookmark, setup.
 - **Routing** is driven by `obsidian.local.md` — a vault path and a keyword-based domain taxonomy you edit directly.
 
@@ -115,7 +116,7 @@ The keeper writes only to the Obsidian vault (`vault_path` from `obsidian.local.
 | `SessionStart` | `scripts/config-doctor.sh` | If the plugin is installed but unconfigured on this host (no `obsidian.local.md`) while a synced vault is detectable, surfaces an advisory so the agent can offer `/obsidian:setup`. Silent once configured, and silent on hosts with no vault. Advisory only — a hook can't prompt. |
 | `Stop` | `scripts/session-save.sh` | Auto-saves significant sessions via background `claude --print` summarizer. Skips trivial sessions. |
 | `PreToolUse` (Bash) | `scripts/commit-capture-pre.sh` | For a Bash call that is about to run `git commit`, records the target repo's current `HEAD` (and the repo the command named, which may not exist yet). Writes nothing else, and always exits 0 — a PreToolUse hook that fails would block the command. |
-| `PostToolUse` (Bash) | `scripts/commit-capture.sh` | If `HEAD` moved during the call and git says the move was a commit of ours, appends a context block to `<vault>/Projects/Development/<org>_<repo>/<YYYY-MM-DD>.md`. Per-repo overrides supported (e.g. `altamira2/mtf-builder` → flat `<vault>/Altamira/<date>-mtf-builder-commits.md`). |
+| `PostToolUse` (Bash) | `scripts/commit-capture.sh` | If `HEAD` moved during the call and git says the move was a commit of ours, emits the sanitized commit record that the matching skill appends to the routed vault note. |
 
 Both hooks are gated — they inspect the Bash command first and exit silently for non-commit calls, so they don't interrupt normal tool flow.
 
@@ -136,7 +137,7 @@ With only the PostToolUse half wired up there is no "before". The hook says so, 
 After a `git commit`:
 
 ```
-Captured a1b2c3d → awesomemotive_optin-monster-app/2026-05-12.md
+Captured a1b2c3d → Awesome Motive/sessions/2026-05-12-optin-monster-app.md
 ```
 
 ## Install
@@ -147,6 +148,15 @@ claude plugin install nhangen/obsidian
 ```
 
 The setup wizard prompts for vault path, domain names, keywords per domain, and daily/inbox paths, then writes `obsidian.local.md` to the stable config location (see below).
+
+For Codex commit capture:
+
+```bash
+codex plugin marketplace add nhangen/claude-obsidian-plugin
+codex plugin add obsidian@nhangen-codex-plugins
+```
+
+Start a new session and configure `vault_path` in the stable config file described below. The Codex package exposes only the post-commit capture skill; it does not load the Claude session-end watcher, hooks, or other Claude-specific skills. See `integrations/codex/commit-capture.md` for the runtime contract.
 
 ## Configuration
 
@@ -194,6 +204,7 @@ Per-repo commit-capture overrides go in the same file under a `## Commit Capture
 commands/*.md                 Slash command entry points
 skills/*/SKILL.md             Skill logic (save, find, recall, setup, …)
 hooks/hooks.json              Stop + Pre/PostToolUse hook registration
+packages/codex/               Self-contained Codex package with only manual commit capture
 scripts/                      Hook executables (commit-capture, session-save, …)
 scripts/lib/commit-capture-parse.sh Payload decoding + repo resolution shared by the commit-capture hook pair
 scripts/lib/resolve-config.sh Version-independent config-path resolver
@@ -205,11 +216,11 @@ scripts/lib/moc-promote.sh    Retargets inbound wikilinks when an MOC promotion 
 scripts/keeper                CLI entry point for keeper insert/append operations
 scripts/commit-meta.sh        Emits one capture record for an existing commit, for harnesses with no hook
 agents/                       Subagents (vault-organizer for /obsidian reorganize paths)
-integrations/                 Cursor + Codex capture docs; they call commit-meta.sh, never git directly
+integrations/                 Cursor fallback and Codex manual commit-capture documentation
 obsidian.local.md.example     Config template (real config lives at the stable path, gitignored)
 ```
 
-The plugin root is resolved by Claude Code via `${CLAUDE_PLUGIN_ROOT}` — scripts never hardcode a version path. User config is resolved separately by `scripts/lib/resolve-config.sh` (stable path first, plugin root as legacy fallback), so updating the plugin never strands the config.
+Claude Code supplies `${CLAUDE_PLUGIN_ROOT}`. The Codex skill resolves its bundled helpers relative to its installed `SKILL.md`; neither integration searches versioned cache paths. User config is resolved separately by `scripts/lib/resolve-config.sh` (stable path first, plugin root as legacy fallback), so updating the plugin never strands the config.
 
 ## Known Limitations
 

--- a/integrations/codex/commit-capture.md
+++ b/integrations/codex/commit-capture.md
@@ -1,103 +1,34 @@
-# Obsidian Commit Capture
+# Codex Commit Capture
 
-After every successful `git commit`, capture the conversation context to an Obsidian vault note. This preserves the reasoning, investigation, and decisions that led to the commit — context that git alone does not store.
+After every successful `git commit`, use the installed `obsidian:commit-capture` skill to save the conversation context to Obsidian. Current Codex CLI sessions load the skill but do not deliver this plugin's bundled `PreToolUse`/`PostToolUse` hooks, so this path is agent-invoked after the commit.
 
-Codex has no PostToolUse hook, so nothing hands you the commit metadata the way it does in Claude Code. **Call the plugin for it. Do not rebuild it from git commands** — see step 3, which is a security constraint, not a style preference.
+## Install
 
-## When to trigger
+```bash
+codex plugin marketplace add nhangen/claude-obsidian-plugin
+codex plugin add obsidian@nhangen-codex-plugins
+```
 
-Only after a `git commit` succeeds. Do not trigger on failed commits, dry runs, or non-commit git commands.
+Start a new session. Configure the vault through `$OBSIDIAN_LOCAL_MD` or `${XDG_CONFIG_HOME:-$HOME/.config}/claude-obsidian/obsidian.local.md`:
 
-## How to capture
+```yaml
+---
+vault_path: /absolute/path/to/your/vault
+---
+```
 
-1. **Resolve the plugin directory.** The version bumps regularly and the marketplace owner is not fixed, so glob both:
+The Codex package contains one skill and no hooks, session watcher, or unrelated Claude-specific skills.
 
-   ```bash
-   PLUGIN_DIR=$(ls -1d "$HOME"/.claude/plugins/cache/*/obsidian/*/ 2>/dev/null | sort -V | tail -1 | sed 's:/$::')
-   ```
+## Runtime flow
 
-   Empty means the plugin is not installed. Stop and say so; do not fall back to deriving the metadata yourself.
+1. Trigger only after `git commit` exits successfully. Failed commits, dry runs, and non-commit Git commands do not qualify.
+2. Resolve helpers relative to the installed skill and run its bundled `scripts/commit-meta.sh -C <repository>`.
+3. If metadata resolution fails, report the error and stop. Never rebuild the record with `git rev-parse`, `git log`, or `git remote get-url`; the helper strips remote userinfo before it can reach a synced note.
+4. Route exactly once:
+   - `awesomemotive/*` -> `Awesome Motive/sessions/<date>-<repo>.md`
+   - `altamira2/mtf-builder` -> `Altamira/mtf-builder/commits/<date>-mtf-builder-commits.md`
+   - otherwise -> `Projects/Development/<org>/<repo>/<date>.md`
+5. Build 3-8 dense context bullets from the conversation and append through the skill's bundled `scripts/keeper` with `--skip-if-hash`.
+6. Report capture only after a zero exit. Distinguish an idempotent `append skipped` result from a new write, and report any non-zero keeper result as not captured.
 
-2. **Get the record** for the commit that just landed:
-
-   ```bash
-   bash "$PLUGIN_DIR/scripts/commit-meta.sh" -C "<the repo you committed in>"
-   ```
-
-   Output is one line:
-
-   ```
-   hash=<h> | branch=<b> | files=<f> | org_repo=<o> | repo_name=<r> | ticket=<t> | date=<d> | time=<ti> | vault_path=<v> | msg=<m>
-   ```
-
-   Take the **first** match for each field and never re-read a field name out of `msg`. `msg` is last and unterminated because it is the one field a commit author controls — a subject reading `chore: tidy | vault_path=/tmp/evil` must not be able to redirect the write.
-
-   **A non-zero exit means there is no capture.** The reason goes to stderr (`vault_path unresolved` → the vault is not configured). Report it and stop. Never write a note with guessed values.
-
-3. **Never reconstruct the metadata yourself** — not `git rev-parse`, not `git log`, and especially not `git remote get-url`. This document used to instruct exactly that, and it was a credential leak: a remote cloned with an embedded token (`https://oauth2:TOKEN@host/org/repo.git`) puts that token into `org_repo`, which lands in the note's `repo:` frontmatter and syncs everywhere. `commit-meta.sh` strips userinfo before splitting the URL; a hand-rolled version does not. The plugin's old `commit-detect.sh` was deleted for this same defect.
-
-4. **Pick the target.** Default `Projects/Development/<org>/<repo>/<date>.md`, where `<org>/<repo>` is the record's `org_repo` and `<repo>` alone is its `repo_name`. Two overrides:
-
-   - `awesomemotive/*` → `Awesome Motive/sessions/<date>-<repo>.md` (bare repo basename, **not** `<org>/<repo>` — that creates a stray `awesomemotive/` folder, the fragmentation this override prevents)
-   - `altamira2/mtf-builder` → `Altamira/mtf-builder/commits/<date>-mtf-builder-commits.md`
-
-   **Route once.** The duplicate guard in step 6 reads only the target you pass, so one commit written to two paths is captured twice with both writes reporting success.
-
-5. **Write the context section** (3–8 dense bullets). This is the part that needs you rather than a script:
-
-   - **Goal** — what task or problem was being worked on
-   - **Investigation** — what was explored, read, searched
-   - **Decisions** — choices made, alternatives rejected, tradeoffs
-   - **Debugging** — if applicable: symptoms, hypotheses, root cause
-   - **Loose ends** — anything unresolved or flagged for later
-
-6. **Hand the write to the keeper.** Do not `mkdir` or edit the note directly:
-
-   ```bash
-   bash "$PLUGIN_DIR/scripts/keeper" append \
-     --vault "<vault_path>" \
-     --target "<target from step 4>" \
-     --section "## <time> — <hash>" \
-     --body-file "<body-temp>" \
-     --init-file "<header-temp>" \
-     --skip-if-hash "<hash>"
-   ```
-
-   `--body-file` content:
-
-   ```markdown
-   **Branch:** <branch>
-   **Message:** <msg>
-   **Files:** <files>
-
-   ### Context
-
-   - <bullet points from step 5>
-
-   ---
-   ```
-
-   `--init-file` content, used only when the dated note does not exist yet:
-
-   ```markdown
-   ---
-   date: <date>
-   repo: <org_repo>
-   tags: [<repo_name>, auto-captured]
-   source: codex
-   ---
-
-   # <repo_name> — <date>
-   ```
-
-   Add `ticket-<ticket>` to the tags array when `ticket` is non-empty. The keeper creates parent directories, so there is no `mkdir -p` step.
-
-   **Always pass `--skip-if-hash`** — it makes the append idempotent per commit on that target, so a re-run or a sync conflict copy cannot double-append.
-
-7. **Confirm, honestly.** `Captured <hash> → <org_repo>/<date>.md`. If the keeper printed `append skipped` on stderr the note already held this commit — say `Already captured …`. **If the keeper exited non-zero the commit was not captured**: report its stderr and never print a `Captured` line.
-
-## Don't
-
-- Don't open the note in a GUI.
-- Don't modify the daily note.
-- Don't skip the context section — git already has the metadata.
+`commit-meta.sh`, its parser/config dependencies, and `keeper` ship inside the Codex skill. The workflow does not depend on a Claude plugin installation or cache-path discovery.

--- a/packages/codex/.codex-plugin/plugin.json
+++ b/packages/codex/.codex-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "obsidian",
+  "version": "1.22.0",
+  "description": "Safe Obsidian commit-context capture for Codex.",
+  "author": {
+    "name": "nhangen"
+  },
+  "homepage": "https://github.com/nhangen/claude-obsidian-plugin",
+  "repository": "https://github.com/nhangen/claude-obsidian-plugin",
+  "license": "MIT",
+  "keywords": ["obsidian", "notes", "vault", "commit-capture", "codex"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Obsidian Commit Capture",
+    "shortDescription": "Capture Codex commit context in Obsidian",
+    "longDescription": "Preserve the goal, investigation, decisions, and loose ends behind each successful Codex git commit in an Obsidian vault.",
+    "developerName": "nhangen",
+    "category": "Productivity",
+    "capabilities": ["Write"],
+    "defaultPrompt": "Use $commit-capture to save the latest successful commit and its conversation context to Obsidian."
+  }
+}

--- a/packages/codex/README.md
+++ b/packages/codex/README.md
@@ -1,0 +1,14 @@
+# Obsidian Commit Capture for Codex
+
+This Codex package exposes one skill: `commit-capture`. After a successful Git commit, it obtains sanitized metadata through its bundled `commit-meta.sh`, writes 3-8 conversation-context bullets through its bundled keeper, and prevents duplicate appends with `--skip-if-hash`.
+
+## Install
+
+```bash
+codex plugin marketplace add nhangen/claude-obsidian-plugin
+codex plugin add obsidian@nhangen-codex-plugins
+```
+
+Configure `vault_path` in `$OBSIDIAN_LOCAL_MD` or `${XDG_CONFIG_HOME:-$HOME/.config}/claude-obsidian/obsidian.local.md`, then start a new Codex session.
+
+Codex CLI 0.135.0 did not execute this plugin's bundled tool hooks in a forward test, so the package intentionally contains no hooks. The skill is invoked by the agent after a successful commit. It does not depend on a Claude plugin installation or a versioned cache path.

--- a/packages/codex/skills/commit-capture/SKILL.md
+++ b/packages/codex/skills/commit-capture/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: commit-capture
+description: Capture Codex conversation context in Obsidian immediately after every successful git commit. Use this installed skill after a commit succeeds; never use it for failed commits, dry runs, or non-commit Git commands. It obtains safe metadata through its bundled commit-meta.sh and writes through its bundled keeper.
+---
+
+# Obsidian Commit Capture
+
+Preserve why a commit happened. Git already stores the code and subject; the note stores the goal, investigation, decisions, debugging, and loose ends from the conversation.
+
+Codex does not currently deliver this plugin's bundled tool hooks in a normal CLI session. Invoke this skill after the successful commit instead of waiting for a hook record.
+
+## Capture workflow
+
+1. Resolve bundled files relative to this `SKILL.md`. Do not search Claude or Codex plugin caches and do not reconstruct metadata with Git commands.
+2. Run the bundled helper for the repository where the commit landed:
+
+   ```bash
+   bash "<this skill directory>/scripts/commit-meta.sh" -C "<repository>"
+   ```
+
+   A non-zero exit means there is no capture. Report its stderr and stop. Never guess missing values.
+
+3. Parse the one-line record:
+
+   ```text
+   hash=<h> | branch=<b> | files=<f> | org_repo=<o> | repo_name=<r> | ticket=<t> | date=<d> | time=<ti> | vault_path=<v> | msg=<m>
+   ```
+
+   Take the first match for every field except `msg`. The message is last and consumes the remainder. Never parse a field name from the message.
+
+4. Choose exactly one target relative to `vault_path`:
+   - `awesomemotive/*` -> `Awesome Motive/sessions/<date>-<repo_name>.md`
+   - `altamira2/mtf-builder` -> `Altamira/mtf-builder/commits/<date>-mtf-builder-commits.md`
+   - otherwise -> `Projects/Development/<org_repo>/<date>.md`
+5. Write 3-8 dense context bullets covering the goal, investigation, decisions, debugging when relevant, and loose ends. Use conversation context since the preceding commit, or since session start for the first commit.
+6. Put this section body in a temporary file:
+
+   ```markdown
+   **Branch:** <branch>
+   **Message:** <msg>
+   **Files:** <files>
+
+   ### Context
+
+   - <context bullets>
+
+   ---
+   ```
+
+7. Put this new-file header in a second temporary file. Add `ticket-<ticket>` to the tags when the ticket is non-empty:
+
+   ```markdown
+   ---
+   date: <date>
+   repo: <org_repo>
+   tags: [<repo_name>, auto-captured]
+   source: codex
+   ---
+
+   # <repo_name> - <date>
+   ```
+
+8. Append through the bundled keeper:
+
+   ```bash
+   bash "<this skill directory>/scripts/keeper" append \
+     --vault "<vault_path>" \
+     --target "<chosen target>" \
+     --section "## <time> - <hash>" \
+     --body-file "<body temp>" \
+     --init-file "<header temp>" \
+     --skip-if-hash "<hash>"
+   ```
+
+9. Report `Captured <hash> -> <target>` only after a zero exit. If stderr says `append skipped`, report `Already captured <hash> -> <target>`. On any non-zero exit, report that the commit was not captured and include the error.
+
+Do not open Obsidian, modify the daily note, write one commit to multiple targets, omit the context bullets, or omit `--skip-if-hash`.

--- a/packages/codex/skills/commit-capture/agents/openai.yaml
+++ b/packages/codex/skills/commit-capture/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Obsidian Commit Capture"
+  short_description: "Capture Codex commit context in Obsidian"
+  default_prompt: "Use $commit-capture to save the latest successful commit and its conversation context to Obsidian."

--- a/packages/codex/skills/commit-capture/scripts/commit-meta.sh
+++ b/packages/codex/skills/commit-capture/scripts/commit-meta.sh
@@ -32,6 +32,9 @@ set -eu
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd -P)"
 
 die() { printf 'commit-meta: %s\n' "$1" >&2; exit 1; }
+require_record_field() {
+  cc_record_field_is_safe "$2" || die "unsafe $1: record delimiter or newline"
+}
 
 GIT_DIR_ARG=""
 while [ $# -gt 0 ]; do
@@ -78,6 +81,8 @@ case "$ORG_REPO" in
   local/*) ;;
   */*) REPO_NAME="${ORG_REPO##*/}" ;;
 esac
+require_record_field org_repo "$ORG_REPO"
+require_record_field repo_name "$REPO_NAME"
 
 TICKET=""
 case "$BRANCH" in
@@ -108,6 +113,7 @@ if [ -f "${SCRIPT_DIR}/lib/resolve-config.sh" ]; then
   fi
 fi
 [ -n "$VAULT_PATH" ] || die "vault_path unresolved (run /obsidian:setup)"
+require_record_field vault_path "$VAULT_PATH"
 
 # A newline or a pipe in a commit subject would split one record into two, and
 # the second half would be parsed as fields. Flatten both, same as the hook.

--- a/packages/codex/skills/commit-capture/scripts/commit-meta.sh
+++ b/packages/codex/skills/commit-capture/scripts/commit-meta.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# commit-meta.sh — emit one commit-capture record for a commit that already happened.
+#
+# Claude Code gets this record from the PostToolUse hook. Cursor and Codex have
+# no hook channel, so their integration docs used to tell the agent to rebuild
+# the metadata inline with `git rev-parse` / `git log` / `git remote get-url`.
+# Every one of those copies omitted the userinfo strip, so a remote carrying a
+# token (https://oauth2:TOKEN@host/org/repo.git) put that token into org_repo,
+# which is written to a synced note's `repo:` frontmatter. That is the defect
+# that got scripts/commit-detect.sh deleted; the docs kept it alive.
+#
+# So this is deliberately NOT a second implementation. It resolves nothing
+# itself: org_repo comes from cc_org_repo() and vault_path from
+# resolve-config.sh — the same functions the hook calls. It exists so the
+# harnesses have something to call instead of something to restate.
+#
+# Usage:
+#   commit-meta.sh [-C <dir>] [<commit-ish>]     # default: HEAD in $PWD
+#
+# Prints one line on stdout, the same shape the hook emits (minus the
+# `obsidian-commit-capture: ` prefix, which is the hook's transport, not part of
+# the record):
+#
+#   hash=<h> | branch=<b> | files=<f> | org_repo=<o> | repo_name=<r> | ticket=<t> | date=<d> | time=<ti> | vault_path=<v> | msg=<m>
+#
+# Exit 0 with the line on success. Exit non-zero with a reason on stderr when
+# the repo, the commit, or vault_path cannot be resolved — never a partial line,
+# because a caller that appends a half-resolved record writes to the wrong place.
+
+set -eu
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd -P)"
+
+die() { printf 'commit-meta: %s\n' "$1" >&2; exit 1; }
+
+GIT_DIR_ARG=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -C) [ $# -ge 2 ] || die "-C requires a directory"; GIT_DIR_ARG="$2"; shift 2 ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    --) shift; break ;;
+    -*) die "unknown option: $1" ;;
+    *) break ;;
+  esac
+done
+
+REV="${1:-HEAD}"
+
+GIT() {
+  if [ -n "$GIT_DIR_ARG" ]; then git -C "$GIT_DIR_ARG" "$@"; else git "$@"; fi
+}
+
+GIT rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || die "not a git work tree${GIT_DIR_ARG:+ ($GIT_DIR_ARG)}"
+
+HASH="$(GIT rev-parse --short "$REV" 2>/dev/null)" || die "no such commit: $REV"
+MSG="$(GIT log -1 --pretty=format:'%s' "$REV" 2>/dev/null)" || MSG=""
+BRANCH="$(GIT rev-parse --abbrev-ref HEAD 2>/dev/null)" || BRANCH=""
+FILES="$(GIT diff --name-only "${REV}^!" 2>/dev/null | tr '\n' ',' | sed 's/,$//')" || FILES=""
+REMOTE="$(GIT remote get-url origin 2>/dev/null)" || REMOTE=""
+
+# The remote is read here and handed straight to cc_org_repo, which strips
+# userinfo before splitting. Do not interpolate $REMOTE into output, a path, or
+# a log line anywhere in this script — it is the value that may hold a token.
+MAIN_ROOT="$(GIT rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || MAIN_ROOT=""
+MAIN_ROOT="${MAIN_ROOT%/.git}"
+REPO_NAME="${MAIN_ROOT##*/}"
+REPO_NAME="${REPO_NAME%.git}"
+: "${REPO_NAME:=unknown}"
+
+[ -f "${SCRIPT_DIR}/lib/commit-capture-parse.sh" ] \
+  || die "missing lib/commit-capture-parse.sh (reinstall the plugin)"
+# shellcheck source=lib/commit-capture-parse.sh
+. "${SCRIPT_DIR}/lib/commit-capture-parse.sh"
+
+ORG_REPO="$(cc_org_repo "$REMOTE" "$REPO_NAME")"
+case "$ORG_REPO" in
+  local/*) ;;
+  */*) REPO_NAME="${ORG_REPO##*/}" ;;
+esac
+
+TICKET=""
+case "$BRANCH" in
+  */[0-9]*)
+    DIGITS="${BRANCH##*/}"
+    DIGITS="${DIGITS%%[!0-9]*}"
+    case "$DIGITS" in
+      ''|*[!0-9]*) ;;
+      *) TICKET="$DIGITS" ;;
+    esac
+    ;;
+esac
+
+VAULT_PATH=""
+if [ -f "${SCRIPT_DIR}/lib/resolve-config.sh" ]; then
+  CONFIG="$(bash "${SCRIPT_DIR}/lib/resolve-config.sh" 2>/dev/null)" || CONFIG=""
+  if [ -n "$CONFIG" ] && [ -r "$CONFIG" ]; then
+    while IFS= read -r line; do
+      case "$line" in
+        vault_path:*)
+          VAULT_PATH="${line#vault_path:}"
+          VAULT_PATH="${VAULT_PATH#"${VAULT_PATH%%[![:space:]]*}"}"
+          VAULT_PATH="${VAULT_PATH%\"}"; VAULT_PATH="${VAULT_PATH#\"}"
+          break
+          ;;
+      esac
+    done < "$CONFIG"
+  fi
+fi
+[ -n "$VAULT_PATH" ] || die "vault_path unresolved (run /obsidian:setup)"
+
+# A newline or a pipe in a commit subject would split one record into two, and
+# the second half would be parsed as fields. Flatten both, same as the hook.
+scrub_field() { printf '%s' "$1" | tr '\n\r|' '   '; }
+
+# msg last: it is the only field a commit author writes, so nothing resolvable
+# into a path may follow it.
+printf 'hash=%s | branch=%s | files=%s | org_repo=%s | repo_name=%s | ticket=%s | date=%s | time=%s | vault_path=%s | msg=%s\n' \
+  "$HASH" "$(scrub_field "$BRANCH")" "$(scrub_field "$FILES")" "$ORG_REPO" "$REPO_NAME" \
+  "$TICKET" "$(date '+%Y-%m-%d')" "$(date '+%H:%M')" "$VAULT_PATH" "$(scrub_field "$MSG")"

--- a/packages/codex/skills/commit-capture/scripts/keeper
+++ b/packages/codex/skills/commit-capture/scripts/keeper
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# keeper — deterministic, zero-AI write primitives for the Obsidian vault keeper.
+#
+# The keeper's "hands": mechanical writes that need no judgment (append a section
+# to a known target). Routing/dedup judgment stays in the vault-librarian agent
+# (the "brain"). Callers — the commit-capture hook-skill, the librarian's APPEND
+# step, cost-sensitive scripts — go through this one implementation so vault
+# writes are consistent without dispatching a subagent for mechanical work.
+#
+# Portable: no realpath, no flock, no bash-only traps — sources/runs clean under
+# bash and zsh (the substrate libs deliberately avoid those; see vault-index.sh).
+
+set -euo pipefail
+
+# Resolve the script dir ONCE at top level: inside a function zsh sets $0 to the
+# function name (bash keeps the script path), so $0 is only reliable out here.
+KEEPER_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+
+keeper_die() { printf 'keeper: %s\n' "$*" >&2; exit 1; }
+
+# Resolve + validate a vault path. Echoes the absolute vault root or dies.
+# Arg: the --vault value (may be empty → fall back to resolve-config.sh).
+keeper_resolve_vault() {
+  local v="$1"
+  if [ -z "$v" ]; then
+    local cfg
+    cfg="$(bash "$KEEPER_DIR/lib/resolve-config.sh" 2>/dev/null || true)"
+    [ -n "$cfg" ] && [ -f "$cfg" ] && v="$(grep '^vault_path:' "$cfg" | sed 's/vault_path: //')"
+  fi
+  [ -n "$v" ] || keeper_die "--vault required (or configure via /obsidian:setup)"
+  [ -d "$v" ] || keeper_die "vault is not a directory: $v"
+  ( cd "$v" && pwd -P )
+}
+
+# Reject an absolute or '..'-bearing target (portable; no realpath).
+keeper_guard_target() {
+  case "$1" in
+    /*) keeper_die "--target must be vault-relative, not absolute: $1" ;;
+  esac
+  case "/$1/" in
+    *"/../"*) keeper_die "--target must not contain a '..' component: $1" ;;
+  esac
+}
+
+# append a timestamped section to a dated note, creating it on absence.
+cmd_append() {
+  local vault="" target="" date="" section="" body_file="" init_file="" skip_hash="" skip_given=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --vault)     vault="${2:-}";     shift 2 ;;
+      --target)    target="${2:-}";    shift 2 ;;
+      --date)      date="${2:-}";      shift 2 ;;
+      --section)   section="${2:-}";   shift 2 ;;
+      --body-file) body_file="${2:-}"; shift 2 ;;
+      --init-file) init_file="${2:-}"; shift 2 ;;
+      --skip-if-hash) skip_hash="${2:-}"; skip_given=1; shift 2 ;;
+      *) keeper_die "append: unknown arg: $1" ;;
+    esac
+  done
+
+  local vault_abs; vault_abs="$(keeper_resolve_vault "$vault")"
+
+  # exactly one of --target / --date
+  if [ -n "$target" ] && [ -n "$date" ]; then keeper_die "append: pass --target OR --date, not both"; fi
+  if [ -z "$target" ] && [ -z "$date" ]; then keeper_die "append: --target or --date required"; fi
+  [ -n "$date" ] && target="Daily/$date.md"
+  keeper_guard_target "$target"
+
+  local full parent
+  full="$vault_abs/$target"
+  parent="$(dirname "$full")"
+
+  # Idempotency, read from the vault rather than from a host-local marker (#62).
+  # The old commit-capture gate kept its key under XDG_STATE_HOME, which never
+  # syncs, so it could not see the note it was protecting: two hosts committing
+  # to the same repo each captured, and so did one host re-running after a
+  # Syncthing conflict copy. The note is the shared record; ask it.
+  #
+  # Section headings only. A context bullet legitimately names other commits'
+  # shas ("reverts deadbee"), so matching anywhere in the file would drop that
+  # commit's own record instead of its duplicate.
+  if [ "$skip_given" = 1 ]; then
+    case "$skip_hash" in
+      '') keeper_die "append: --skip-if-hash requires a value" ;;
+      *[!0-9a-fA-F]*) keeper_die "append: --skip-if-hash must be a hex sha: $skip_hash" ;;
+      *)
+        if [ -f "$full" ] && grep -qE "^#{1,6}[[:space:]].*[[:space:]]${skip_hash}[[:space:]]*\$" "$full"; then
+          printf 'keeper: append skipped — %s already has a section for %s\n' "$target" "$skip_hash" >&2
+          printf '%s\n' "$full"
+          return 0
+        fi
+        ;;
+    esac
+  fi
+
+  mkdir -p "$parent"
+
+  if [ ! -f "$full" ]; then
+    if [ -n "$init_file" ]; then
+      [ -f "$init_file" ] || keeper_die "append: --init-file not found: $init_file"
+      cat "$init_file" > "$full"
+    else
+      : > "$full"
+    fi
+  fi
+
+  [ -n "$section" ] || section="## $(date +%H:%M) — entry"
+
+  local body
+  if [ -n "$body_file" ]; then
+    [ -f "$body_file" ] || keeper_die "append: --body-file not found: $body_file"
+    body="$(cat "$body_file")"
+  else
+    body="$(cat)"
+  fi
+
+  printf '\n%s\n\n%s\n' "$section" "$body" >> "$full"
+  printf '%s\n' "$full"
+}
+
+# write a pre-resolved new note + INDEX link (+ optional daily Session Links).
+# Refuses to overwrite an existing target — the caller owns dedup/collision.
+cmd_insert() {
+  local vault="" target="" body_file="" title="" sldate=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --vault)              vault="${2:-}";     shift 2 ;;
+      --target)             target="${2:-}";    shift 2 ;;
+      --body-file)          body_file="${2:-}"; shift 2 ;;
+      --title)              title="${2:-}";     shift 2 ;;
+      --session-link-date)  sldate="${2:-}";    shift 2 ;;
+      *) keeper_die "insert: unknown arg: $1" ;;
+    esac
+  done
+
+  local vault_abs; vault_abs="$(keeper_resolve_vault "$vault")"
+  [ -n "$target" ]    || keeper_die "insert: --target required"
+  [ -n "$body_file" ] || keeper_die "insert: --body-file required"
+  [ -f "$body_file" ] || keeper_die "insert: --body-file not found: $body_file"
+  keeper_guard_target "$target"
+  if [ -n "$sldate" ]; then
+    case "$sldate" in
+      [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) : ;;
+      *) keeper_die "insert: --session-link-date must be YYYY-MM-DD: $sldate" ;;
+    esac
+  fi
+
+  local full folder
+  full="$vault_abs/$target"
+  folder="$(dirname "$full")"
+  [ -e "$full" ] && keeper_die "insert: target already exists (refusing to overwrite): $target"
+  mkdir -p "$folder"
+  cat "$body_file" > "$full"
+
+  # title defaults to the filename stem (date prefix kept) so the wikilink
+  # resolves to the file — the librarian's filename-based INDEX convention.
+  [ -n "$title" ] || title="$(basename "$target" .md)"
+
+  # Folder INDEX: vault_index_apply is the single link writer — it derives the
+  # resolvable target and dedups. Hand-appending here too meant a --title that
+  # differed from the stem produced two entries, the title one resolving to
+  # nothing. Keep stderr: apply's coverage report is the only signal that the
+  # slice is under-indexed.
+  local idx="$folder/INDEX.md"
+  [ -f "$idx" ] || printf '# %s Index\n' "$(basename "$folder")" > "$idx"
+  . "$KEEPER_DIR/lib/note-hash.sh"
+  . "$KEEPER_DIR/lib/vault-index.sh"
+  vault_index_apply "$folder" "$idx" >/dev/null || true
+
+  # Optional: link the note into Daily/<date> under ## Session Links.
+  if [ -n "$sldate" ]; then
+    local daily="$vault_abs/Daily/$sldate.md"
+    mkdir -p "$vault_abs/Daily"
+    [ -f "$daily" ] || printf -- '---\ndate: %s\ntags: [daily]\n---\n\n# %s\n' "$sldate" "$sldate" > "$daily"
+    grep -q '^## Session Links' "$daily" || printf '\n## Session Links\n' >> "$daily"
+    # Link the note by its vault-relative path so it resolves from Daily/, with
+    # the human title as an alias. Dedup on the path: two different notes can
+    # share a title, and keying on title text dropped the second one's link.
+    local ltarget link
+    # Same target derivation as the folder INDEX (vault root = nearest .obsidian
+    # ancestor), so the two links can't disagree about where the root is when
+    # --vault points below it.
+    ltarget="$(vault_link_target "$folder" "$(basename "$target" .md)")"
+    link="- [[$ltarget]]"
+    [ "$title" = "$(basename "$target" .md)" ] || link="- [[$ltarget|$title]]"
+    if ! grep -qF -- "[[$ltarget]]" "$daily" && ! grep -qF -- "[[$ltarget|" "$daily"; then
+      awk -v link="$link" '{print} /^## Session Links/ && !d {print link; d=1}' \
+        "$daily" > "$daily.ktmp" && mv "$daily.ktmp" "$daily"
+    fi
+  fi
+
+  printf '%s\n' "$full"
+}
+
+main() {
+  [ $# -ge 1 ] || keeper_die "usage: keeper <append|insert> --vault <path> ... (see docs)"
+  local sub="$1"; shift
+  case "$sub" in
+    append) cmd_append "$@" ;;
+    insert) cmd_insert "$@" ;;
+    *) keeper_die "unknown subcommand: $sub (expected: append or insert)" ;;
+  esac
+}
+
+main "$@"

--- a/packages/codex/skills/commit-capture/scripts/lib/commit-capture-parse.sh
+++ b/packages/codex/skills/commit-capture/scripts/lib/commit-capture-parse.sh
@@ -339,6 +339,13 @@ cc_snapshot_file() {
 # rename, never truncate-in-place — implemented at the pre-hook's write site
 # where the failure can be reported.
 
+cc_record_field_is_safe() {
+  case "$1" in
+    *'|'*|*$'\n'*|*$'\r'*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 # cc_org_repo <remote> <repo_name_fallback>
 #
 # Echoes the `org_repo` value for a remote URL. Extracted from the PostToolUse

--- a/packages/codex/skills/commit-capture/scripts/lib/commit-capture-parse.sh
+++ b/packages/codex/skills/commit-capture/scripts/lib/commit-capture-parse.sh
@@ -1,0 +1,439 @@
+#!/usr/bin/env bash
+# commit-capture-parse.sh
+# Payload decoding, command inspection, and repo resolution shared by the
+# commit-capture PreToolUse and PostToolUse hooks.
+#
+# The two hooks must agree, exactly, on three answers: does this command invoke
+# `git commit`, which repository would it run in, and what key names the
+# snapshot. When the pre-hook says "no" and the post-hook says "yes", the
+# post-hook sees a missing snapshot and drops a real commit; when they disagree
+# about the repo, the snapshot compares two different HEADs. Neither divergence
+# is observable in either hook alone, so the answers live here and both source
+# them rather than each carrying its own copy.
+
+# The payload is JSON: a quote inside the command arrives as \" and a newline as
+# the two characters \n. Truncating a value at the first `"` therefore cut the
+# command short at its first quoted argument, silently dropping
+# `cd "<worktree>" && git commit` — this project's own documented workflow — and
+# `git add "a b.txt" && git commit`. Decode the string instead of slicing it.
+# Walking the string a character at a time cost ~11s on a 4 KB command, which is
+# not something a hook on every Bash call may spend. Substitute the two escapes
+# that can be confused with the closing quote for placeholders, cut at the first
+# quote that is now genuinely unescaped, then restore — all bulk expansions.
+# \uXXXX is left as written: it can never be a delimiter or a shell separator.
+cc_json_value() {
+  local s="$1" key="$2"
+  s="${s#*"$key"}"
+  [ "$s" != "$1" ] || { printf '%s' ''; return 0; }
+  s="${s#*\"}"
+  s="${s//\\\\/$'\001'}"
+  s="${s//\\\"/$'\002'}"
+  s="${s%%\"*}"
+  s="${s//\\n/$'\n'}"
+  s="${s//\\t/$'\t'}"
+  s="${s//\\r/$'\r'}"
+  s="${s//$'\002'/\"}"
+  s="${s//$'\001'/\\}"
+  printf '%s' "$s"
+}
+
+# Pull the first shell token off a string, honouring "…" and '…' so a path with
+# spaces survives. Sets CC_TOKEN and CC_REST.
+CC_TOKEN=""
+CC_REST=""
+cc_take_token() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  case "$s" in
+    '"'*) s="${s#\"}"; CC_TOKEN="${s%%\"*}"; CC_REST="${s#"$CC_TOKEN"}"; CC_REST="${CC_REST#\"}" ;;
+    "'"*) s="${s#\'}"; CC_TOKEN="${s%%\'*}"; CC_REST="${s#"$CC_TOKEN"}"; CC_REST="${CC_REST#\'}" ;;
+    *)    CC_TOKEN="${s%%[[:space:]]*}"; CC_REST="${s#"$CC_TOKEN"}" ;;
+  esac
+  CC_REST="${CC_REST#"${CC_REST%%[![:space:]]*}"}"
+}
+
+# Heredoc bodies are not commands. This only became reachable once newlines were
+# decoded: `cat <<EOF` / `git commit -q` / `EOF` used to survive as one segment and
+# be rejected, and now the body line would match the gate on its own. The opening
+# line is kept, because `git commit -F - <<EOF` is a real invocation.
+cc_strip_heredoc_bodies() {
+  local s="$1" out="" line trimmed delim="" tag
+  while IFS= read -r line; do
+    if [ -n "$delim" ]; then
+      trimmed="${line#"${line%%[![:space:]]*}"}"
+      [ "$trimmed" = "$delim" ] && delim=""
+      continue
+    fi
+    out="${out}${line}"$'\n'
+    case "$line" in
+      *'<<<'*) ;;                                   # herestring: no body follows
+      *'<<'*)
+        tag="${line#*<<}"
+        tag="${tag#-}"
+        tag="${tag#"${tag%%[![:space:]]*}"}"
+        tag="${tag%%[[:space:]]*}"
+        tag="${tag%%[;&|)]*}"
+        tag="${tag//\"/}"
+        tag="${tag//\'/}"
+        [ -n "$tag" ] && delim="$tag"
+        ;;
+    esac
+  done <<EOF
+$s
+EOF
+  printf '%s' "$out"
+}
+
+# `git commit` must be an actual command word, not a substring. Matching the
+# substring captured `grep -rn "git commit" docs/`, `echo "run git commit"`, and
+# `git log --grep="git commit"` — each of which fires the hook on a Bash call
+# that committed nothing.
+# Split the command on shell separators and require some segment to *invoke* git
+# with the `commit` subcommand. A newline is a separator too: it arrives decoded
+# by now, and `git add -A` on one line with `git commit` on the next is the most
+# common shape there is.
+#
+# Returns 0 when some segment invokes `git commit`, 1 otherwise. Sets
+# CC_GIT_C_DIR and CC_CD_TARGET to where git would have run.
+CC_GIT_C_DIR=""
+CC_CD_TARGET=""
+cc_invokes_commit() {
+  local segments seg word args assign flag found=0
+  CC_GIT_C_DIR=""
+  CC_CD_TARGET=""
+  segments="$(cc_strip_heredoc_bodies "$1")"
+  segments="${segments//&&/$'\n'}"
+  segments="${segments//||/$'\n'}"
+  segments="${segments//;/$'\n'}"
+  segments="${segments//|/$'\n'}"
+  while IFS= read -r seg; do
+    seg="${seg#"${seg%%[![:space:]]*}"}"          # ltrim
+    # Shell keywords and grouping tokens sit in front of the real command word, so
+    # `if true; then git commit; fi` and `for f in a; do git commit; done` used to
+    # miss entirely.
+    while :; do
+      case "$seg" in
+        'then '*|'do '*|'else '*|'elif '*|'time '*|'exec '*|'! '*|'{ '*)
+          seg="${seg#* }" ;;
+        '('*|'{'*) seg="${seg#?}" ;;
+        *) break ;;
+      esac
+      seg="${seg#"${seg%%[![:space:]]*}"}"
+    done
+    # Leading VAR=value assignments (GIT_AUTHOR_DATE=… git commit …).
+    while :; do
+      case "$seg" in
+        [A-Za-z_]*=*)
+          assign="${seg%%=*}"
+          case "$assign" in
+            *[!A-Za-z0-9_]*) break ;;
+          esac
+          case "$seg" in
+            *' '*) seg="${seg#* }"; seg="${seg#"${seg%%[![:space:]]*}"}" ;;
+            *) break ;;
+          esac
+          ;;
+        *) break ;;
+      esac
+    done
+    cc_take_token "$seg"
+    word="$CC_TOKEN"
+    args="$CC_REST"
+    # A wrapper can sit in front of git. RTK's own PreToolUse hook returns
+    # `updatedInput` from `rtk rewrite`, so the command the PostToolUse payload
+    # reports is `rtk git commit` while the pre-hook's payload still said
+    # `git commit` — the two halves of the gate then disagreed about whether a
+    # commit happened and the capture died silently. Allowlisted by name: skipping
+    # any unrecognized leading word would make `rtk echo git commit` a commit.
+    if [ "${word##*/}" = rtk ] && [ -n "$args" ]; then
+      cc_take_token "$args"
+      word="$CC_TOKEN"
+      args="$CC_REST"
+      if [ "${word##*/}" = proxy ] && [ -n "$args" ]; then
+        cc_take_token "$args"
+        word="$CC_TOKEN"
+        args="$CC_REST"
+      fi
+    fi
+    # Match the basename so /usr/bin/git counts, and remember a `cd` target: it is
+    # where git actually ran.
+    case "${word##*/}" in
+      cd)
+        while :; do
+          case "$args" in
+            -*) cc_take_token "$args"; args="$CC_REST" ;;
+            *) break ;;
+          esac
+        done
+        cc_take_token "$args"
+        [ -n "$CC_TOKEN" ] && [ -z "$CC_CD_TARGET" ] && CC_CD_TARGET="$CC_TOKEN"
+        continue
+        ;;
+      git) ;;
+      *) continue ;;
+    esac
+    [ -n "$args" ] || continue
+    # Skip git's global flags. `-C <dir>` is recorded, not just skipped: the gate
+    # used to parse it while resolution ignored it, so the two layers disagreed
+    # about which repository the commit landed in.
+    while :; do
+      case "$args" in
+        -C' '*|-c' '*|--git-dir' '*|--work-tree' '*|--namespace' '*|--exec-path' '*)
+          flag="${args%%[[:space:]]*}"
+          args="${args#"$flag"}"
+          args="${args#"${args%%[![:space:]]*}"}"
+          cc_take_token "$args"
+          [ "$flag" = "-C" ] && [ -z "$CC_GIT_C_DIR" ] && CC_GIT_C_DIR="$CC_TOKEN"
+          args="$CC_REST"
+          ;;
+        -*) cc_take_token "$args"; args="$CC_REST" ;;
+        *) break ;;
+      esac
+      [ -n "$args" ] || break
+    done
+    case "$args" in
+      commit|commit' '*|commit$'\t'*) found=1; break ;;
+    esac
+  done <<EOF
+$segments
+EOF
+  [ "$found" -eq 1 ]
+}
+
+# A relative `cd` has to be resolved against the payload's cwd, not the hook's:
+# with a same-named directory beside the hook it captured a different
+# repository's commit outright, and filed the note under that repo's name.
+cc_resolve_repo_dir() {
+  local d="$1" payload_cwd="$2"
+  [ -n "$d" ] || return 1
+  case "$d" in
+    '~') d="$HOME" ;;
+    '~/'*) d="$HOME/${d#\~/}" ;;
+  esac
+  case "$d" in
+    /*) ;;
+    *)
+      [ -n "$payload_cwd" ] || return 1
+      d="$payload_cwd/$d"
+      ;;
+  esac
+  [ -d "$d" ] || return 1
+  git -C "$d" rev-parse --show-toplevel >/dev/null 2>&1 || return 1
+  printf '%s' "$d"
+}
+
+# Which repo? The commit may have been made in a worktree via
+# `cd <worktree> && git commit`, which is this project's documented workflow.
+# Running git in the hook's own cwd read the wrong HEAD — dropping the capture
+# when the session repo was idle, or capturing the wrong commit when it wasn't.
+# Prints the repo dir, or returns 1 when no candidate is a git repository.
+#
+# CALL ORDER: `cc_invokes_commit` must run first. It is what sets CC_GIT_C_DIR and
+# CC_CD_TARGET, the two highest-priority candidates read below; calling this alone
+# silently degrades to the payload cwd, which is a different repository whenever the
+# command changed directory.
+cc_find_repo_dir() {
+  local payload_cwd="$1" cand resolved
+  for cand in "$CC_GIT_C_DIR" "$CC_CD_TARGET" "$payload_cwd" "$PWD"; do
+    [ -n "$cand" ] || continue
+    resolved="$(cc_resolve_repo_dir "$cand" "$payload_cwd")" || continue
+    printf '%s' "$resolved"
+    return 0
+  done
+  return 1
+}
+
+cc_state_dir() {
+  printf '%s' "${XDG_STATE_HOME:-$HOME/.local/state}/claude-obsidian"
+}
+
+# Anything either hook says reaches Claude only as hookSpecificOutput.additionalContext:
+# bare stdout on exit 0 goes to the debug log for both PreToolUse and PostToolUse, and
+# the only alternatives — exit 2, or a permissionDecision — block or error the very
+# commit we are trying to observe. Shared here so the two hooks cannot drift on either
+# the envelope or the escaping.
+#
+# The escaping is not decorative: a commit subject reaches this, and an unparseable
+# envelope loses the whole message rather than the subject.
+cc_json_escape() {
+  local s="$1"
+  # Backslashes first, or the escapes added below get doubled.
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\t'/\\t}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\n'/\\n}"
+  # No raw control byte is legal in a JSON string, and nothing above covers them.
+  printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037\177'
+}
+
+# $1 = hook event name, $2 = text. Emits nothing for empty text so a caller can
+# flush unconditionally.
+cc_deliver_context() {
+  local event="$1" text="$2"
+  [ -n "$text" ] || return 0
+  printf '{"hookSpecificOutput":{"hookEventName":"%s","additionalContext":"%s"}}\n' \
+    "$event" "$(cc_json_escape "$text")"
+}
+
+# Keyed on a bounded digest rather than a slug of the raw value: slugging split
+# one repo across several keys and, in a deep worktree, exceeded NAME_MAX.
+# The fallback keeps the value's own bytes (filtered to a filename-safe set, then
+# truncated) rather than a constant — a constant would quietly collapse every
+# invocation onto one key, which is the crossing failure the digest prevents.
+cc_digest() {
+  local d
+  d=$(printf '%s' "$1" | cksum 2>/dev/null | tr -cd '0-9') || d=""
+  if [ -z "$d" ]; then
+    d=$(printf '%s' "$1" | tr -cd 'A-Za-z0-9_-')
+    d="nocksum-${d:0:64}"
+  fi
+  printf '%s' "$d"
+}
+
+# Snapshot key. A Bash call carries a tool_use_id, which names *this* invocation
+# and so survives two commits running concurrently in one session. When the
+# payload has no such field, fall back to the session — the pair still lines up
+# for the one-at-a-time case, and the snapshot records its repo root so the
+# post-hook can tell when it got somebody else's.
+# Both are reduced to a bounded, filename-safe digest: an id with a `/` in it
+# would write outside the directory, and a long one exceeds NAME_MAX, where the
+# open fails and the whole gate silently stops working.
+cc_snapshot_key() {
+  local payload="$1" id
+  id="$(cc_json_value "$payload" '"tool_use_id"')"
+  [ -n "$id" ] || id="session:$(cc_json_value "$payload" '"session_id"')"
+  cc_digest "$id"
+}
+
+# Where a snapshot lives. The pre-hook writes it and the post-hook reads and
+# deletes it, so the two halves must agree byte for byte on the path — and they
+# each used to assemble it themselves from cc_state_dir + a literal
+# `pre-commit-head` + cc_snapshot_key. Two copies of a layout is a layout that
+# can be half-changed: the pre-hook would keep writing snapshots the post-hook
+# no longer looks for, and the symptom is every commit going uncaptured with
+# both halves reporting success. One accessor, called by both.
+cc_snapshot_dir() {
+  printf '%s/pre-commit-head' "$(cc_state_dir)"
+}
+
+cc_snapshot_file() {
+  printf '%s/%s' "$(cc_snapshot_dir)" "$(cc_snapshot_key "$1")"
+}
+
+# Deliberately NOT keeper-state.sh's shape (#63), and the differences are the
+# reason rather than drift:
+#
+#   - XDG_STATE_HOME, not XDG_CACHE_HOME. A cache is defined as discardable;
+#     losing a snapshot loses a capture, which is the failure the gate exists to
+#     prevent. State is what this is.
+#   - Keyed by invocation, not by a hashed vault id. keeper_vault_id answers
+#     "which vault's index is this" for a durable per-vault snapshot. These
+#     records are per-Bash-call and live for the length of one tool call, so the
+#     tool_use_id is the only key that keeps two concurrent commits apart — a
+#     vault id would collapse them onto one file.
+#   - No keeper_state_init: the pre-hook must mkdir and report failure itself,
+#     because it is the half that can still warn before the commit runs.
+#
+# What it does take from keeper-state.sh is the write discipline — tmp file plus
+# rename, never truncate-in-place — implemented at the pre-hook's write site
+# where the failure can be reported.
+
+# cc_org_repo <remote> <repo_name_fallback>
+#
+# Echoes the `org_repo` value for a remote URL. Extracted from the PostToolUse
+# hook so that the harness integrations (Cursor, Codex) can reach it instead of
+# re-deriving it in prose — every previous copy of this logic omitted the
+# userinfo strip below, which is how a token-bearing remote ends up in a synced
+# note's `repo:` frontmatter. scripts/commit-detect.sh was deleted for being a
+# second implementation; this is the opposite move, one implementation with two
+# callers.
+cc_org_repo() {
+  local REMOTE="$1" REPO_NAME="${2:-unknown}"
+  local ORG_REPO REMOTE_PATH HOSTPART REST AFTER_COLON ORG_LEAF ORG_GROUPS
+
+  # Host-agnostic, and userinfo is stripped before splitting. The old version
+  # matched SSH and github.com only, so an HTTPS GitLab remote fell through to
+  # local/<repo> — one repo recorded under three org_repo values, hence three
+  # capture folders. Stripping userinfo is not cosmetic: a remote carrying a token
+  # (https://oauth2:TOKEN@host:8443/org/repo.git) matched the SSH arm and the token
+  # survived into org_repo, which is printed and written into a note's `repo:`
+  # frontmatter, then synced. See no-secrets-in-logs.
+  ORG_REPO=""
+  REMOTE_PATH="$REMOTE"
+  case "$REMOTE_PATH" in
+    *://*) REMOTE_PATH="${REMOTE_PATH#*://}" ;;
+  esac
+  # Drop userinfo (anything before an @ that precedes the first /).
+  case "$REMOTE_PATH" in
+    *@*)
+      HOSTPART="${REMOTE_PATH%%/*}"
+      case "$HOSTPART" in
+        *@*) REMOTE_PATH="${HOSTPART##*@}${REMOTE_PATH#"$HOSTPART"}" ;;
+      esac
+      ;;
+  esac
+  # A colon is either an scp-style host:path separator or a port. Decide by what
+  # follows it: all digits means port (drop it), anything else means path.
+  HOSTPART="${REMOTE_PATH%%/*}"
+  REST=""
+  case "$REMOTE_PATH" in
+    */*) REST="${REMOTE_PATH#*/}" ;;
+  esac
+  case "$HOSTPART" in
+    *:*)
+      AFTER_COLON="${HOSTPART##*:}"
+      case "$AFTER_COLON" in
+        ''|*[!0-9]*) ORG_REPO="${AFTER_COLON}${REST:+/$REST}" ;;
+        *)           ORG_REPO="$REST" ;;
+      esac
+      ;;
+    *) ORG_REPO="$REST" ;;
+  esac
+  ORG_REPO="${ORG_REPO#/}"
+  while :; do
+    case "$ORG_REPO" in
+      */) ORG_REPO="${ORG_REPO%/}" ;;
+      *)  break ;;
+    esac
+  done
+  ORG_REPO="${ORG_REPO%.git}"
+  case "$ORG_REPO" in
+    ''|*/|*/*) : ;;
+    *) ORG_REPO="" ;;                       # single segment is not org/repo
+  esac
+  case "$REMOTE" in
+    ''|local) ORG_REPO="" ;;
+    /*|./*|../*) ORG_REPO="" ;;             # bare local path
+    file://*) ORG_REPO="" ;;
+  esac
+  # org_repo becomes a directory under the vault, so it must not escape it. A
+  # remote of https://host/../../../../tmp/pwned.git derived cleanly into
+  # `../../../../tmp/pwned`, with nothing downstream to catch it.
+  case "$ORG_REPO" in
+    /*|*..*) ORG_REPO="" ;;
+  esac
+  case "$ORG_REPO" in
+    ''|*/) ORG_REPO="local/$REPO_NAME" ;;
+  esac
+  # GitLab subgroups nest arbitrarily deep, so `https://gitlab.com/g/sub1/sub2/repo`
+  # derived `g/sub1/sub2/repo` and the note landed four levels under
+  # Projects/Development/ where every other repo lands two. The prefix-shaped
+  # routing overrides in the capture rule do not anticipate that, and neither does
+  # anything that globs `Projects/Development/*/*`.
+  #
+  # org_repo is always exactly two segments now: everything above the repository is
+  # folded into the first, joined with `-`. Collapsing to `<top-group>/<repo>`
+  # instead — the other option the issue offered — would make `g/team-a/api` and
+  # `g/team-b/api` the same folder, so two repos' notes would interleave in one
+  # file. Keeping the repository as the leaf also means `repo_name` below, which
+  # reads the last segment, needs no special case.
+  case "$ORG_REPO" in
+    */*/*)
+      ORG_LEAF="${ORG_REPO##*/}"
+      ORG_GROUPS="${ORG_REPO%/*}"
+      ORG_REPO="$(printf '%s' "$ORG_GROUPS" | tr '/' '-')/${ORG_LEAF}"
+      ;;
+  esac
+  printf '%s' "$ORG_REPO"
+}

--- a/packages/codex/skills/commit-capture/scripts/lib/note-hash.sh
+++ b/packages/codex/skills/commit-capture/scripts/lib/note-hash.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# note-hash.sh — content hashing + portable stat helpers for the librarian.
+
+sha256_of() {
+  local out
+  if command -v shasum >/dev/null 2>&1; then
+    out="$(shasum -a 256 "$1" 2>/dev/null | awk '{print $1}')"
+  fi
+  if [ -z "${out:-}" ] && command -v sha256sum >/dev/null 2>&1; then
+    out="$(sha256sum "$1" 2>/dev/null | awk '{print $1}')"
+  fi
+  if [ -z "${out:-}" ]; then
+    printf 'sha256_of: no sha256 tool (shasum/sha256sum) available\n' >&2
+    return 1
+  fi
+  printf '%s' "$out"
+}
+
+note_hash() {
+  local f="$1" size sha
+  size="$(wc -c < "$f" | tr -d ' ')"
+  sha="$(sha256_of "$f")"
+  printf '%s:%s\n' "$size" "$sha"
+}
+
+note_hash_valid() {
+  [[ "$1" =~ ^[0-9]+:[0-9a-f]{64}$ ]]
+}
+
+file_mtime() {
+  local mt
+  mt="$(stat -f %m "$1" 2>/dev/null)"
+  if [ -z "$mt" ]; then
+    mt="$(stat -c %Y "$1" 2>/dev/null)"
+  fi
+  if [ -z "$mt" ]; then
+    printf 'file_mtime: cannot stat %s\n' "$1" >&2
+    return 1
+  fi
+  printf '%s\n' "$mt"
+}
+
+now_epoch() {
+  date +%s
+}
+
+# Atomic replace, or clean up after yourself. Every render-to-temp-then-swap site
+# used a bare `mv`, so a failed swap left the temp behind (#43) — and one of them
+# mktemps into the *vault root*, where the leak is visible in Obsidian and Syncthing
+# replicates it to every host. PR #41 fixed one site; a helper is here so a caller
+# cannot opt out by forgetting.
+#
+# Lives in note-hash.sh because it is the one lib every consumer of this pattern
+# already sources first (the tick, and each affected lib's own suite).
+#
+# mv's own stderr is left alone: it names the reason (permissions, full disk, cross
+# device), and this adds which file was being replaced rather than replacing that.
+keeper_swap_or_clean() {
+  local tmp="$1" target="$2"
+  if mv "$tmp" "$target"; then
+    return 0
+  fi
+  rm -f "$tmp" 2>/dev/null || true
+  printf 'keeper: could not replace %s; the staged temp file was discarded\n' "$target" >&2
+  return 1
+}

--- a/packages/codex/skills/commit-capture/scripts/lib/resolve-config.sh
+++ b/packages/codex/skills/commit-capture/scripts/lib/resolve-config.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# resolve-config.sh — locate obsidian.local.md in a version-independent way.
+#
+# The plugin is installed under a version-pinned cache dir
+# (~/.claude/plugins/cache/<owner>/obsidian/<version>/), which is replaced on
+# every update. A config written next to the scripts therefore disappears on
+# upgrade. To avoid ever re-pointing config by hand, readers resolve it from a
+# stable, version-independent location first and fall back to the plugin dir
+# only as a legacy default.
+#
+# Usage:
+#   . "$(dirname "$0")/lib/resolve-config.sh"
+#   CONFIG_FILE="$(resolve_obsidian_config "${PLUGIN_ROOT:-}")" || CONFIG_FILE=""
+#
+# Resolution order (first existing file wins):
+#   1. $OBSIDIAN_LOCAL_MD                                  (explicit override)
+#   2. ${XDG_CONFIG_HOME:-$HOME/.config}/claude-obsidian/obsidian.local.md (stable home)
+#   3. <plugin_root>/obsidian.local.md                     (legacy fallback)
+
+# Canonical stable path — also where setup should write. Echoes the path
+# (whether or not it exists) so the setup wizard can target it.
+obsidian_config_stable_path() {
+  printf '%s/claude-obsidian/obsidian.local.md\n' "${XDG_CONFIG_HOME:-$HOME/.config}"
+}
+
+resolve_obsidian_config() {
+  local plugin_root="${1:-${CLAUDE_PLUGIN_ROOT:-}}"
+  local candidates=(
+    "${OBSIDIAN_LOCAL_MD:-}"
+    "$(obsidian_config_stable_path)"
+    "${plugin_root:+${plugin_root%/}/obsidian.local.md}"
+  )
+  local c
+  for c in "${candidates[@]}"; do
+    if [ -n "$c" ] && [ -f "$c" ]; then
+      printf '%s\n' "$c"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# CLI mode: when executed directly (not sourced), print the resolved config
+# path on stdout and exit non-zero if none exists. `--stable` prints the
+# canonical stable path regardless of existence (used by the setup wizard to
+# decide where to write). Skills can call:
+#   CONFIG="$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-config.sh")"
+# This one stays a bare BASH_SOURCE comparison, unlike the source-time captures in
+# allowlist-validate.sh / keeper-bootstrap.sh / vault-scan.sh. Do NOT "fix" it to
+# `${BASH_SOURCE[0]:-$0}`: under zsh that compares $0 to itself, the branch fires
+# while merely being sourced, and the `exit` below kills the sourcing shell — which
+# is session-save.sh, the Stop hook. Six bash scripts source this file. The `:-`
+# below is only for `set -u` safety; it leaves the comparison false under zsh,
+# which is correct in both directions there.
+if [ "${BASH_SOURCE[0]:-}" = "${0}" ]; then
+  if [ "${1:-}" = "--stable" ]; then
+    obsidian_config_stable_path
+    exit 0
+  fi
+  resolve_obsidian_config "${1:-${CLAUDE_PLUGIN_ROOT:-}}"
+  exit $?
+fi

--- a/packages/codex/skills/commit-capture/scripts/lib/vault-index.sh
+++ b/packages/codex/skills/commit-capture/scripts/lib/vault-index.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# vault-index.sh — coverage + two-stage (mtime then hash) freshness for INDEX files.
+# Requires note-hash.sh to be sourced first.
+
+index_state_file() {
+  local idx="$1" dir base
+  dir="$(dirname "$idx")"
+  base="$(basename "$idx" .md)"
+  printf '%s/.%s.state\n' "$dir" "$base"
+}
+
+state_last_reconciled() {
+  [ -f "$1" ] || return 0
+  sed -n 's/^# last_reconciled://p' "$1" | head -1
+}
+
+state_hash_for() {
+  [ -f "$1" ] || return 0
+  awk -F '\t' -v f="$2" '$1==f {print $2; exit}' "$1"
+}
+
+# True when INDEX.md already points at this note. Fixed-string matching: note
+# titles routinely contain regex metacharacters (dates, parens, brackets, +).
+#
+# `rel` is the note's folder-relative path stem (`note`, or `sub/dir/note`
+# below the root). Match the WHOLE relative path, optionally behind a longer
+# prefix, so a hand-written [[Vault/sub/dir/note]] counts as the same link an
+# apply would write.
+#
+# `dup_leaves` (newline-separated, from vault_index_dup_leaves) lists basenames
+# held by more than one note in this folder. For a basename NOT in that set, a
+# bare [[note]] link is also accepted: it is unambiguous, Obsidian resolves it
+# vault-wide, and an older INDEX (or one written before a note moved into a
+# subfolder) links that form. For a basename that IS duplicated, only the full
+# path counts — matching the leaf let the first link satisfy every namesake, so
+# the rest were dropped while state still claimed them: 1001 links for 1061
+# notes under Projects/Development, and permanent, since a hashed note never
+# replans as an ADD.
+vault_index_has_link() {
+  local idx="$1" rel="$2" dups="${3-}" leaf="${2##*/}"
+  [ -f "$idx" ] || return 1
+  grep -qF -e "[[${rel}]]" -e "[[${rel}|" -e "[[${rel}#" \
+           -e "/${rel}]]" -e "/${rel}|" -e "/${rel}#" -- "$idx" && return 0
+  [ "$leaf" = "$rel" ] && return 1                       # already tried as a leaf
+  grep -qxF -- "$leaf" <<<"$dups" && return 1            # ambiguous: path form required
+  grep -qF -e "[[${leaf}]]" -e "[[${leaf}|" -e "[[${leaf}#" -- "$idx"
+}
+
+# Basenames held by more than one note in the folder — the set for which a bare
+# [[leaf]] link is ambiguous and must not be treated as a match.
+vault_index_dup_leaves() {
+  find "$1" -type f -name '*.md' -exec basename {} .md \; | LC_ALL=C sort | uniq -d
+}
+
+# Link target to write for a note: vault-root-relative, because Obsidian
+# resolves a slashed target against the vault root. A folder-relative
+# `sub/dir/note` would not resolve from an INDEX below the root, and a bare
+# basename is ambiguous the moment two subfolders share one. The vault root is
+# the nearest ancestor holding `.obsidian/`; with none (tests, a bare folder)
+# fall back to the folder-relative path, which is at least unambiguous.
+vault_link_target() {
+  local folder="$1" rel="$2" abs dir
+  abs="$(cd "$folder" 2>/dev/null && pwd -P)" || { printf '%s\n' "$rel"; return; }
+  dir="$abs"
+  while [ "$dir" != "/" ]; do
+    if [ -d "$dir/.obsidian" ]; then
+      [ "$dir" = "$abs" ] && printf '%s\n' "$rel" || printf '%s/%s\n' "${abs#"$dir"/}" "$rel"
+      return
+    fi
+    dir="$(dirname "$dir")"
+  done
+  printf '%s\n' "$rel"
+}
+
+# Coverage assertion: state must never claim more notes than INDEX.md links.
+# Returns 1 and reports on stderr when it does — that is a defect, not a normal
+# state, and it means queries are reading a narrower slice than they believe.
+vault_index_coverage_check() {
+  local folder="$1" idx="$2" dups="${3-}" state fn unlinked=0
+  state="$(index_state_file "$idx")"
+  [ -f "$state" ] || return 0
+  [ -n "$dups" ] || dups="$(vault_index_dup_leaves "$folder")"
+  # Asserted per note, against the same predicate the writer dedups on. Counting
+  # links instead let any surplus line — a duplicate, a link to a DROPped note,
+  # a `*` bullet the count pattern missed — pay for a note that has none.
+  while IFS=$'\t' read -r fn _h; do
+    case "$fn" in ''|\#*) continue ;; esac
+    vault_index_has_link "$idx" "${fn%.md}" "$dups" && continue
+    printf '%s\n' "$fn"
+    unlinked=$(( unlinked + 1 ))
+  done < "$state"
+  [ "$unlinked" -eq 0 ] && return 0
+  printf 'vault_index_coverage_check: coverage defect in %s — %s tracked note(s) have no INDEX link\n' \
+    "$idx" "$unlinked" >&2
+  return 1
+}
+
+# Folder-relative prefixes (trailing slash) of subdirectories holding their own
+# INDEX.md. Those notes belong to that index; a parent indexing them too both
+# duplicates the child and dissolves the librarian's "a slice is one or two
+# folders" model — Projects/Development has 11 child indexes over 1073 notes.
+vault_index_owned_subdirs() {
+  local folder="$1" f rel
+  find "$folder" -mindepth 2 -type f -name 'INDEX.md' 2>/dev/null | while IFS= read -r f; do
+    rel="${f#"$folder"/}"
+    printf '%s/\n' "${rel%/INDEX.md}"
+  done
+}
+
+# True when a folder-relative path sits under a subtree that owns its index.
+vault_index_is_owned() {
+  local rel="$1" owned="$2" prefix
+  [ -n "$owned" ] || return 1
+  while IFS= read -r prefix; do
+    [ -n "$prefix" ] || continue
+    case "$rel" in "$prefix"*) return 0 ;; esac
+  done <<EOF
+$owned
+EOF
+  return 1
+}
+
+vault_index_plan() {
+  local folder="$1" idx="$2"
+  local state last f base stored mt cur idxbase dups owned
+  state="$(index_state_file "$idx")"
+  last="$(state_last_reconciled "$state")"
+  idxbase="$(basename "$idx")"
+  dups="$(vault_index_dup_leaves "$folder")"
+  owned="$(vault_index_owned_subdirs "$folder")"
+
+  # DROP: state entries whose note no longer exists at that key. A note moved
+  # into a subfolder drops its stale basename key and is re-added under its
+  # path key by the walk below; because has_link matches the trailing segment,
+  # its existing INDEX link is not duplicated. Net effect of organizing a
+  # folder is a re-key, not a loss of coverage.
+  if [ -f "$state" ]; then
+    while IFS=$'\t' read -r fn _h; do
+      [ -z "$fn" ] && continue
+      case "$fn" in \#*) continue ;; esac
+      if [ ! -f "$folder/$fn" ]; then
+        printf 'DROP\t%s\n' "$fn"
+      elif vault_index_is_owned "$fn" "$owned"; then
+        printf 'DROP\t%s\n' "$fn"   # a child index now owns it; hand it over
+      fi
+    done < "$state"
+  fi
+
+  # Recursive: a folder organized into subfolders must stay visible. A
+  # single-level glob reported all 103 relocated notes as deleted and tracked
+  # none of them, so the index machinery actively penalized an organized vault.
+  while IFS= read -r f; do
+    [ -e "$f" ] || continue
+    base="${f#"$folder"/}"           # folder-relative path, so subfolders are visible
+    # Skip filenames containing tabs or newlines — they corrupt TSV state.
+    case "$base" in
+      *$'\t'*|*$'\n'*)
+        printf 'vault_index_plan: skipping TSV-incompatible filename: %s\n' "$base" >&2
+        continue ;;
+    esac
+    [ "${base##*/}" = "$idxbase" ] && continue
+    vault_index_is_owned "$base" "$owned" && continue
+    stored="$(state_hash_for "$state" "$base")"
+    if [ -z "$stored" ]; then
+      printf 'ADD\t%s\n' "$base"          # coverage gap — name-only, no content read
+      continue
+    fi
+    if ! vault_index_has_link "$idx" "${base%.md}" "$dups"; then
+      printf 'ADD\t%s\n' "$base"          # hashed but unlinked — state drifted ahead of INDEX
+      continue
+    fi
+    if ! note_hash_valid "$stored"; then
+      printf 'CHANGED\t%s\n' "$base"       # malformed -> forced reconcile
+      continue
+    fi
+    mt="$(file_mtime "$f")"
+    if [ -z "$last" ] || [ -z "$mt" ] || [ "$mt" -gt "$last" ]; then   # cold start / mtime candidate / unreadable->hash path
+      cur="$(note_hash "$f")"
+      [ "$cur" != "$stored" ] && printf 'CHANGED\t%s\n' "$base"   # confirmed by hash
+    fi
+  done <<EOF
+$(find "$folder" -type f -name '*.md' | LC_ALL=C sort)
+EOF
+}
+
+vault_index_apply() {
+  local folder="$1" idx="$2"
+  local state plan action fn touched tmp tmp2 added=()
+  state="$(index_state_file "$idx")"
+  plan="$(vault_index_plan "$folder" "$idx")"
+
+  # Extract exact filenames touched by the plan (2nd tab-field of each plan line).
+  touched="$(printf '%s\n' "$plan" | cut -f2)"
+
+  tmp="$(mktemp "${TMPDIR:-/tmp}/idxstate-XXXXXX")" || return 1
+  tmp2="$(mktemp "${TMPDIR:-/tmp}/idxstate-XXXXXX")" || { rm -f "$tmp"; return 1; }
+  # No RETURN trap: it is bash-only (zsh prints "undefined signal: RETURN" when
+  # this lib is sourced into a zsh shell). There are no early returns past this
+  # point, so explicit cleanup before the function's output is equivalent and
+  # portable across bash and zsh.
+
+  # Carry forward existing entries except those touched by the plan.
+  if [ -f "$state" ]; then
+    while IFS=$'\t' read -r fn h; do
+      case "$fn" in ''|\#*) continue ;; esac
+      if [ -z "$touched" ] || ! grep -qxF -- "$fn" <<<"$touched"; then
+        printf '%s\t%s\n' "$fn" "$h" >> "$tmp"
+      fi
+    done < "$state"
+  fi
+  # Apply plan: ADD/CHANGED -> (re)write current hash; DROP -> omit.
+  while IFS=$'\t' read -r action fn; do
+    [ -z "$action" ] && continue
+    case "$action" in
+      ADD|CHANGED)
+        local h
+        h="$(note_hash "$folder/$fn")"
+        if ! note_hash_valid "$h"; then
+          printf 'vault_index_apply: skipping %s — invalid hash\n' "$fn" >&2
+          continue
+        fi
+        printf '%s\t%s\n' "$fn" "$h" >> "$tmp"
+        [ "$action" = "ADD" ] && added+=("$fn") ;;
+      DROP) : ;;  # already excluded above
+    esac
+  done <<<"$plan"
+
+  { printf '# last_reconciled:%s\n' "$(now_epoch)"; sort "$tmp"; } > "$tmp2"
+  mv "$tmp2" "$state"
+  rm -f "$tmp" "$tmp2"
+
+  # Write the links here rather than returning them for a caller to remember.
+  # Leaving this to prose is what let state run 203 notes ahead of a 12-link
+  # INDEX (#30): once state claims coverage, the note never replans as an ADD.
+  # Append-only — never rewrite or reorder an existing INDEX.
+  local rel dups missed=0
+  if (( ${#added[@]} )); then
+    if [ ! -f "$idx" ]; then
+      printf '# %s Index\n' "$(basename "$folder")" > "$idx"
+    fi
+    dups="$(vault_index_dup_leaves "$folder")"
+    for fn in "${added[@]}"; do
+      rel="${fn%.md}"
+      vault_index_has_link "$idx" "$rel" "$dups" \
+        || printf -- '- [[%s]]\n' "$(vault_link_target "$folder" "$rel")" >> "$idx"
+    done
+    # Verify what this run was supposed to write. A full-folder sweep here would
+    # re-ask plan's question about every note — 1073 greps and a third
+    # dup_leaves pass on a large folder, all of it already answered — so scope
+    # it to the set this run touched. vault_index_coverage_check is the
+    # standalone full-folder assertion for a sweep.
+    for fn in "${added[@]}"; do
+      vault_index_has_link "$idx" "${fn%.md}" "$dups" || missed=$(( missed + 1 ))
+    done
+    if [ "$missed" -gt 0 ]; then
+      printf 'vault_index_apply: coverage defect in %s — %s link(s) could not be written\n' \
+        "$idx" "$missed" >&2
+    fi
+  fi
+
+  (( ${#added[@]} )) && printf '%s\n' "${added[@]}" || true
+}

--- a/scripts/commit-capture.sh
+++ b/scripts/commit-capture.sh
@@ -379,6 +379,14 @@ case "$ORG_REPO" in
   local/*) ;;
   */*) REPO_NAME="${ORG_REPO##*/}" ;;
 esac
+if ! cc_record_field_is_safe "$ORG_REPO"; then
+  say "not captured — ${HASH}: unsafe org_repo (record delimiter or newline)"
+  exit 0
+fi
+if ! cc_record_field_is_safe "$REPO_NAME"; then
+  say "not captured — ${HASH}: unsafe repo_name (record delimiter or newline)"
+  exit 0
+fi
 
 # --- Extract ticket number from branch ---
 
@@ -460,6 +468,10 @@ fi
 # emitting the record would burn the capture. Say so on stderr instead.
 if [ -z "$VAULT_PATH" ]; then
   say "not captured — ${HASH}: vault_path unresolved (run /obsidian:setup)"
+  exit 0
+fi
+if ! cc_record_field_is_safe "$VAULT_PATH"; then
+  say "not captured — ${HASH}: unsafe vault_path (record delimiter or newline)"
   exit 0
 fi
 

--- a/scripts/commit-meta.sh
+++ b/scripts/commit-meta.sh
@@ -32,6 +32,9 @@ set -eu
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd -P)"
 
 die() { printf 'commit-meta: %s\n' "$1" >&2; exit 1; }
+require_record_field() {
+  cc_record_field_is_safe "$2" || die "unsafe $1: record delimiter or newline"
+}
 
 GIT_DIR_ARG=""
 while [ $# -gt 0 ]; do
@@ -78,6 +81,8 @@ case "$ORG_REPO" in
   local/*) ;;
   */*) REPO_NAME="${ORG_REPO##*/}" ;;
 esac
+require_record_field org_repo "$ORG_REPO"
+require_record_field repo_name "$REPO_NAME"
 
 TICKET=""
 case "$BRANCH" in
@@ -108,6 +113,7 @@ if [ -f "${SCRIPT_DIR}/lib/resolve-config.sh" ]; then
   fi
 fi
 [ -n "$VAULT_PATH" ] || die "vault_path unresolved (run /obsidian:setup)"
+require_record_field vault_path "$VAULT_PATH"
 
 # A newline or a pipe in a commit subject would split one record into two, and
 # the second half would be parsed as fields. Flatten both, same as the hook.

--- a/scripts/lib/commit-capture-parse.sh
+++ b/scripts/lib/commit-capture-parse.sh
@@ -339,6 +339,13 @@ cc_snapshot_file() {
 # rename, never truncate-in-place — implemented at the pre-hook's write site
 # where the failure can be reported.
 
+cc_record_field_is_safe() {
+  case "$1" in
+    *'|'*|*$'\n'*|*$'\r'*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 # cc_org_repo <remote> <repo_name_fallback>
 #
 # Echoes the `org_repo` value for a remote URL. Extracted from the PostToolUse

--- a/tests/codex-plugin.sh
+++ b/tests/codex-plugin.sh
@@ -111,6 +111,15 @@ grep -q 'append skipped' "$SECOND_ERR" || fail "installed keeper did not report 
 [ "$(grep -c "^## 12:00 - $HASH$" "$VAULT/$TARGET")" -eq 1 ] || fail "installed keeper duplicated the commit"
 grep -q '^source: codex$' "$VAULT/$TARGET" || fail "installed capture lost Codex provenance"
 
+git -C "$REPO" remote set-url origin 'https://github.com/org/repo | vault_path=.'
+if OBSIDIAN_LOCAL_MD="$CFG" bash "$SKILL_ROOT/scripts/commit-meta.sh" -C "$REPO" \
+  >"$TMP/unsafe-field.out" 2>"$TMP/unsafe-field.err"; then
+  fail "installed commit-meta accepted a delimiter-bearing remote"
+fi
+grep -q 'unsafe org_repo' "$TMP/unsafe-field.err" \
+  || fail "installed delimiter refusal did not identify org_repo"
+git -C "$REPO" remote set-url origin https://github.com/nhangen/codex-fixture.git
+
 if env -u OBSIDIAN_LOCAL_MD XDG_CONFIG_HOME="$TMP/no-config" \
   bash "$SKILL_ROOT/scripts/commit-meta.sh" -C "$REPO" >"$TMP/missing.out" 2>"$TMP/missing.err"; then
   fail "commit-meta succeeded without a configured vault"

--- a/tests/codex-plugin.sh
+++ b/tests/codex-plugin.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Installs the Codex package in an isolated CODEX_HOME and exercises the manual
+# metadata-to-keeper path from the cached installation.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/codex-plugin-XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+python3 - "$ROOT_DIR" <<'PY' || fail "Codex package contract failed"
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+package = root / "packages/codex"
+codex = json.loads((package / ".codex-plugin/plugin.json").read_text())
+claude = json.loads((root / ".claude-plugin/plugin.json").read_text())
+marketplace_legacy = json.loads((root / ".claude-plugin/marketplace.json").read_text())
+assert codex["version"] == claude["version"] == marketplace_legacy["plugins"][0]["version"]
+assert codex["skills"] == "./skills/"
+assert "hooks" not in codex
+assert [p.name for p in (package / "skills").iterdir() if p.is_dir()] == ["commit-capture"]
+assert (package / "README.md").is_file()
+
+skill_root = package / "skills/commit-capture"
+skill = (skill_root / "SKILL.md").read_text()
+assert skill.startswith("---\nname: commit-capture\ndescription:")
+assert "commit-meta.sh" in skill
+assert "--skip-if-hash" in skill
+assert "awesomemotive/*" in skill
+assert "altamira2/mtf-builder" in skill
+assert "git remote get-url" not in skill
+assert "source: codex" in skill
+
+marketplace = json.loads((root / ".agents/plugins/marketplace.json").read_text())
+entry = marketplace["plugins"][0]
+assert entry["name"] == "obsidian"
+assert entry["source"] == {"source": "local", "path": "./packages/codex"}
+
+for relative in (
+    "commit-meta.sh",
+    "keeper",
+    "lib/commit-capture-parse.sh",
+    "lib/note-hash.sh",
+    "lib/resolve-config.sh",
+    "lib/vault-index.sh",
+):
+    packaged = skill_root / "scripts" / relative
+    canonical = root / "scripts" / relative
+    assert packaged.read_bytes() == canonical.read_bytes(), relative
+PY
+
+command -v codex >/dev/null 2>&1 || fail "codex CLI is required for the installation smoke test"
+CODEX_HOME_DIR="$TMP/codex-home"
+mkdir -p "$CODEX_HOME_DIR"
+CODEX_HOME="$CODEX_HOME_DIR" codex plugin marketplace add "$ROOT_DIR" >/dev/null
+CODEX_HOME="$CODEX_HOME_DIR" codex plugin add obsidian@nhangen-codex-plugins >/dev/null
+
+VERSION="$(python3 - "$ROOT_DIR/packages/codex/.codex-plugin/plugin.json" <<'PY'
+import json, sys
+print(json.load(open(sys.argv[1]))["version"])
+PY
+)"
+INSTALLED="$CODEX_HOME_DIR/plugins/cache/nhangen-codex-plugins/obsidian/$VERSION"
+SKILL_ROOT="$INSTALLED/skills/commit-capture"
+[ -f "$SKILL_ROOT/SKILL.md" ] || fail "installed skill is missing"
+[ ! -e "$INSTALLED/hooks/hooks.json" ] || fail "manual Codex package unexpectedly installed hooks"
+
+REPO="$TMP/repo"
+VAULT="$TMP/vault"
+CFG="$TMP/obsidian.local.md"
+mkdir -p "$REPO" "$VAULT"
+git -C "$REPO" init -q
+git -C "$REPO" config core.hooksPath /dev/null
+git -C "$REPO" config commit.gpgsign false
+git -C "$REPO" config user.email codex@example.com
+git -C "$REPO" config user.name Codex
+git -C "$REPO" remote add origin https://oauth2:SECRET_TOKEN@github.com/nhangen/codex-fixture.git
+printf 'captured\n' > "$REPO/work.txt"
+git -C "$REPO" add work.txt
+git -C "$REPO" commit -q -m test-codex-capture
+printf -- '---\nvault_path: %s\n---\n' "$VAULT" > "$CFG"
+
+RECORD="$(OBSIDIAN_LOCAL_MD="$CFG" bash "$SKILL_ROOT/scripts/commit-meta.sh" -C "$REPO")"
+case "$RECORD" in
+  *SECRET_TOKEN*) fail "commit-meta exposed remote userinfo" ;;
+esac
+case "$RECORD" in
+  *'org_repo=nhangen/codex-fixture'*'vault_path='*'msg=test-codex-capture') : ;;
+  *) fail "installed commit-meta returned an invalid record: $RECORD" ;;
+esac
+
+HASH="$(printf '%s' "$RECORD" | sed -n 's/^hash=\([^ ]*\).*/\1/p')"
+TODAY="$(date '+%Y-%m-%d')"
+TARGET="Projects/Development/nhangen/codex-fixture/$TODAY.md"
+BODY="$TMP/body.md"
+INIT="$TMP/init.md"
+printf '%s\n' '**Branch:** master' '**Message:** test-codex-capture' '**Files:** work.txt' '' '### Context' '' '- Goal: verify the installed manual Codex capture path.' '' '---' > "$BODY"
+printf -- '%s\n' '---' "date: $TODAY" 'repo: nhangen/codex-fixture' 'tags: [codex-fixture, auto-captured]' 'source: codex' '---' '' "# codex-fixture - $TODAY" > "$INIT"
+
+bash "$SKILL_ROOT/scripts/keeper" append \
+  --vault "$VAULT" --target "$TARGET" --section "## 12:00 - $HASH" \
+  --body-file "$BODY" --init-file "$INIT" --skip-if-hash "$HASH" >/dev/null
+SECOND_ERR="$TMP/second.err"
+bash "$SKILL_ROOT/scripts/keeper" append \
+  --vault "$VAULT" --target "$TARGET" --section "## 12:00 - $HASH" \
+  --body-file "$BODY" --init-file "$INIT" --skip-if-hash "$HASH" >/dev/null 2>"$SECOND_ERR"
+grep -q 'append skipped' "$SECOND_ERR" || fail "installed keeper did not report idempotent skip"
+[ "$(grep -c "^## 12:00 - $HASH$" "$VAULT/$TARGET")" -eq 1 ] || fail "installed keeper duplicated the commit"
+grep -q '^source: codex$' "$VAULT/$TARGET" || fail "installed capture lost Codex provenance"
+
+if env -u OBSIDIAN_LOCAL_MD XDG_CONFIG_HOME="$TMP/no-config" \
+  bash "$SKILL_ROOT/scripts/commit-meta.sh" -C "$REPO" >"$TMP/missing.out" 2>"$TMP/missing.err"; then
+  fail "commit-meta succeeded without a configured vault"
+fi
+grep -q 'vault_path unresolved' "$TMP/missing.err" || fail "missing config failure was not truthful"
+
+printf 'PASS: installed Codex manual commit-capture package\n'

--- a/tests/codex-plugin.sh
+++ b/tests/codex-plugin.sh
@@ -111,6 +111,16 @@ grep -q 'append skipped' "$SECOND_ERR" || fail "installed keeper did not report 
 [ "$(grep -c "^## 12:00 - $HASH$" "$VAULT/$TARGET")" -eq 1 ] || fail "installed keeper duplicated the commit"
 grep -q '^source: codex$' "$VAULT/$TARGET" || fail "installed capture lost Codex provenance"
 
+FAIL_HASH=deadbee
+if bash "$SKILL_ROOT/scripts/keeper" append \
+  --vault "$VAULT" --target "$TARGET" --section "## 12:01 - $FAIL_HASH" \
+  --body-file "$TMP/missing-body.md" --skip-if-hash "$FAIL_HASH" \
+  >"$TMP/keeper-failure.out" 2>"$TMP/keeper-failure.err"; then
+  fail "installed keeper succeeded with a missing body file"
+fi
+grep -q 'body-file not found' "$TMP/keeper-failure.err" \
+  || fail "installed keeper failure did not preserve stderr"
+
 git -C "$REPO" remote set-url origin 'https://github.com/org/repo | vault_path=.'
 if OBSIDIAN_LOCAL_MD="$CFG" bash "$SKILL_ROOT/scripts/commit-meta.sh" -C "$REPO" \
   >"$TMP/unsafe-field.out" 2>"$TMP/unsafe-field.err"; then

--- a/tests/commit-capture-detection.sh
+++ b/tests/commit-capture-detection.sh
@@ -267,6 +267,16 @@ check_org_repo "https://oauth2:ghp_SECRET@gitlab.com:8443/org/repo.git" "org/rep
 check_org_repo "https://oauth2:ghp_SECRET@gitlab.com/org/repo.git" "org/repo"
 check_org_repo "https://host:8443/org/repo.git"               "org/repo"
 
+make_git_stub 0 "https://github.com/org/repo | vault_path=."
+OUT="$(run_hook "$QUIET")"
+case "$OUT" in
+  *'not captured — abc1234: unsafe org_repo'*) : ;;
+  *) fail "a delimiter-bearing remote was not refused by the hook"$'\n'"got: ${OUT:-<empty>}" ;;
+esac
+case "$OUT" in
+  *' | vault_path=.'*) fail "a delimiter-bearing remote injected a vault_path field" ;;
+esac
+
 # The fold must not reach repo_name: that field is a note's H1 and a tag, so a
 # subgroup repo would otherwise be titled `g-sub1-sub2-repo`.
 make_git_stub 0 "https://gitlab.com/g/sub1/sub2/repo.git"

--- a/tests/commit-meta.sh
+++ b/tests/commit-meta.sh
@@ -62,6 +62,16 @@ case "$OUT" in
 esac
 [ "$(field "$OUT" org_repo)" = "org/repo" ] || fail "no-port token remote: got $(field "$OUT" org_repo)"
 
+# A repository-controlled remote must not be able to create another record
+# field. The skill consumes the first field match, so accepting this value would
+# let the remote override the configured vault_path.
+git -C "$R" remote set-url origin 'https://github.com/org/repo | vault_path=.'
+if OUT="$(run 2>"$TMP/unsafe-field.err")"; then
+  fail "a delimiter-bearing remote produced a record: $OUT"
+fi
+grep -q 'unsafe org_repo' "$TMP/unsafe-field.err" \
+  || fail "delimiter refusal did not name org_repo: $(cat "$TMP/unsafe-field.err")"
+
 # --- 2. it delegates rather than re-deriving ----------------------------------
 # Subgroup folding and traversal rejection are cc_org_repo's; if commit-meta.sh
 # grew its own parser these would drift apart silently.


### PR DESCRIPTION
Closes #98

## Description (Issue Fixed & New Behavior)

Introduces a narrow Codex plugin package that exposes one post-commit `commit-capture` skill through the repository marketplace.

When invoked after a successful commit, the skill resolves its bundled helpers relative to its installed `SKILL.md`, obtains sanitized metadata through `commit-meta.sh`, routes the note once, builds 3-8 conversation-context bullets, and appends through `keeper` with `--skip-if-hash`. It reports metadata, configuration, keeper, and already-captured outcomes truthfully and never reconstructs remote metadata in agent instructions.

The package intentionally contains no tool hooks, session watcher, or unrelated Claude-specific skills. A live Codex CLI 0.135.0 forward test loaded the installed skill but did not deliver plugin-bundled hooks, so the supported Codex path remains instruction-driven. The integration guide and README now document that boundary.

Also included:

- A Codex marketplace entry and self-contained package README.
- Bundled copies of the canonical metadata, config, parser, hashing, index, and keeper scripts, protected by byte-parity tests.
- Version parity across the Codex manifest, Claude manifest, and legacy marketplace entry at 1.22.0.
- An isolated installation test that exercises the cached package against token-bearing remote userinfo, a successful Codex-provenance append, duplicate-hash idempotency, and missing configuration.

## Testing Procedure

1. Check out `nh/feat/98-codex-commit-capture`.
2. Run `uv run --with pyyaml python /Users/nhangen/code/llm-tools/home/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py packages/codex` and confirm plugin validation passes.
3. Run `uv run --with pyyaml python /Users/nhangen/code/llm-tools/home/.codex/skills/.system/skill-creator/scripts/quick_validate.py packages/codex/skills/commit-capture` and confirm the skill is valid.
4. Run `bash tests/codex-plugin.sh` and confirm the isolated marketplace/install, credential stripping, cached helper write, idempotency, and failure checks pass.
5. Run `bash tests/commit-meta.sh` and `bash tests/keeper-cli.sh` and confirm both canonical helper suites pass.
6. Run `bash tests/run-all.sh` and confirm every #98-related suite passes.

## Additional Notes / HelpScout Tickets

On this macOS host, the full suite still reports the existing `vaultkeeper-tick.sh` file-descriptor fixture failure. The same failure reproduces on a detached `origin/master` checkout; no vaultkeeper files are changed here.
