### PR TITLE
save-conversation: add fast path for routine execution saves

### DIFF
--- a/skills/save-conversation/SKILL.md
+++ b/skills/save-conversation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: save-conversation
 description: Exports the current Claude conversation to the Obsidian vault. Triggers on phrases like "save this to Obsidian", "export to obsidian", "document this session", "save our conversation", "write this up", "put this in obsidian". Formats the conversation as structured markdown, determines the correct project folder from context, and saves with a timestamped filename. Optionally opens the note in the Obsidian GUI.
-version: 1.2.0
+version: 1.3.0
 ---
 
 # Save Conversation to Obsidian
@@ -16,6 +16,60 @@ directly. The keeper is the sole writer; this skill resolves the target and
 passes a `resolved: true` payload so the keeper writes it as-is without
 re-routing or re-deduping. The one exception is MOC-promotion *file moves*, which
 remain native (structural reorg is the vault-organizer's domain, not a note-write).
+
+## Fast Path (routine execution/project saves)
+
+Use this path when **all** guards hold; otherwise drop to the full procedure below.
+The fast path calls the same validators and the same keeper CLI as the full
+procedure — nothing is skipped, only the reading of the detail sections.
+
+**Guards (any hit → full procedure):**
+- A topic hint was provided
+- 2+ taxonomy domains matched the keyword scan (needs the Cross-Domain Tiebreaker)
+- Same-day dedup score ≥ threshold (needs append vs new prompt)
+- Session was research/planning/reflection, or tested an active research claim
+  (needs intent scoring care / substrate filing)
+- `#bookmark` markers or >30-min gaps present (Chapter Segmentation)
+- Target folder would be `Inbox/` (ambiguous — needs confirmation)
+
+**Steps:**
+```bash
+CONFIG="$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-config.sh")"
+# route: single keyword match against ## Project Taxonomy in $CONFIG → <target-folder>
+. "${CLAUDE_PLUGIN_ROOT}/scripts/lib/allowlist-validate.sh"
+allowlist_validate "<target-folder>" || exit 0   # refusal already printed
+. "${CLAUDE_PLUGIN_ROOT}/scripts/lib/dedup-scan.sh"
+dedup_same_day "<vault_path>/<target-folder>" "$(date +%Y-%m-%d)" "<slug>" "${dedup_jaccard_threshold:-0.4}"
+# no output above → proceed
+```
+
+Build the body from the frontmatter template in **Output Format** below
+(`session_intent: execution`, `capture_action: project_note`,
+`research_state_change: none`), then write through the keeper:
+
+```
+op: insert
+resolved: true
+target: <target-folder>/<YYYY-MM-DD-title>.md
+title: <YYYY-MM-DD-title>
+session_link_date: <today YYYY-MM-DD>
+---
+<frontmatter + body per Output Format>
+```
+
+Validate with `kspayload_validate <payload-file>` (source
+`${CLAUDE_PLUGIN_ROOT}/scripts/lib/keeper-save-payload.sh`), extract the body
+with `kspayload_body`, then run the keeper CLI directly:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/keeper" insert --vault "$VAULT" \
+  --target "<target-folder>/<YYYY-MM-DD-title>.md" \
+  --body-file "<body-temp>" --title "<YYYY-MM-DD-title>" \
+  --session-link-date "<today YYYY-MM-DD>"
+```
+
+Relay the committed path. Then run the MOC-Promotion Prompt check (step 14) —
+that post-save step applies on the fast path too.
 
 ## Config
 

--- a/skills/save-conversation/SKILL.md
+++ b/skills/save-conversation/SKILL.md
@@ -21,25 +21,35 @@ remain native (structural reorg is the vault-organizer's domain, not a note-writ
 
 Use this path when **all** guards hold; otherwise drop to the full procedure below.
 The fast path calls the same validators and the same keeper CLI as the full
-procedure — nothing is skipped, only the reading of the detail sections.
+procedure — nothing is skipped, only the reading of the detail sections. Three
+full-procedure steps are intentionally not restated here because they cannot
+change a routine execution save: the VAULT.md conventions read (step 1), the
+staleness banner, and `auto_open` handling (step 13) are covered by the notes
+below; when in doubt, use the full procedure.
 
 **Guards (any hit → full procedure):**
 - A topic hint was provided
 - 2+ taxonomy domains matched the keyword scan (needs the Cross-Domain Tiebreaker)
+- No taxonomy domain matched (route per Routing Logic / confirm Inbox with the user)
 - Same-day dedup score ≥ threshold (needs append vs new prompt)
 - Session was research/planning/reflection, or tested an active research claim
-  (needs intent scoring care / substrate filing)
+  (state your one-line evidence for this call; if borderline, use the full procedure)
 - `#bookmark` markers or >30-min gaps present (Chapter Segmentation)
 - Target folder would be `Inbox/` (ambiguous — needs confirmation)
 
 **Steps:**
 ```bash
 CONFIG="$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-config.sh")"
+# read vault_path and dedup_jaccard_threshold from $CONFIG:
+VAULT="$(grep '^vault_path:' "$CONFIG" | head -1 | sed 's/^vault_path:[[:space:]]*//')"
+THRESHOLD="$(awk '/^dedup_jaccard_threshold:/ {print $2}' "$CONFIG")"
+THRESHOLD="${THRESHOLD:-0.4}"
 # route: single keyword match against ## Project Taxonomy in $CONFIG → <target-folder>
 . "${CLAUDE_PLUGIN_ROOT}/scripts/lib/allowlist-validate.sh"
-allowlist_validate "<target-folder>" || exit 0   # refusal already printed
+allowlist_validate "<target-folder>" || exit 0   # refusal printed to stderr — surface it;
+                                                 # a refusal naming /obsidian:setup is a config fault
 . "${CLAUDE_PLUGIN_ROOT}/scripts/lib/dedup-scan.sh"
-dedup_same_day "<vault_path>/<target-folder>" "$(date +%Y-%m-%d)" "<slug>" "${dedup_jaccard_threshold:-0.4}"
+dedup_same_day "<vault_path>/<target-folder>" "$(date +%Y-%m-%d)" "<slug>" "$THRESHOLD"
 # no output above → proceed
 ```
 
@@ -57,9 +67,14 @@ session_link_date: <today YYYY-MM-DD>
 <frontmatter + body per Output Format>
 ```
 
+If `<target>` already exists (same-minute double save), append `-2`, `-3`, etc.
+and recheck until the path is free.
+
 Validate with `kspayload_validate <payload-file>` (source
-`${CLAUDE_PLUGIN_ROOT}/scripts/lib/keeper-save-payload.sh`), extract the body
-with `kspayload_body`, then run the keeper CLI directly:
+`${CLAUDE_PLUGIN_ROOT}/scripts/lib/keeper-save-payload.sh`) — on failure,
+surface the stderr line and stop; do **not** run the CLI. Extract the body
+with `kspayload_body`, run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/ask-staleness.sh"`
+and surface any ⚠ line it prints, then run the keeper CLI directly:
 
 ```bash
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/keeper" insert --vault "$VAULT" \
@@ -68,8 +83,9 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/keeper" insert --vault "$VAULT" \
   --session-link-date "<today YYYY-MM-DD>"
 ```
 
-Relay the committed path. Then run the MOC-Promotion Prompt check (step 14) —
-that post-save step applies on the fast path too.
+Relay the committed path, honor `auto_open` from `$CONFIG` (step 13), then run
+the MOC-Promotion Prompt check (step 14) — those post-save steps apply on the
+fast path too.
 
 ## Config
 

--- a/tests/sole-brain-save-conversation.sh
+++ b/tests/sole-brain-save-conversation.sh
@@ -13,4 +13,30 @@ need 'dedup_same_day'
 need 'tokenize_slug'
 # the inline Jaccard prose must be gone (now delegated to the lib)
 absent 'compute .A ∩ B'
+
+# Fast Path section: presence, guards, gate ordering, config sourcing
+need '## Fast Path'
+need 'A topic hint was provided'
+need 'Cross-Domain Tiebreaker'
+need '#bookmark'
+need 'Inbox/'
+need 'No taxonomy domain matched'
+need 'kspayload_validate <payload-file>'
+need 'ask-staleness.sh'
+# vault_path and the dedup threshold must be sourced from $CONFIG, not bare vars
+grep -q "vault_path.*CONFIG\|CONFIG.*vault_path" "$F" || fail "missing: vault_path from \$CONFIG"
+grep -qE 'dedup_jaccard_threshold:[[:space:]]*\$|dedup_jaccard_threshold.*"\$CONFIG"|\$\{dedup_jaccard_threshold:-0\.4\}' "$F" || true
+grep -q -- '--vault "$VAULT"' "$F" || fail "missing: keeper insert --vault"
+# fail-closed ordering inside the Fast Path: allowlist_validate must precede
+# both kspayload_validate and the keeper insert call
+FP="$(awk '/^## Fast Path/{f=1} f && /^## Config/{exit} f' "$F")"
+echo "$FP" | grep -q allowlist_validate || fail "fast path missing allowlist_validate"
+echo "$FP" | grep -q 'kspayload_validate' || fail "fast path missing kspayload_validate"
+echo "$FP" | grep -q 'scripts/keeper" insert' || fail "fast path missing keeper insert"
+[ "$(echo "$FP" | grep -n allowlist_validate | head -1 | cut -d: -f1)" -lt \
+  "$(echo "$FP" | grep -n 'scripts/keeper" insert' | head -1 | cut -d: -f1)" ] \
+  || fail "gate ordering: allowlist_validate must precede keeper insert"
+[ "$(echo "$FP" | grep -n 'kspayload_validate' | head -1 | cut -d: -f1)" -lt \
+  "$(echo "$FP" | grep -n 'scripts/keeper" insert' | head -1 | cut -d: -f1)" ] \
+  || fail "gate ordering: kspayload_validate must precede keeper insert"
 echo "PASS: sole-brain-save-conversation"

--- a/tests/sole-brain-save-conversation.sh
+++ b/tests/sole-brain-save-conversation.sh
@@ -23,10 +23,6 @@ need 'Inbox/'
 need 'No taxonomy domain matched'
 need 'kspayload_validate <payload-file>'
 need 'ask-staleness.sh'
-# vault_path and the dedup threshold must be sourced from $CONFIG, not bare vars
-grep -q "vault_path.*CONFIG\|CONFIG.*vault_path" "$F" || fail "missing: vault_path from \$CONFIG"
-grep -qE 'dedup_jaccard_threshold:[[:space:]]*\$|dedup_jaccard_threshold.*"\$CONFIG"|\$\{dedup_jaccard_threshold:-0\.4\}' "$F" || true
-grep -q -- '--vault "$VAULT"' "$F" || fail "missing: keeper insert --vault"
 # fail-closed ordering inside the Fast Path: allowlist_validate must precede
 # both kspayload_validate and the keeper insert call
 FP="$(awk '/^## Fast Path/{f=1} f && /^## Config/{exit} f' "$F")"
@@ -39,4 +35,13 @@ echo "$FP" | grep -q 'scripts/keeper" insert' || fail "fast path missing keeper 
 [ "$(echo "$FP" | grep -n 'kspayload_validate' | head -1 | cut -d: -f1)" -lt \
   "$(echo "$FP" | grep -n 'scripts/keeper" insert' | head -1 | cut -d: -f1)" ] \
   || fail "gate ordering: kspayload_validate must precede keeper insert"
+# config sourcing must be real assignments inside the fast-path block, not
+# comments or bare variable references: $VAULT and the dedup threshold both
+# have to derive from $CONFIG
+echo "$FP" | grep -qE '^VAULT=.*vault_path.*"\$CONFIG"' \
+  || fail "fast path must assign VAULT from \$CONFIG vault_path"
+echo "$FP" | grep -qE '^THRESHOLD=.*dedup_jaccard_threshold.*"\$CONFIG"' \
+  || fail "fast path must read dedup_jaccard_threshold from \$CONFIG"
+echo "$FP" | grep -q -- '--vault "\$VAULT"' \
+  || fail "keeper insert must consume the sourced \$VAULT"
 echo "PASS: sole-brain-save-conversation"


### PR DESCRIPTION
## Summary

Adds a guarded fast-path section to the top of `save-conversation/SKILL.md` so routine execution/project saves stop paying ~7k tokens reading contingency machinery (cross-domain tiebreakers, substrate filing, MOC promotion, chapter segmentation) that doesn't apply.

## What changes

- New ~55-line **Fast Path** section immediately after the skill intro
- Fail-closed guards: topic hint, 2+ taxonomy matches, dedup ≥ threshold, research/planning/reflection sessions, `#bookmark` markers, Inbox routing — any hit drops to the unchanged full procedure
- Fast path calls the same validators (`allowlist_validate`, `dedup_same_day`, `kspayload_validate`) and the same keeper CLI insert with `resolved: true` — no second writer, no skipped gate; it is a reading-order optimization only
- Inlines the payload format + keeper CLI invocation so `keeper-save/SKILL.md` need not be read on the insert path
- Version bump 1.2.0 → 1.3.0

## Testing

- `tests/run-all.sh` in a worktree: all suites pass except `commit-capture-head-gate.sh` and `vaultkeeper-tick.sh`, both confirmed failing on pristine `origin/master` (pre-existing, unrelated)
- Touched-area suites green: `sole-brain-save-conversation`, `keeper-save-payload`, `dedup-scan`, `resolve-config`, `moc-promote`

Environment: local test fixtures via `tests/run-all.sh`.