### PR TITLE
Clear the open issue list, easiest first (#94, #95, #100, #101, #103, #104)

### DIFF
--- a/agents/vault-librarian.md
+++ b/agents/vault-librarian.md
@@ -93,7 +93,7 @@ deduped.)
 
    If routing confidence is low, do **not** commit silently — append an
    `[ask:where should this go?]` entry to `$VAULT_PATH/Pending.md` and ask the user once.
-2. **Dedup:** call the shared scanner — `dedup_same_day "<vault>/<folder>" "$(date +%Y-%m-%d)" "<slug>"`. If it echoes a `path<TAB>score`, surface that note and ask whether to append rather than file a duplicate — never silently merge.
+2. **Dedup:** call the shared scanner — `dedup_same_day "<vault>/<folder>" "$(date +%Y-%m-%d)" "<slug>"`. Pass no threshold: the scanner reads the vault's `dedup_jaccard_threshold` (default `0.4`) itself. If it echoes a `path<TAB>score`, surface that note and ask whether to append rather than file a duplicate — never silently merge.
 3. Write the note using the matching template in `$VAULT_PATH/Templates/`. Its
    INDEX link is written by step 5 (`vault_index_apply`), not by hand. Link
    session notes to the daily note under `## Session Links`. A domain MOC that

--- a/docs/superpowers/specs/2026-06-29-keeper-cli-design.md
+++ b/docs/superpowers/specs/2026-06-29-keeper-cli-design.md
@@ -36,7 +36,10 @@ keeper append --vault <path> --date <YYYY-MM-DD> ...   # --date → Daily/<date>
 - **`--target`** note path relative to the vault, OR **`--date`** which resolves
   to `Daily/<date>.md`. Exactly one required.
 - **`--section`** the heading line (e.g. `## 14:30 — Topic`). Optional; default
-  `## <HH:MM> — entry`.
+  `## <HH:MM> — entry`. A value with no `#` prefix is promoted to `## <value>`:
+  a section written as a paragraph is absent from Obsidian's outline and from
+  the heading-shaped `--skip-if-hash` gate (#100). An explicit prefix (`###`)
+  is kept, so the caller picks the level.
 - **`--body-file`** file holding the section body (use a file, not an argv blob,
   so multi-line markdown survives). Stdin if omitted.
 - **`--init-file`** content written ONLY when the target does not yet exist (the

--- a/packages/codex/skills/commit-capture/scripts/keeper
+++ b/packages/codex/skills/commit-capture/scripts/keeper
@@ -207,7 +207,11 @@ cmd_insert() {
   local link_rc=0 stem
   vault_index_apply "$folder" "$idx" >/dev/null || link_rc=$?
   stem="$(basename "$target" .md)"
-  if ! vault_index_has_link "$idx" "$stem" "$(vault_index_dup_leaves "$folder")"; then
+  # No dup_leaves argument: $stem is a bare basename, so vault_index_has_link
+  # returns before it consults that set (the leaf IS the rel). Passing it meant
+  # a second full recursive sweep of the folder per insert, duplicating the one
+  # vault_index_apply just did.
+  if ! vault_index_has_link "$idx" "$stem"; then
     printf 'keeper: warning — %s is written but is not linked from %s%s\n' \
       "$target" "${idx#"$vault_abs"/}" \
       "$([ "$link_rc" -eq 0 ] || printf ' (INDEX step failed, rc=%s)' "$link_rc")" >&2

--- a/packages/codex/skills/commit-capture/scripts/keeper
+++ b/packages/codex/skills/commit-capture/scripts/keeper
@@ -220,9 +220,27 @@ cmd_insert() {
   # Optional: link the note into Daily/<date> under ## Session Links.
   if [ -n "$sldate" ]; then
     local daily="$vault_abs/Daily/$sldate.md"
-    mkdir -p "$vault_abs/Daily"
-    [ -f "$daily" ] || printf -- '---\ndate: %s\ntags: [daily]\n---\n\n# %s\n' "$sldate" "$sldate" > "$daily"
-    grep -q '^## Session Links' "$daily" || printf '\n## Session Links\n' >> "$daily"
+    # Every write below is guarded, not just the swap at the end. Bare under
+    # `set -e` these abort the whole insert AFTER the note has committed, with
+    # nothing on stderr — and a caller reads a non-zero exit as "not captured",
+    # so a capture that did happen is reported as lost and the retry then dies
+    # on "target already exists". The note is written; a daily link that cannot
+    # be made is a warning, not a failure.
+    local sl_warn="keeper: warning — $target is written but Daily/$sldate.md"
+    if ! mkdir -p "$vault_abs/Daily" 2>/dev/null; then
+      printf '%s could not be created; no session link\n' "$sl_warn" >&2
+      printf '%s\n' "$full"; return 0
+    fi
+    if [ ! -f "$daily" ] \
+       && ! printf -- '---\ndate: %s\ntags: [daily]\n---\n\n# %s\n' "$sldate" "$sldate" > "$daily" 2>/dev/null; then
+      printf '%s could not be created; no session link\n' "$sl_warn" >&2
+      printf '%s\n' "$full"; return 0
+    fi
+    if ! grep -q '^## Session Links' "$daily" \
+       && ! printf '\n## Session Links\n' >> "$daily" 2>/dev/null; then
+      printf '%s is unwritable; no session link\n' "$sl_warn" >&2
+      printf '%s\n' "$full"; return 0
+    fi
     # Link the note by its vault-relative path so it resolves from Daily/, with
     # the human title as an alias. Dedup on the path: two different notes can
     # share a title, and keying on title text dropped the second one's link.

--- a/packages/codex/skills/commit-capture/scripts/keeper
+++ b/packages/codex/skills/commit-capture/scripts/keeper
@@ -191,8 +191,14 @@ cmd_insert() {
   # differed from the stem produced two entries, the title one resolving to
   # nothing. Keep stderr: apply's coverage report is the only signal that the
   # slice is under-indexed.
-  local idx="$folder/INDEX.md"
-  [ -f "$idx" ] || printf '# %s Index\n' "$(basename "$folder")" > "$idx"
+  local idx="$folder/INDEX.md" iprep=1
+  # Guarded for the same reason as the Daily/ writes below: the note committed
+  # above, so aborting here under `set -e` reports "not captured" for a capture
+  # that happened. An INDEX.md that cannot be created (ENOSPC, or a directory
+  # sitting on the name) is a link failure, and a link failure is a warning.
+  if [ ! -f "$idx" ]; then
+    printf '# %s Index\n' "$(basename "$folder")" > "$idx" 2>/dev/null || iprep=0
+  fi
   . "$KEEPER_DIR/lib/note-hash.sh"
   . "$KEEPER_DIR/lib/vault-index.sh"
   # `|| true` alone made a failed link indistinguishable from a written one
@@ -205,13 +211,13 @@ cmd_insert() {
   # apply's stderr and still returns 0, so rc by itself would miss the common
   # shape (an unwritable INDEX.md).
   local link_rc=0 stem
-  vault_index_apply "$folder" "$idx" >/dev/null || link_rc=$?
+  [ "$iprep" = 1 ] && { vault_index_apply "$folder" "$idx" >/dev/null || link_rc=$?; }
   stem="$(basename "$target" .md)"
   # No dup_leaves argument: $stem is a bare basename, so vault_index_has_link
   # returns before it consults that set (the leaf IS the rel). Passing it meant
   # a second full recursive sweep of the folder per insert, duplicating the one
   # vault_index_apply just did.
-  if ! vault_index_has_link "$idx" "$stem"; then
+  if [ "$iprep" = 0 ] || ! vault_index_has_link "$idx" "$stem"; then
     printf 'keeper: warning — %s is written but is not linked from %s%s\n' \
       "$target" "${idx#"$vault_abs"/}" \
       "$([ "$link_rc" -eq 0 ] || printf ' (INDEX step failed, rc=%s)' "$link_rc")" >&2

--- a/packages/codex/skills/commit-capture/scripts/keeper
+++ b/packages/codex/skills/commit-capture/scripts/keeper
@@ -42,6 +42,23 @@ keeper_guard_target() {
   esac
 }
 
+# Does any section heading in $1 name the sha $2? Heading-only (a context bullet
+# legitimately names other commits' shas) and position-independent: writers put
+# the sha at the head of the line ("## <sha> — msg") as often as at the end, and
+# an end-anchored match never fired for them (#101).
+#
+# awk, not a grep pipeline: `grep -E '^#' | grep -q` lets -q's early exit SIGPIPE
+# the first grep, which `set -o pipefail` then reports as a failed match.
+# Boundaries are hex-class rather than \b — BSD grep/awk do not carry \b — and
+# the compare is case-folded because the validator accepts [0-9a-fA-F].
+keeper_heading_has_sha() {
+  awk -v sha="$2" '
+    BEGIN { sha = tolower(sha); pat = "(^|[^0-9a-f])" sha "([^0-9a-f]|$)" }
+    $1 ~ /^##?#?#?#?#?$/ && NF > 1 && tolower($0) ~ pat { found = 1; exit }
+    END { exit(found ? 0 : 1) }
+  ' "$1"
+}
+
 # append a timestamped section to a dated note, creating it on absence.
 cmd_append() {
   local vault="" target="" date="" section="" body_file="" init_file="" skip_hash="" skip_given=0
@@ -84,7 +101,7 @@ cmd_append() {
       '') keeper_die "append: --skip-if-hash requires a value" ;;
       *[!0-9a-fA-F]*) keeper_die "append: --skip-if-hash must be a hex sha: $skip_hash" ;;
       *)
-        if [ -f "$full" ] && grep -qE "^#{1,6}[[:space:]].*[[:space:]]${skip_hash}[[:space:]]*\$" "$full"; then
+        if [ -f "$full" ] && keeper_heading_has_sha "$full" "$skip_hash"; then
           printf 'keeper: append skipped — %s already has a section for %s\n' "$target" "$skip_hash" >&2
           printf '%s\n' "$full"
           return 0
@@ -104,7 +121,20 @@ cmd_append() {
     fi
   fi
 
+  # --section names a section, so it is written as a heading (#100). Callers
+  # that pass a bare title ("Some title") had it land as a paragraph: content
+  # intact, but absent from Obsidian's outline, and invisible to the
+  # heading-shaped --skip-if-hash gate above, which would then let the same
+  # commit be captured twice. A value that already carries its own `#` prefix
+  # is kept verbatim, so a caller can choose the level.
+  case "$section" in *[![:space:]]*) : ;; *) section="" ;; esac   # blanks == none
   [ -n "$section" ] || section="## $(date +%H:%M) — entry"
+  section="${section#"${section%%[![:space:]]*}"}"                # trim indent
+  case "$section" in
+    '#'[[:space:]]*|'##'[[:space:]]*|'###'[[:space:]]*|\
+    '####'[[:space:]]*|'#####'[[:space:]]*|'######'[[:space:]]*) : ;;
+    *) section="## $section" ;;
+  esac
 
   local body
   if [ -n "$body_file" ]; then
@@ -165,7 +195,23 @@ cmd_insert() {
   [ -f "$idx" ] || printf '# %s Index\n' "$(basename "$folder")" > "$idx"
   . "$KEEPER_DIR/lib/note-hash.sh"
   . "$KEEPER_DIR/lib/vault-index.sh"
-  vault_index_apply "$folder" "$idx" >/dev/null || true
+  # `|| true` alone made a failed link indistinguishable from a written one
+  # (#104): the note is committed before this runs, so insert still printed the
+  # path and exited 0 while nothing in the vault pointed at the note. Keep the
+  # exit status (the note IS written — failing here would tell the caller the
+  # opposite), but say on stderr what is missing.
+  #
+  # Check the link, not just apply's rc: a coverage defect is reported on
+  # apply's stderr and still returns 0, so rc by itself would miss the common
+  # shape (an unwritable INDEX.md).
+  local link_rc=0 stem
+  vault_index_apply "$folder" "$idx" >/dev/null || link_rc=$?
+  stem="$(basename "$target" .md)"
+  if ! vault_index_has_link "$idx" "$stem" "$(vault_index_dup_leaves "$folder")"; then
+    printf 'keeper: warning — %s is written but is not linked from %s%s\n' \
+      "$target" "${idx#"$vault_abs"/}" \
+      "$([ "$link_rc" -eq 0 ] || printf ' (INDEX step failed, rc=%s)' "$link_rc")" >&2
+  fi
 
   # Optional: link the note into Daily/<date> under ## Session Links.
   if [ -n "$sldate" ]; then

--- a/packages/codex/skills/commit-capture/scripts/keeper
+++ b/packages/codex/skills/commit-capture/scripts/keeper
@@ -234,8 +234,25 @@ cmd_insert() {
     link="- [[$ltarget]]"
     [ "$title" = "$(basename "$target" .md)" ] || link="- [[$ltarget|$title]]"
     if ! grep -qF -- "[[$ltarget]]" "$daily" && ! grep -qF -- "[[$ltarget|" "$daily"; then
-      awk -v link="$link" '{print} /^## Session Links/ && !d {print link; d=1}' \
-        "$daily" > "$daily.ktmp" && mv "$daily.ktmp" "$daily"
+      # Stage and swap through the shared helper, which cleans the temp file up
+      # when the replace fails. `> "$daily.ktmp" && mv` left a stray .ktmp in
+      # the user's Daily/ folder on an unwritable note, and since the note
+      # itself committed above, the obvious retry then died on
+      # "target already exists". Warn and keep exit 0, like the INDEX link.
+      local dtmp
+      if dtmp="$(mktemp "$vault_abs/Daily/.ktmp-XXXXXX")"; then
+        if awk -v link="$link" '{print} /^## Session Links/ && !d {print link; d=1}' \
+             "$daily" > "$dtmp" && keeper_swap_or_clean "$dtmp" "$daily"; then
+          :
+        else
+          rm -f "$dtmp" 2>/dev/null || true
+          printf 'keeper: warning — %s is written but could not be linked into Daily/%s.md\n' \
+            "$target" "$sldate" >&2
+        fi
+      else
+        printf 'keeper: warning — %s is written but Daily/ is unwritable; no session link\n' \
+          "$target" >&2
+      fi
     fi
   fi
 

--- a/packages/codex/skills/commit-capture/scripts/lib/note-hash.sh
+++ b/packages/codex/skills/commit-capture/scripts/lib/note-hash.sh
@@ -27,17 +27,23 @@ note_hash_valid() {
   [[ "$1" =~ ^[0-9]+:[0-9a-f]{64}$ ]]
 }
 
+# BSD stat spells mtime `-f %m`, GNU stat `-c %Y`. Probing by failure does not
+# separate them: GNU stat reads `-f` as "report the FILESYSTEM", so on Linux the
+# BSD probe SUCCEEDS and returns a block of filesystem stats. Every caller then
+# had a non-numeric mtime — vault_index_plan compared it with `-gt` and errored
+# per file, silently falling back to hashing every note it walked. So validate
+# the answer rather than trusting the exit status, and take whichever spelling
+# actually yields an epoch.
 file_mtime() {
   local mt
-  mt="$(stat -f %m "$1" 2>/dev/null)"
-  if [ -z "$mt" ]; then
-    mt="$(stat -c %Y "$1" 2>/dev/null)"
-  fi
-  if [ -z "$mt" ]; then
-    printf 'file_mtime: cannot stat %s\n' "$1" >&2
-    return 1
-  fi
-  printf '%s\n' "$mt"
+  for mt in "$(stat -f %m "$1" 2>/dev/null)" "$(stat -c %Y "$1" 2>/dev/null)"; do
+    case "$mt" in
+      ''|*[!0-9]*) continue ;;
+      *) printf '%s\n' "$mt"; return 0 ;;
+    esac
+  done
+  printf 'file_mtime: cannot stat %s\n' "$1" >&2
+  return 1
 }
 
 now_epoch() {

--- a/packages/codex/skills/commit-capture/scripts/lib/resolve-config.sh
+++ b/packages/codex/skills/commit-capture/scripts/lib/resolve-config.sh
@@ -50,14 +50,28 @@ obsidian_config_value() {
   cfg="$(resolve_obsidian_config "${2:-${CLAUDE_PLUGIN_ROOT:-}}")" || return 1
   # Bounded to the frontmatter block: the body of a config is prose that can
   # legitimately open a line with `vault_path:` inside an example, and the
-  # first such line would otherwise win. Surrounding quotes are stripped, so a
-  # YAML-quoted scalar ("0.2") reads as the number the writer meant.
+  # first such line would otherwise win.
+  #
+  # Three shapes of YAML noise are removed, because the hand-rolled readers
+  # this function replaces each removed a different subset and so disagreed
+  # about the same config: a trailing ` # comment`, surrounding quotes, and
+  # surrounding whitespace. The comment strip requires whitespace before the
+  # `#` — a bare one is part of the value, so a vault at /notes/#inbox keeps
+  # its name — and is skipped inside a quoted scalar, where `#` is literal.
   v="$(awk -v k="$key" '
     NR == 1 { fm = ($0 ~ /^---[[:space:]]*$/); if (fm) next }
     fm && $0 ~ /^---[[:space:]]*$/ { exit }
     index($0, k ":") == 1 {
-      sub(/^[^:]*:[[:space:]]*/, ""); sub(/[[:space:]]+$/, "")
-      if ($0 ~ /^".*"$/ || $0 ~ /^'"'"'.*'"'"'$/) { $0 = substr($0, 2, length($0) - 2) }
+      sub(/^[^:]*:[[:space:]]*/, "")
+      if ($0 ~ /^"[^"]*"/ || $0 ~ /^'"'"'[^'"'"']*'"'"'/) {
+        q = substr($0, 1, 1)
+        rest = substr($0, 2)
+        close_at = index(rest, q)
+        $0 = substr(rest, 1, close_at - 1)
+      } else {
+        sub(/[[:space:]]+#.*$/, "")
+        sub(/[[:space:]]+$/, "")
+      }
       print; exit
     }' "$cfg")"
   [ -n "$v" ] || return 1

--- a/packages/codex/skills/commit-capture/scripts/lib/resolve-config.sh
+++ b/packages/codex/skills/commit-capture/scripts/lib/resolve-config.sh
@@ -40,6 +40,22 @@ resolve_obsidian_config() {
   return 1
 }
 
+# Read a scalar `key: value` out of the resolved config's frontmatter. Echoes
+# the trimmed value; returns 1 when no config resolves or the key is absent, so
+# a caller can tell "unset" (use my default) from "set". Config keys documented
+# in a SKILL and written by setup were otherwise read by whichever call site
+# remembered to (#103) — dedup_jaccard_threshold reached none of its three.
+obsidian_config_value() {
+  local key="$1" cfg v
+  cfg="$(resolve_obsidian_config "${2:-${CLAUDE_PLUGIN_ROOT:-}}")" || return 1
+  v="$(awk -v k="$key" '
+    index($0, k ":") == 1 {
+      sub(/^[^:]*:[[:space:]]*/, ""); sub(/[[:space:]]+$/, ""); print; exit
+    }' "$cfg")"
+  [ -n "$v" ] || return 1
+  printf '%s\n' "$v"
+}
+
 # CLI mode: when executed directly (not sourced), print the resolved config
 # path on stdout and exit non-zero if none exists. `--stable` prints the
 # canonical stable path regardless of existence (used by the setup wizard to

--- a/packages/codex/skills/commit-capture/scripts/lib/resolve-config.sh
+++ b/packages/codex/skills/commit-capture/scripts/lib/resolve-config.sh
@@ -48,9 +48,17 @@ resolve_obsidian_config() {
 obsidian_config_value() {
   local key="$1" cfg v
   cfg="$(resolve_obsidian_config "${2:-${CLAUDE_PLUGIN_ROOT:-}}")" || return 1
+  # Bounded to the frontmatter block: the body of a config is prose that can
+  # legitimately open a line with `vault_path:` inside an example, and the
+  # first such line would otherwise win. Surrounding quotes are stripped, so a
+  # YAML-quoted scalar ("0.2") reads as the number the writer meant.
   v="$(awk -v k="$key" '
+    NR == 1 { fm = ($0 ~ /^---[[:space:]]*$/); if (fm) next }
+    fm && $0 ~ /^---[[:space:]]*$/ { exit }
     index($0, k ":") == 1 {
-      sub(/^[^:]*:[[:space:]]*/, ""); sub(/[[:space:]]+$/, ""); print; exit
+      sub(/^[^:]*:[[:space:]]*/, ""); sub(/[[:space:]]+$/, "")
+      if ($0 ~ /^".*"$/ || $0 ~ /^'"'"'.*'"'"'$/) { $0 = substr($0, 2, length($0) - 2) }
+      print; exit
     }' "$cfg")"
   [ -n "$v" ] || return 1
   printf '%s\n' "$v"

--- a/scripts/ask-staleness.sh
+++ b/scripts/ask-staleness.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${ROOT}/lib/note-hash.sh"
 . "${ROOT}/lib/keeper-state.sh"
+# Sourced so the banner can name the elected owner when it has to speak from
+# the vault's evidence rather than this host's (#95).
+. "${ROOT}/lib/keeper-lease.sh"
 . "${ROOT}/lib/resolve-config.sh"
 
 CONFIG="$(resolve_obsidian_config "${CLAUDE_PLUGIN_ROOT:-${ROOT%/scripts}}")" || exit 0
@@ -12,7 +15,10 @@ VAULT="$(grep '^vault_path:' "$CONFIG" | head -1 | sed 's/vault_path: *//')"
 [ -n "$VAULT" ] || exit 0
 INTERVAL="$(grep '^keeper_interval_secs:' "$CONFIG" | head -1 | sed 's/.*: *//')"
 INTERVAL="${INTERVAL:-900}"
+# `|| true`: the key is optional, and an unmatched grep is a failed pipeline
+# under this script's pipefail — which would abort the freshness check itself.
+PRIORITY="$(grep '^keeper_host_priority:' "$CONFIG" | head -1 | sed 's/.*: *//' | tr ' ' ',' || true)"
 # Do not let the check's own failure read as a clean bill of health: every
 # consumer keys off stdout alone ("if it prints a line, show it"), and this
 # script's set -e would otherwise exit 1 with nothing printed (#94).
-staleness_banner "$VAULT" "$INTERVAL" || printf '⚠ could not determine index freshness\n'
+staleness_banner "$VAULT" "$INTERVAL" "$PRIORITY" || printf '⚠ could not determine index freshness\n'

--- a/scripts/ask-staleness.sh
+++ b/scripts/ask-staleness.sh
@@ -11,13 +11,18 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${ROOT}/lib/resolve-config.sh"
 
 CONFIG="$(resolve_obsidian_config "${CLAUDE_PLUGIN_ROOT:-${ROOT%/scripts}}")" || exit 0
-VAULT="$(grep '^vault_path:' "$CONFIG" | head -1 | sed 's/vault_path: *//')"
+# Every one of these is an unmatched-grep away from a failed pipeline under this
+# script's pipefail, and an abort here prints nothing — which every consumer
+# reads as a healthy index (#94). keeper_interval_secs is the live case: the
+# setup wizard's config template does not write it, so on a default install the
+# freshness check aborted one line before the guard meant to protect it, and the
+# `[ -n "$VAULT" ]` test below was dead code.
+cfg_val() { grep "^$1:" "$CONFIG" | head -1 | sed "s/^$1:[[:space:]]*//" || true; }
+VAULT="$(cfg_val vault_path)"
 [ -n "$VAULT" ] || exit 0
-INTERVAL="$(grep '^keeper_interval_secs:' "$CONFIG" | head -1 | sed 's/.*: *//')"
+INTERVAL="$(cfg_val keeper_interval_secs)"
 INTERVAL="${INTERVAL:-900}"
-# `|| true`: the key is optional, and an unmatched grep is a failed pipeline
-# under this script's pipefail — which would abort the freshness check itself.
-PRIORITY="$(grep '^keeper_host_priority:' "$CONFIG" | head -1 | sed 's/.*: *//' | tr ' ' ',' || true)"
+PRIORITY="$(cfg_val keeper_host_priority | tr ' ' ',')"
 # Do not let the check's own failure read as a clean bill of health: every
 # consumer keys off stdout alone ("if it prints a line, show it"), and this
 # script's set -e would otherwise exit 1 with nothing printed (#94).

--- a/scripts/ask-staleness.sh
+++ b/scripts/ask-staleness.sh
@@ -11,18 +11,18 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${ROOT}/lib/resolve-config.sh"
 
 CONFIG="$(resolve_obsidian_config "${CLAUDE_PLUGIN_ROOT:-${ROOT%/scripts}}")" || exit 0
-# Every one of these is an unmatched-grep away from a failed pipeline under this
-# script's pipefail, and an abort here prints nothing — which every consumer
-# reads as a healthy index (#94). keeper_interval_secs is the live case: the
-# setup wizard's config template does not write it, so on a default install the
-# freshness check aborted one line before the guard meant to protect it, and the
-# `[ -n "$VAULT" ]` test below was dead code.
-cfg_val() { grep "^$1:" "$CONFIG" | head -1 | sed "s/^$1:[[:space:]]*//" || true; }
-VAULT="$(cfg_val vault_path)"
+# obsidian_config_value, not a local grep/sed: an abort here prints nothing,
+# which every consumer reads as a healthy index (#94) — and a hand-rolled read
+# keeps the quotes, so a config with `vault_path: "/vault"` sent a $VAULT that
+# matches no directory into keeper_vault_health, which then took its
+# "no host has ever claimed this vault, stay quiet" branch and hid a faulting
+# owner. Same shape one layer on for a quoted keeper_interval_secs.
+# `|| true`: an absent key returns 1, and each has a default below.
+VAULT="$(obsidian_config_value vault_path || true)"
 [ -n "$VAULT" ] || exit 0
-INTERVAL="$(cfg_val keeper_interval_secs)"
+INTERVAL="$(obsidian_config_value keeper_interval_secs || true)"
 INTERVAL="${INTERVAL:-900}"
-PRIORITY="$(cfg_val keeper_host_priority | tr ' ' ',')"
+PRIORITY="$(obsidian_config_value keeper_host_priority | tr ' ' ',' || true)"
 # Do not let the check's own failure read as a clean bill of health: every
 # consumer keys off stdout alone ("if it prints a line, show it"), and this
 # script's set -e would otherwise exit 1 with nothing printed (#94).

--- a/scripts/ask-staleness.sh
+++ b/scripts/ask-staleness.sh
@@ -12,4 +12,7 @@ VAULT="$(grep '^vault_path:' "$CONFIG" | head -1 | sed 's/vault_path: *//')"
 [ -n "$VAULT" ] || exit 0
 INTERVAL="$(grep '^keeper_interval_secs:' "$CONFIG" | head -1 | sed 's/.*: *//')"
 INTERVAL="${INTERVAL:-900}"
-staleness_banner "$VAULT" "$INTERVAL"
+# Do not let the check's own failure read as a clean bill of health: every
+# consumer keys off stdout alone ("if it prints a line, show it"), and this
+# script's set -e would otherwise exit 1 with nothing printed (#94).
+staleness_banner "$VAULT" "$INTERVAL" || printf '⚠ could not determine index freshness\n'

--- a/scripts/keeper
+++ b/scripts/keeper
@@ -207,7 +207,11 @@ cmd_insert() {
   local link_rc=0 stem
   vault_index_apply "$folder" "$idx" >/dev/null || link_rc=$?
   stem="$(basename "$target" .md)"
-  if ! vault_index_has_link "$idx" "$stem" "$(vault_index_dup_leaves "$folder")"; then
+  # No dup_leaves argument: $stem is a bare basename, so vault_index_has_link
+  # returns before it consults that set (the leaf IS the rel). Passing it meant
+  # a second full recursive sweep of the folder per insert, duplicating the one
+  # vault_index_apply just did.
+  if ! vault_index_has_link "$idx" "$stem"; then
     printf 'keeper: warning — %s is written but is not linked from %s%s\n' \
       "$target" "${idx#"$vault_abs"/}" \
       "$([ "$link_rc" -eq 0 ] || printf ' (INDEX step failed, rc=%s)' "$link_rc")" >&2

--- a/scripts/keeper
+++ b/scripts/keeper
@@ -220,9 +220,27 @@ cmd_insert() {
   # Optional: link the note into Daily/<date> under ## Session Links.
   if [ -n "$sldate" ]; then
     local daily="$vault_abs/Daily/$sldate.md"
-    mkdir -p "$vault_abs/Daily"
-    [ -f "$daily" ] || printf -- '---\ndate: %s\ntags: [daily]\n---\n\n# %s\n' "$sldate" "$sldate" > "$daily"
-    grep -q '^## Session Links' "$daily" || printf '\n## Session Links\n' >> "$daily"
+    # Every write below is guarded, not just the swap at the end. Bare under
+    # `set -e` these abort the whole insert AFTER the note has committed, with
+    # nothing on stderr — and a caller reads a non-zero exit as "not captured",
+    # so a capture that did happen is reported as lost and the retry then dies
+    # on "target already exists". The note is written; a daily link that cannot
+    # be made is a warning, not a failure.
+    local sl_warn="keeper: warning — $target is written but Daily/$sldate.md"
+    if ! mkdir -p "$vault_abs/Daily" 2>/dev/null; then
+      printf '%s could not be created; no session link\n' "$sl_warn" >&2
+      printf '%s\n' "$full"; return 0
+    fi
+    if [ ! -f "$daily" ] \
+       && ! printf -- '---\ndate: %s\ntags: [daily]\n---\n\n# %s\n' "$sldate" "$sldate" > "$daily" 2>/dev/null; then
+      printf '%s could not be created; no session link\n' "$sl_warn" >&2
+      printf '%s\n' "$full"; return 0
+    fi
+    if ! grep -q '^## Session Links' "$daily" \
+       && ! printf '\n## Session Links\n' >> "$daily" 2>/dev/null; then
+      printf '%s is unwritable; no session link\n' "$sl_warn" >&2
+      printf '%s\n' "$full"; return 0
+    fi
     # Link the note by its vault-relative path so it resolves from Daily/, with
     # the human title as an alias. Dedup on the path: two different notes can
     # share a title, and keying on title text dropped the second one's link.

--- a/scripts/keeper
+++ b/scripts/keeper
@@ -191,8 +191,14 @@ cmd_insert() {
   # differed from the stem produced two entries, the title one resolving to
   # nothing. Keep stderr: apply's coverage report is the only signal that the
   # slice is under-indexed.
-  local idx="$folder/INDEX.md"
-  [ -f "$idx" ] || printf '# %s Index\n' "$(basename "$folder")" > "$idx"
+  local idx="$folder/INDEX.md" iprep=1
+  # Guarded for the same reason as the Daily/ writes below: the note committed
+  # above, so aborting here under `set -e` reports "not captured" for a capture
+  # that happened. An INDEX.md that cannot be created (ENOSPC, or a directory
+  # sitting on the name) is a link failure, and a link failure is a warning.
+  if [ ! -f "$idx" ]; then
+    printf '# %s Index\n' "$(basename "$folder")" > "$idx" 2>/dev/null || iprep=0
+  fi
   . "$KEEPER_DIR/lib/note-hash.sh"
   . "$KEEPER_DIR/lib/vault-index.sh"
   # `|| true` alone made a failed link indistinguishable from a written one
@@ -205,13 +211,13 @@ cmd_insert() {
   # apply's stderr and still returns 0, so rc by itself would miss the common
   # shape (an unwritable INDEX.md).
   local link_rc=0 stem
-  vault_index_apply "$folder" "$idx" >/dev/null || link_rc=$?
+  [ "$iprep" = 1 ] && { vault_index_apply "$folder" "$idx" >/dev/null || link_rc=$?; }
   stem="$(basename "$target" .md)"
   # No dup_leaves argument: $stem is a bare basename, so vault_index_has_link
   # returns before it consults that set (the leaf IS the rel). Passing it meant
   # a second full recursive sweep of the folder per insert, duplicating the one
   # vault_index_apply just did.
-  if ! vault_index_has_link "$idx" "$stem"; then
+  if [ "$iprep" = 0 ] || ! vault_index_has_link "$idx" "$stem"; then
     printf 'keeper: warning — %s is written but is not linked from %s%s\n' \
       "$target" "${idx#"$vault_abs"/}" \
       "$([ "$link_rc" -eq 0 ] || printf ' (INDEX step failed, rc=%s)' "$link_rc")" >&2

--- a/scripts/keeper
+++ b/scripts/keeper
@@ -42,6 +42,23 @@ keeper_guard_target() {
   esac
 }
 
+# Does any section heading in $1 name the sha $2? Heading-only (a context bullet
+# legitimately names other commits' shas) and position-independent: writers put
+# the sha at the head of the line ("## <sha> — msg") as often as at the end, and
+# an end-anchored match never fired for them (#101).
+#
+# awk, not a grep pipeline: `grep -E '^#' | grep -q` lets -q's early exit SIGPIPE
+# the first grep, which `set -o pipefail` then reports as a failed match.
+# Boundaries are hex-class rather than \b — BSD grep/awk do not carry \b — and
+# the compare is case-folded because the validator accepts [0-9a-fA-F].
+keeper_heading_has_sha() {
+  awk -v sha="$2" '
+    BEGIN { sha = tolower(sha); pat = "(^|[^0-9a-f])" sha "([^0-9a-f]|$)" }
+    $1 ~ /^##?#?#?#?#?$/ && NF > 1 && tolower($0) ~ pat { found = 1; exit }
+    END { exit(found ? 0 : 1) }
+  ' "$1"
+}
+
 # append a timestamped section to a dated note, creating it on absence.
 cmd_append() {
   local vault="" target="" date="" section="" body_file="" init_file="" skip_hash="" skip_given=0
@@ -84,7 +101,7 @@ cmd_append() {
       '') keeper_die "append: --skip-if-hash requires a value" ;;
       *[!0-9a-fA-F]*) keeper_die "append: --skip-if-hash must be a hex sha: $skip_hash" ;;
       *)
-        if [ -f "$full" ] && grep -qE "^#{1,6}[[:space:]].*[[:space:]]${skip_hash}[[:space:]]*\$" "$full"; then
+        if [ -f "$full" ] && keeper_heading_has_sha "$full" "$skip_hash"; then
           printf 'keeper: append skipped — %s already has a section for %s\n' "$target" "$skip_hash" >&2
           printf '%s\n' "$full"
           return 0
@@ -165,7 +182,23 @@ cmd_insert() {
   [ -f "$idx" ] || printf '# %s Index\n' "$(basename "$folder")" > "$idx"
   . "$KEEPER_DIR/lib/note-hash.sh"
   . "$KEEPER_DIR/lib/vault-index.sh"
-  vault_index_apply "$folder" "$idx" >/dev/null || true
+  # `|| true` alone made a failed link indistinguishable from a written one
+  # (#104): the note is committed before this runs, so insert still printed the
+  # path and exited 0 while nothing in the vault pointed at the note. Keep the
+  # exit status (the note IS written — failing here would tell the caller the
+  # opposite), but say on stderr what is missing.
+  #
+  # Check the link, not just apply's rc: a coverage defect is reported on
+  # apply's stderr and still returns 0, so rc by itself would miss the common
+  # shape (an unwritable INDEX.md).
+  local link_rc=0 stem
+  vault_index_apply "$folder" "$idx" >/dev/null || link_rc=$?
+  stem="$(basename "$target" .md)"
+  if ! vault_index_has_link "$idx" "$stem" "$(vault_index_dup_leaves "$folder")"; then
+    printf 'keeper: warning — %s is written but is not linked from %s%s\n' \
+      "$target" "${idx#"$vault_abs"/}" \
+      "$([ "$link_rc" -eq 0 ] || printf ' (INDEX step failed, rc=%s)' "$link_rc")" >&2
+  fi
 
   # Optional: link the note into Daily/<date> under ## Session Links.
   if [ -n "$sldate" ]; then

--- a/scripts/keeper
+++ b/scripts/keeper
@@ -121,7 +121,20 @@ cmd_append() {
     fi
   fi
 
+  # --section names a section, so it is written as a heading (#100). Callers
+  # that pass a bare title ("Some title") had it land as a paragraph: content
+  # intact, but absent from Obsidian's outline, and invisible to the
+  # heading-shaped --skip-if-hash gate above, which would then let the same
+  # commit be captured twice. A value that already carries its own `#` prefix
+  # is kept verbatim, so a caller can choose the level.
+  case "$section" in *[![:space:]]*) : ;; *) section="" ;; esac   # blanks == none
   [ -n "$section" ] || section="## $(date +%H:%M) — entry"
+  section="${section#"${section%%[![:space:]]*}"}"                # trim indent
+  case "$section" in
+    '#'[[:space:]]*|'##'[[:space:]]*|'###'[[:space:]]*|\
+    '####'[[:space:]]*|'#####'[[:space:]]*|'######'[[:space:]]*) : ;;
+    *) section="## $section" ;;
+  esac
 
   local body
   if [ -n "$body_file" ]; then

--- a/scripts/keeper
+++ b/scripts/keeper
@@ -234,8 +234,25 @@ cmd_insert() {
     link="- [[$ltarget]]"
     [ "$title" = "$(basename "$target" .md)" ] || link="- [[$ltarget|$title]]"
     if ! grep -qF -- "[[$ltarget]]" "$daily" && ! grep -qF -- "[[$ltarget|" "$daily"; then
-      awk -v link="$link" '{print} /^## Session Links/ && !d {print link; d=1}' \
-        "$daily" > "$daily.ktmp" && mv "$daily.ktmp" "$daily"
+      # Stage and swap through the shared helper, which cleans the temp file up
+      # when the replace fails. `> "$daily.ktmp" && mv` left a stray .ktmp in
+      # the user's Daily/ folder on an unwritable note, and since the note
+      # itself committed above, the obvious retry then died on
+      # "target already exists". Warn and keep exit 0, like the INDEX link.
+      local dtmp
+      if dtmp="$(mktemp "$vault_abs/Daily/.ktmp-XXXXXX")"; then
+        if awk -v link="$link" '{print} /^## Session Links/ && !d {print link; d=1}' \
+             "$daily" > "$dtmp" && keeper_swap_or_clean "$dtmp" "$daily"; then
+          :
+        else
+          rm -f "$dtmp" 2>/dev/null || true
+          printf 'keeper: warning — %s is written but could not be linked into Daily/%s.md\n' \
+            "$target" "$sldate" >&2
+        fi
+      else
+        printf 'keeper: warning — %s is written but Daily/ is unwritable; no session link\n' \
+          "$target" >&2
+      fi
     fi
   fi
 

--- a/scripts/lib/dedup-scan.sh
+++ b/scripts/lib/dedup-scan.sh
@@ -48,6 +48,13 @@ DEDUP_JACCARD_DEFAULT="0.4"
 #
 # An unusable value warns and falls back rather than reaching awk, where a
 # non-numeric threshold compares as 0 and matches the first note it sees.
+# A float in 0.0-1.0. Anything else compares as 0 inside awk and matches the
+# first note in the folder, so every path into dedup_same_day is checked — the
+# argument one included, since a caller can pass a quoted or malformed value.
+dedup_threshold_valid() {
+  printf '%s' "$1" | grep -qE '^(0(\.[0-9]+)?|1(\.0+)?|\.[0-9]+)$'
+}
+
 dedup_threshold() {
   local v="${OBSIDIAN_DEDUP_JACCARD_THRESHOLD:-}"
   if [ -z "$v" ] && [ -n "$_ds_lib_dir" ] && [ -f "$_ds_lib_dir/resolve-config.sh" ]; then
@@ -55,9 +62,7 @@ dedup_threshold() {
     v="$(obsidian_config_value dedup_jaccard_threshold || true)"
   fi
   if [ -z "$v" ]; then printf '%s\n' "$DEDUP_JACCARD_DEFAULT"; return 0; fi
-  if printf '%s' "$v" | grep -qE '^(0(\.[0-9]+)?|1(\.0+)?|\.[0-9]+)$'; then
-    printf '%s\n' "$v"; return 0
-  fi
+  if dedup_threshold_valid "$v"; then printf '%s\n' "$v"; return 0; fi
   printf 'dedup_same_day: unusable dedup_jaccard_threshold %s — using %s\n' \
     "$v" "$DEDUP_JACCARD_DEFAULT" >&2
   printf '%s\n' "$DEDUP_JACCARD_DEFAULT"
@@ -65,6 +70,11 @@ dedup_threshold() {
 
 dedup_same_day() {
   local folder="$1" date="$2" slug="$3" threshold="${4:-}"
+  if [ -n "$threshold" ] && ! dedup_threshold_valid "$threshold"; then
+    printf 'dedup_same_day: unusable threshold argument %s — using %s\n' \
+      "$threshold" "$DEDUP_JACCARD_DEFAULT" >&2
+    threshold=""
+  fi
   [ -n "$threshold" ] || threshold="$(dedup_threshold)"
   local f base score best_path="" best_score="0.00"
   while IFS= read -r f; do

--- a/scripts/lib/dedup-scan.sh
+++ b/scripts/lib/dedup-scan.sh
@@ -32,8 +32,40 @@ jaccard() {
   awk -v i="$inter" -v u="$uni" 'BEGIN{printf "%.2f\n", i/u}'
 }
 
+# Captured at source time — see the note in keeper-bootstrap.sh: zsh has no
+# BASH_SOURCE, and its `$0` only names the sourced file while it is being read.
+_ds_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)" || _ds_lib_dir=""
+
+DEDUP_JACCARD_DEFAULT="0.4"
+
+# The threshold to score against when the caller passes none. Resolved here
+# rather than at each call site: the per-vault `dedup_jaccard_threshold`
+# override is documented and written by setup, but every caller fell back to
+# the library default instead of reading it, so a vault that set 0.0 silently
+# ran at 0.4 and re-enabled the twin-note failure the check exists to prevent
+# (#103). $OBSIDIAN_DEDUP_JACCARD_THRESHOLD overrides the config, for tests and
+# one-off runs.
+#
+# An unusable value warns and falls back rather than reaching awk, where a
+# non-numeric threshold compares as 0 and matches the first note it sees.
+dedup_threshold() {
+  local v="${OBSIDIAN_DEDUP_JACCARD_THRESHOLD:-}"
+  if [ -z "$v" ] && [ -n "$_ds_lib_dir" ] && [ -f "$_ds_lib_dir/resolve-config.sh" ]; then
+    . "$_ds_lib_dir/resolve-config.sh"
+    v="$(obsidian_config_value dedup_jaccard_threshold || true)"
+  fi
+  if [ -z "$v" ]; then printf '%s\n' "$DEDUP_JACCARD_DEFAULT"; return 0; fi
+  if printf '%s' "$v" | grep -qE '^(0(\.[0-9]+)?|1(\.0+)?|\.[0-9]+)$'; then
+    printf '%s\n' "$v"; return 0
+  fi
+  printf 'dedup_same_day: unusable dedup_jaccard_threshold %s — using %s\n' \
+    "$v" "$DEDUP_JACCARD_DEFAULT" >&2
+  printf '%s\n' "$DEDUP_JACCARD_DEFAULT"
+}
+
 dedup_same_day() {
-  local folder="$1" date="$2" slug="$3" threshold="${4:-0.4}"
+  local folder="$1" date="$2" slug="$3" threshold="${4:-}"
+  [ -n "$threshold" ] || threshold="$(dedup_threshold)"
   local f base score best_path="" best_score="0.00"
   while IFS= read -r f; do
     [ -n "$f" ] || continue

--- a/scripts/lib/dedup-scan.sh
+++ b/scripts/lib/dedup-scan.sh
@@ -71,7 +71,13 @@ dedup_same_day() {
     [ -n "$f" ] || continue
     base="$(basename "$f" .md)"; base="${base#"$date"-}"
     score="$(jaccard "$slug" "$base")"
-    if awk -v s="$score" -v t="$threshold" -v b="$best_score" 'BEGIN{exit !(s>=t && s>b)}'; then
+    # Two tests, not one. Folding "beats the best so far" into the threshold
+    # test seeded the comparison with best_score="0.00", so a 0.00 score could
+    # never win — and `dedup_jaccard_threshold: 0.0` is documented as "always
+    # prompt". That endpoint was unreachable, which went unnoticed while the
+    # override reached no call site at all (#103).
+    if awk -v s="$score" -v t="$threshold" 'BEGIN{exit !(s>=t)}' \
+       && { [ -z "$best_path" ] || awk -v s="$score" -v b="$best_score" 'BEGIN{exit !(s>b)}'; }; then
       best_score="$score"; best_path="$f"
     fi
   done < <(find "$folder" -maxdepth 1 -type f -name "$date-*.md" 2>/dev/null)

--- a/scripts/lib/dedup-scan.sh
+++ b/scripts/lib/dedup-scan.sh
@@ -57,9 +57,19 @@ dedup_threshold_valid() {
 
 dedup_threshold() {
   local v="${OBSIDIAN_DEDUP_JACCARD_THRESHOLD:-}"
-  if [ -z "$v" ] && [ -n "$_ds_lib_dir" ] && [ -f "$_ds_lib_dir/resolve-config.sh" ]; then
-    . "$_ds_lib_dir/resolve-config.sh"
-    v="$(obsidian_config_value dedup_jaccard_threshold || true)"
+  if [ -z "$v" ]; then
+    if [ -n "$_ds_lib_dir" ] && [ -f "$_ds_lib_dir/resolve-config.sh" ]; then
+      . "$_ds_lib_dir/resolve-config.sh"
+      v="$(obsidian_config_value dedup_jaccard_threshold || true)"
+    else
+      # Silence here reads as "the vault set no threshold", so a vault that set
+      # 0.0 would run at 0.4 — the twin-note failure #103 exists to prevent —
+      # with nothing said. The unusable-value path below is loud; this half has
+      # to be too. Same wording as allowlist-validate.sh and vault-scan.sh: the
+      # install is broken, not the config.
+      printf 'dedup_same_day: cannot read the vault threshold — %s/resolve-config.sh is missing; the install is broken, not the config. Using %s\n' \
+        "${_ds_lib_dir:-<lib dir unresolved>}" "$DEDUP_JACCARD_DEFAULT" >&2
+    fi
   fi
   if [ -z "$v" ]; then printf '%s\n' "$DEDUP_JACCARD_DEFAULT"; return 0; fi
   if dedup_threshold_valid "$v"; then printf '%s\n' "$v"; return 0; fi

--- a/scripts/lib/keeper-state.sh
+++ b/scripts/lib/keeper-state.sh
@@ -40,16 +40,49 @@ keeper_write_snapshot() {
   keeper_swap_or_clean "$tmp" "$f"
 }
 
+# Read an epoch state file. Three outcomes, because the banner has to tell them
+# apart (#94): rc 0 and the value (a usable timestamp), rc 1 (no file — nothing
+# has happened on this host yet), rc 2 (the file is there but holds no
+# timestamp). `>` truncates on open and can then fail on write, which is how
+# ENOSPC leaves a zero-byte file behind — so "exists but empty" is a real
+# degraded shape, and reading it as "absent" puts a faulting host back in the
+# silence #49 and #52 exist to remove. An unreadable file (permissions) lands
+# in the same branch: cat fails, the value is empty, and neither is a state to
+# stay quiet about.
+keeper_read_ts() {
+  local f="$1" v
+  [ -f "$f" ] || return 1
+  v="$(cat "$f" 2>/dev/null || true)"
+  case "$v" in
+    ''|*[!0-9]*) return 2 ;;
+  esac
+  printf '%s\n' "$v"
+}
+
+# Stage and swap rather than writing in place, so a failed or partial write
+# leaves the previous timestamp rather than a zero-byte file that reads as a
+# state nobody is in. The temp file is staged in the target's own directory:
+# a $TMPDIR on another filesystem makes the mv a copy, which is what this is
+# avoiding. Returns non-zero on failure — vaultkeeper-tick.sh checks it.
+keeper_write_ts() {
+  local f="$1" d tmp
+  d="$(dirname "$f")"
+  mkdir -p "$d" || return 1
+  tmp="$(mktemp "$d/.ts-XXXXXX")" || return 1
+  now_epoch > "$tmp" || { rm -f "$tmp"; return 1; }
+  keeper_swap_or_clean "$tmp" "$f"
+}
+
 keeper_last_scan_file() { printf '%s/last_scan\n' "$(keeper_cache_dir "$1")"; }
-keeper_record_scan()    { local f; f="$(keeper_last_scan_file "$1")"; mkdir -p "$(dirname "$f")"; now_epoch > "$f"; }
-keeper_last_scan()      { local f; f="$(keeper_last_scan_file "$1")"; [ -f "$f" ] && cat "$f" || true; }
+keeper_record_scan()    { keeper_write_ts "$(keeper_last_scan_file "$1")"; }
+keeper_last_scan()      { keeper_read_ts "$(keeper_last_scan_file "$1")" || true; }
 
 # An attempt is recorded by the elected owner immediately before it scans, whether or
 # not that scan goes on to complete. It is what makes an absent last_scan legible: with
 # no attempt nothing has tried from this host, and with one every try faulted.
 keeper_last_attempt_file() { printf '%s/last_attempt\n' "$(keeper_cache_dir "$1")"; }
-keeper_record_attempt()    { local f; f="$(keeper_last_attempt_file "$1")"; mkdir -p "$(dirname "$f")"; now_epoch > "$f"; }
-keeper_last_attempt()      { local f; f="$(keeper_last_attempt_file "$1")"; [ -f "$f" ] && cat "$f" || true; }
+keeper_record_attempt()    { keeper_write_ts "$(keeper_last_attempt_file "$1")"; }
+keeper_last_attempt()      { keeper_read_ts "$(keeper_last_attempt_file "$1")" || true; }
 
 # The banner is the only place a user hears that the index is not being
 # maintained. It used to return silently when last_scan was absent, which is
@@ -65,20 +98,23 @@ keeper_last_attempt()      { local f; f="$(keeper_last_attempt_file "$1")"; [ -f
 # is a worse failure than the silence #52 removed. The attempt file is written below
 # that gate, so only a host that actually scans has one.
 staleness_banner() {
-  local vault="$1" interval="$2" last attempted now
-  last="$(keeper_last_scan "$vault")"
-  if [ -z "$last" ]; then
-    attempted="$(keeper_last_attempt "$vault")"
-    [ -n "$attempted" ] || return 0
-    # Same reasoning as the last_scan guard below: this branch does arithmetic on the
-    # value, and a truncated write here would abort the caller in the one state this
-    # warning exists to describe.
-    case "$attempted" in
-      *[!0-9]*)
-        printf '⚠ index last_attempt is unreadable on this host\n'
-        return 0
-        ;;
-    esac
+  local vault="$1" interval="$2" last attempted now scan_rc=0 att_rc=0
+  last="$(keeper_read_ts "$(keeper_last_scan_file "$vault")")" || scan_rc=$?
+  if [ "$scan_rc" = "2" ]; then
+    # Empty or non-numeric. Neither "healthy" nor "never scanned" is a claim
+    # this host can make from that, and the arithmetic below would abort the
+    # caller (ask-staleness.sh runs under set -e), whose consumers all read a
+    # missing line as healthy.
+    printf '⚠ index last_scan is unreadable on this host\n'
+    return 0
+  fi
+  if [ "$scan_rc" != "0" ]; then
+    attempted="$(keeper_read_ts "$(keeper_last_attempt_file "$vault")")" || att_rc=$?
+    [ "$att_rc" = "1" ] && return 0
+    if [ "$att_rc" != "0" ]; then
+      printf '⚠ index last_attempt is unreadable on this host\n'
+      return 0
+    fi
     # No aging grace here, deliberately: one recorded attempt with no completed scan
     # already means the index has never been fully built on this host. The window
     # between the attempt and the scan is however long one tick's scanners take, so on
@@ -89,15 +125,6 @@ staleness_banner() {
       "$(( $(now_epoch) - attempted ))"
     return 0
   fi
-  # A last_scan that is not a number cannot be compared, and the arithmetic below
-  # would abort the caller (ask-staleness.sh runs under set -e). Unreadable is a
-  # state to report, not one to fall silent on.
-  case "$last" in
-    *[!0-9]*)
-      printf '⚠ index last_scan is unreadable on this host\n'
-      return 0
-      ;;
-  esac
   now="$(now_epoch)"
   if [ "$(( now - last ))" -gt "$(( interval * 2 ))" ]; then
     printf '⚠ index last maintained %ss ago\n' "$(( now - last ))"

--- a/scripts/lib/keeper-state.sh
+++ b/scripts/lib/keeper-state.sh
@@ -2,6 +2,10 @@
 # keeper-state.sh — non-synced per-host state: cache dir, prior-scan snapshot,
 # last_scan, last_attempt, cold-start detection, staleness banner. Requires
 # note-hash.sh.
+#
+# The banner also reads two *synced* artifacts, but only where the host has no
+# local state to speak from (#95): Librarian.md, whose shape surfacing.sh owns,
+# and the lease dir, whose shape keeper-lease.sh owns.
 
 keeper_vault_id() {
   local out
@@ -84,6 +88,62 @@ keeper_last_attempt_file() { printf '%s/last_attempt\n' "$(keeper_cache_dir "$1"
 keeper_record_attempt()    { keeper_write_ts "$(keeper_last_attempt_file "$1")"; }
 keeper_last_attempt()      { keeper_read_ts "$(keeper_last_attempt_file "$1")" || true; }
 
+# What the vault itself says about the index, for a host with no local state of
+# its own. Only the elected owner scans, and keeper state is per-host and never
+# synced, so a deferring host has neither a scan nor an attempt and used to stay
+# silent unconditionally — whether the owner was healthy or had faulted on every
+# tick since install (#95). On a two-host vault the deferring host is usually
+# where /obsidian:ask is being run.
+#
+# It reads the evidence that *is* synced rather than manufacturing local
+# evidence: hoisting keeper_record_attempt above the ownership gate makes a
+# deferring host claim an attempt it never makes and warn forever, on a vault
+# the owner is scanning perfectly well (tests/vaultkeeper-tick.sh pins that).
+#
+# Echoes a banner line, or nothing when the vault reports a healthy scan.
+keeper_vault_health() {
+  local vault="$1" interval="$2" prio="${3:-}" digest="$1/Librarian.md"
+  local lease="$1/.vaultkeeper" owner="" suffix="" status last now
+
+  # No claim by any host means the keeper has never run anywhere — not a fault,
+  # and not this host's to report. A vault nobody has ever pointed the keeper at
+  # must stay quiet.
+  [ -d "$lease" ] || return 0
+  set -- "$lease"/.keeper-claim-*
+  [ -e "$1" ] || return 0
+
+  # Name the owner when the caller has sourced keeper-lease.sh; election is that
+  # file's business, and a banner is not worth a second implementation of it.
+  if command -v keeper_elect >/dev/null 2>&1; then
+    owner="$(keeper_elect "$lease" "$prio" "$(( interval * 2 ))" || true)"
+  fi
+  [ -n "$owner" ] && suffix=" (owner: $owner)"
+
+  if [ ! -f "$digest" ]; then
+    printf '⚠ no host has produced an index digest for this vault%s\n' "$suffix"
+    return 0
+  fi
+  status="$(grep '^scan_status:' "$digest" 2>/dev/null | head -1 | sed 's/^scan_status:[[:space:]]*//')"
+  if [ "$status" = "INCOMPLETE" ]; then
+    printf '⚠ the last index scan faulted%s — see Librarian.md\n' "$suffix"
+    return 0
+  fi
+  # A digest nobody has refreshed is the shape a dead owner leaves: it never
+  # gets to stamp INCOMPLETE. Same 2x grace the local branch allows, which also
+  # covers replication lag.
+  last="$(grep '^last_scan:' "$digest" 2>/dev/null | head -1 | sed 's/^last_scan:[[:space:]]*//')"
+  case "$last" in
+    ''|*[!0-9]*)
+      printf '⚠ the index digest for this vault is unreadable%s\n' "$suffix"
+      return 0
+      ;;
+  esac
+  now="$(now_epoch)"
+  if [ "$(( now - last ))" -gt "$(( interval * 2 ))" ]; then
+    printf '⚠ index last maintained %ss ago%s\n' "$(( now - last ))" "$suffix"
+  fi
+}
+
 # The banner is the only place a user hears that the index is not being
 # maintained. It used to return silently when last_scan was absent, which is
 # indistinguishable from a fresh successful scan — and absent is exactly what a
@@ -97,8 +157,11 @@ keeper_last_attempt()      { keeper_read_ts "$(keeper_last_attempt_file "$1")" |
 # was scanning perfectly well. A banner that always fires carries no information, which
 # is a worse failure than the silence #52 removed. The attempt file is written below
 # that gate, so only a host that actually scans has one.
+# $3 (optional) is the configured host priority, forwarded to the election that
+# names the owner in a vault-sourced line; without it the banner still fires,
+# just unattributed.
 staleness_banner() {
-  local vault="$1" interval="$2" last attempted now scan_rc=0 att_rc=0
+  local vault="$1" interval="$2" prio="${3:-}" last attempted now scan_rc=0 att_rc=0
   last="$(keeper_read_ts "$(keeper_last_scan_file "$vault")")" || scan_rc=$?
   if [ "$scan_rc" = "2" ]; then
     # Empty or non-numeric. Neither "healthy" nor "never scanned" is a claim
@@ -110,7 +173,9 @@ staleness_banner() {
   fi
   if [ "$scan_rc" != "0" ]; then
     attempted="$(keeper_read_ts "$(keeper_last_attempt_file "$vault")")" || att_rc=$?
-    [ "$att_rc" = "1" ] && return 0
+    # Nothing has tried from this host. That is not evidence of health — on a
+    # deferring host it is the normal state — so ask the vault (#95).
+    [ "$att_rc" = "1" ] && { keeper_vault_health "$vault" "$interval" "$prio"; return 0; }
     if [ "$att_rc" != "0" ]; then
       printf '⚠ index last_attempt is unreadable on this host\n'
       return 0

--- a/scripts/lib/note-hash.sh
+++ b/scripts/lib/note-hash.sh
@@ -27,17 +27,23 @@ note_hash_valid() {
   [[ "$1" =~ ^[0-9]+:[0-9a-f]{64}$ ]]
 }
 
+# BSD stat spells mtime `-f %m`, GNU stat `-c %Y`. Probing by failure does not
+# separate them: GNU stat reads `-f` as "report the FILESYSTEM", so on Linux the
+# BSD probe SUCCEEDS and returns a block of filesystem stats. Every caller then
+# had a non-numeric mtime — vault_index_plan compared it with `-gt` and errored
+# per file, silently falling back to hashing every note it walked. So validate
+# the answer rather than trusting the exit status, and take whichever spelling
+# actually yields an epoch.
 file_mtime() {
   local mt
-  mt="$(stat -f %m "$1" 2>/dev/null)"
-  if [ -z "$mt" ]; then
-    mt="$(stat -c %Y "$1" 2>/dev/null)"
-  fi
-  if [ -z "$mt" ]; then
-    printf 'file_mtime: cannot stat %s\n' "$1" >&2
-    return 1
-  fi
-  printf '%s\n' "$mt"
+  for mt in "$(stat -f %m "$1" 2>/dev/null)" "$(stat -c %Y "$1" 2>/dev/null)"; do
+    case "$mt" in
+      ''|*[!0-9]*) continue ;;
+      *) printf '%s\n' "$mt"; return 0 ;;
+    esac
+  done
+  printf 'file_mtime: cannot stat %s\n' "$1" >&2
+  return 1
 }
 
 now_epoch() {

--- a/scripts/lib/resolve-config.sh
+++ b/scripts/lib/resolve-config.sh
@@ -50,14 +50,28 @@ obsidian_config_value() {
   cfg="$(resolve_obsidian_config "${2:-${CLAUDE_PLUGIN_ROOT:-}}")" || return 1
   # Bounded to the frontmatter block: the body of a config is prose that can
   # legitimately open a line with `vault_path:` inside an example, and the
-  # first such line would otherwise win. Surrounding quotes are stripped, so a
-  # YAML-quoted scalar ("0.2") reads as the number the writer meant.
+  # first such line would otherwise win.
+  #
+  # Three shapes of YAML noise are removed, because the hand-rolled readers
+  # this function replaces each removed a different subset and so disagreed
+  # about the same config: a trailing ` # comment`, surrounding quotes, and
+  # surrounding whitespace. The comment strip requires whitespace before the
+  # `#` — a bare one is part of the value, so a vault at /notes/#inbox keeps
+  # its name — and is skipped inside a quoted scalar, where `#` is literal.
   v="$(awk -v k="$key" '
     NR == 1 { fm = ($0 ~ /^---[[:space:]]*$/); if (fm) next }
     fm && $0 ~ /^---[[:space:]]*$/ { exit }
     index($0, k ":") == 1 {
-      sub(/^[^:]*:[[:space:]]*/, ""); sub(/[[:space:]]+$/, "")
-      if ($0 ~ /^".*"$/ || $0 ~ /^'"'"'.*'"'"'$/) { $0 = substr($0, 2, length($0) - 2) }
+      sub(/^[^:]*:[[:space:]]*/, "")
+      if ($0 ~ /^"[^"]*"/ || $0 ~ /^'"'"'[^'"'"']*'"'"'/) {
+        q = substr($0, 1, 1)
+        rest = substr($0, 2)
+        close_at = index(rest, q)
+        $0 = substr(rest, 1, close_at - 1)
+      } else {
+        sub(/[[:space:]]+#.*$/, "")
+        sub(/[[:space:]]+$/, "")
+      }
       print; exit
     }' "$cfg")"
   [ -n "$v" ] || return 1

--- a/scripts/lib/resolve-config.sh
+++ b/scripts/lib/resolve-config.sh
@@ -40,6 +40,22 @@ resolve_obsidian_config() {
   return 1
 }
 
+# Read a scalar `key: value` out of the resolved config's frontmatter. Echoes
+# the trimmed value; returns 1 when no config resolves or the key is absent, so
+# a caller can tell "unset" (use my default) from "set". Config keys documented
+# in a SKILL and written by setup were otherwise read by whichever call site
+# remembered to (#103) — dedup_jaccard_threshold reached none of its three.
+obsidian_config_value() {
+  local key="$1" cfg v
+  cfg="$(resolve_obsidian_config "${2:-${CLAUDE_PLUGIN_ROOT:-}}")" || return 1
+  v="$(awk -v k="$key" '
+    index($0, k ":") == 1 {
+      sub(/^[^:]*:[[:space:]]*/, ""); sub(/[[:space:]]+$/, ""); print; exit
+    }' "$cfg")"
+  [ -n "$v" ] || return 1
+  printf '%s\n' "$v"
+}
+
 # CLI mode: when executed directly (not sourced), print the resolved config
 # path on stdout and exit non-zero if none exists. `--stable` prints the
 # canonical stable path regardless of existence (used by the setup wizard to

--- a/scripts/lib/resolve-config.sh
+++ b/scripts/lib/resolve-config.sh
@@ -48,9 +48,17 @@ resolve_obsidian_config() {
 obsidian_config_value() {
   local key="$1" cfg v
   cfg="$(resolve_obsidian_config "${2:-${CLAUDE_PLUGIN_ROOT:-}}")" || return 1
+  # Bounded to the frontmatter block: the body of a config is prose that can
+  # legitimately open a line with `vault_path:` inside an example, and the
+  # first such line would otherwise win. Surrounding quotes are stripped, so a
+  # YAML-quoted scalar ("0.2") reads as the number the writer meant.
   v="$(awk -v k="$key" '
+    NR == 1 { fm = ($0 ~ /^---[[:space:]]*$/); if (fm) next }
+    fm && $0 ~ /^---[[:space:]]*$/ { exit }
     index($0, k ":") == 1 {
-      sub(/^[^:]*:[[:space:]]*/, ""); sub(/[[:space:]]+$/, ""); print; exit
+      sub(/^[^:]*:[[:space:]]*/, ""); sub(/[[:space:]]+$/, "")
+      if ($0 ~ /^".*"$/ || $0 ~ /^'"'"'.*'"'"'$/) { $0 = substr($0, 2, length($0) - 2) }
+      print; exit
     }' "$cfg")"
   [ -n "$v" ] || return 1
   printf '%s\n' "$v"

--- a/scripts/session-save.sh
+++ b/scripts/session-save.sh
@@ -20,7 +20,11 @@ if [ "$AUTO_SAVE" = "false" ]; then
   exit 0
 fi
 
-VAULT_PATH=$(grep '^vault_path:' "$CONFIG_FILE" | head -1 | sed 's/^vault_path:[[:space:]]*//')
+# The shared reader: this hook is the autosave path, and a config with a
+# trailing comment or quoted path parsed to a directory that does not exist,
+# which the guard below turns into a silent exit 0 — the session is simply
+# never saved, with nothing said.
+VAULT_PATH=$(OBSIDIAN_LOCAL_MD="$CONFIG_FILE" obsidian_config_value vault_path || true)
 if [ -z "$VAULT_PATH" ] || [ ! -d "$VAULT_PATH" ]; then
   exit 0
 fi

--- a/scripts/vaultkeeper-tick.sh
+++ b/scripts/vaultkeeper-tick.sh
@@ -204,5 +204,13 @@ if [ -n "$SCAN_FAULT" ]; then
 fi
 
 printf '%s\n' "$CAND" | surfacing_pending_transition "$VAULT"
-keeper_record_scan "$VAULT"
+# Guarded for the same reason as keeper_record_attempt above, and because
+# keeper-state.sh documents this call as checked: bare under `set -e` a failed
+# write aborts the tick here, after every shared write has already landed, so
+# the run reads as a crash rather than as the one thing it could not record.
+# The scan did complete; only the receipt is missing, and the banner's own
+# unreadable-state branch covers a host that cannot write its state.
+if ! keeper_record_scan "$VAULT"; then
+  printf 'vaultkeeper: scan complete but last_scan could not be recorded (cache dir unwritable)\n' >&2
+fi
 echo "vaultkeeper: scan complete ($HOST)"

--- a/skills/save-conversation/SKILL.md
+++ b/skills/save-conversation/SKILL.md
@@ -344,7 +344,7 @@ Before writing a new note in the resolved target folder, check whether a same-da
 
    `dedup_same_day` globs today's notes in the folder, scores each slug's token Jaccard against the proposed slug (via the single `tokenize_slug`), and echoes `path<TAB>score` for the best match at or above the threshold, or nothing. Pass no threshold: the scanner reads the vault's `dedup_jaccard_threshold` itself and falls back to `0.4`. (A fourth argument still overrides it, as the fast path above does.)
 2. If it echoed a match, prompt the user (append vs new), as below.
-3. **If the highest score is ≥ 0.4**, treat as a likely match and prompt the user:
+3. **If step 1 echoed a match**, treat it as a likely match and prompt the user. (Do not re-test the score against `0.4`: the scanner has already applied the vault's threshold, and re-gating on the default here is what made a lowered `dedup_jaccard_threshold` a no-op even once it reached the scanner.)
    > Same-day note already exists: `<existing-path>` (similarity: `<score>`).
    > - **append** → add `## HH:MM — <new-topic>` section to the existing file
    > - **new** → write the proposed new file anyway
@@ -367,12 +367,12 @@ Before writing a new note in the resolved target folder, check whether a same-da
    etc. and recheck until the path is free, then pass the free path's folder as
    `folder_hint`. (Collisions only happen when two saves run within the same
    minute against the same slug.)
-6. **No match (highest < 0.4)**: skip the prompt and proceed with the keeper
-   INSERT (step 11, new file).
+6. **No match (step 1 echoed nothing)**: skip the prompt and proceed with the
+   keeper INSERT (step 11, new file).
 
 ### Threshold
 
-`0.4` is the default. Override per-vault by setting `dedup_jaccard_threshold: 0.5` (or any float 0.0–1.0) in `obsidian.local.md` frontmatter. Set to `0.0` to always prompt; set to `1.0` to disable the check. `dedup_same_day` resolves the setting itself, so every call site inherits it; a value that is not a float in that range is reported on stderr and the `0.4` default is used.
+`0.4` is the default. Override per-vault by setting `dedup_jaccard_threshold: 0.5` (or any float 0.0–1.0) in `obsidian.local.md` frontmatter. Set to `0.0` to prompt on any same-day note; `1.0` prompts only on an identical slug. `dedup_same_day` resolves the setting itself, so every call site inherits it; a value that is not a float in that range is reported on stderr and the `0.4` default is used.
 
 ### Why
 

--- a/skills/save-conversation/SKILL.md
+++ b/skills/save-conversation/SKILL.md
@@ -40,16 +40,18 @@ below; when in doubt, use the full procedure.
 **Steps:**
 ```bash
 CONFIG="$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-config.sh")"
-# read vault_path and dedup_jaccard_threshold from $CONFIG:
-VAULT="$(grep '^vault_path:' "$CONFIG" | head -1 | sed 's/^vault_path:[[:space:]]*//')"
-THRESHOLD="$(awk '/^dedup_jaccard_threshold:/ {print $2}' "$CONFIG")"
-THRESHOLD="${THRESHOLD:-0.4}"
+# One reader for config scalars: it bounds itself to the frontmatter and strips
+# YAML quotes, which hand-rolled greps here did not.
+. "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-config.sh"
+VAULT="$(obsidian_config_value vault_path)"
 # route: single keyword match against ## Project Taxonomy in $CONFIG → <target-folder>
 . "${CLAUDE_PLUGIN_ROOT}/scripts/lib/allowlist-validate.sh"
 allowlist_validate "<target-folder>" || exit 0   # refusal printed to stderr — surface it;
                                                  # a refusal naming /obsidian:setup is a config fault
 . "${CLAUDE_PLUGIN_ROOT}/scripts/lib/dedup-scan.sh"
-dedup_same_day "<vault_path>/<target-folder>" "$(date +%Y-%m-%d)" "<slug>" "$THRESHOLD"
+# No threshold argument: dedup_same_day reads the vault's
+# dedup_jaccard_threshold itself and falls back to 0.4.
+dedup_same_day "$VAULT/<target-folder>" "$(date +%Y-%m-%d)" "<slug>"
 # no output above → proceed
 ```
 

--- a/skills/save-conversation/SKILL.md
+++ b/skills/save-conversation/SKILL.md
@@ -340,9 +340,9 @@ Before writing a new note in the resolved target folder, check whether a same-da
 1. Source the shared scanner and call it:
 
        . "${CLAUDE_PLUGIN_ROOT}/scripts/lib/dedup-scan.sh"
-       dedup_same_day "<vault>/<target-folder>" "$(date +%Y-%m-%d)" "<proposed-slug>" "${dedup_jaccard_threshold:-0.4}"
+       dedup_same_day "<vault>/<target-folder>" "$(date +%Y-%m-%d)" "<proposed-slug>"
 
-   `dedup_same_day` globs today's notes in the folder, scores each slug's token Jaccard against the proposed slug (via the single `tokenize_slug`), and echoes `path<TAB>score` for the best match at or above the threshold, or nothing.
+   `dedup_same_day` globs today's notes in the folder, scores each slug's token Jaccard against the proposed slug (via the single `tokenize_slug`), and echoes `path<TAB>score` for the best match at or above the threshold, or nothing. Pass no threshold: the scanner reads the vault's `dedup_jaccard_threshold` itself and falls back to `0.4`. (A fourth argument still overrides it, as the fast path above does.)
 2. If it echoed a match, prompt the user (append vs new), as below.
 3. **If the highest score is ≥ 0.4**, treat as a likely match and prompt the user:
    > Same-day note already exists: `<existing-path>` (similarity: `<score>`).
@@ -372,7 +372,7 @@ Before writing a new note in the resolved target folder, check whether a same-da
 
 ### Threshold
 
-`0.4` is the default. Override per-vault by setting `dedup_jaccard_threshold: 0.5` (or any float 0.0–1.0) in `obsidian.local.md` frontmatter. Set to `0.0` to always prompt; set to `1.0` to disable the check.
+`0.4` is the default. Override per-vault by setting `dedup_jaccard_threshold: 0.5` (or any float 0.0–1.0) in `obsidian.local.md` frontmatter. Set to `0.0` to always prompt; set to `1.0` to disable the check. `dedup_same_day` resolves the setting itself, so every call site inherits it; a value that is not a float in that range is reported on stderr and the `0.4` default is used.
 
 ### Why
 

--- a/skills/save-conversation/SKILL.md
+++ b/skills/save-conversation/SKILL.md
@@ -43,7 +43,13 @@ CONFIG="$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-config.sh")"
 # One reader for config scalars: it bounds itself to the frontmatter and strips
 # YAML quotes, which hand-rolled greps here did not.
 . "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-config.sh"
-VAULT="$(obsidian_config_value vault_path)"
+VAULT="$(obsidian_config_value vault_path)" || exit 0   # no vault_path → a config
+                                                        # fault; say so rather than
+                                                        # scanning /<target-folder>,
+                                                        # where find's 2>/dev/null
+                                                        # makes "no output" mean
+                                                        # "no duplicate" and the
+                                                        # agent files a twin note
 # route: single keyword match against ## Project Taxonomy in $CONFIG → <target-folder>
 . "${CLAUDE_PLUGIN_ROOT}/scripts/lib/allowlist-validate.sh"
 allowlist_validate "<target-folder>" || exit 0   # refusal printed to stderr — surface it;

--- a/tests/ask-staleness.sh
+++ b/tests/ask-staleness.sh
@@ -32,4 +32,29 @@ case "$(run)" in
   *) fail "entrypoint did not surface the never-completed state: $(run)" ;;
 esac
 
+# A degraded state file must reach the user through the real entrypoint too. An
+# empty last_scan (what ENOSPC leaves: `>` truncates on open, then fails on
+# write) used to read as "never scanned" here, and an empty last_attempt as
+# "nothing has tried" — silence, which every consumer treats as healthy (#94).
+: > "$(keeper_last_scan_file "$V")"
+case "$(run)" in
+  *unreadable*) : ;;
+  *) fail "an empty last_scan did not surface through the entrypoint: $(run)" ;;
+esac
+rm -f "$(keeper_last_scan_file "$V")"
+: > "$(keeper_last_attempt_file "$V")"
+case "$(run)" in
+  *unreadable*) : ;;
+  *) fail "an empty last_attempt did not surface through the entrypoint: $(run)" ;;
+esac
+
+# The entrypoint must not let its own failure pass as a clean bill of health:
+# it runs under set -e with staleness_banner as its last command, so an abort
+# there exits 1 with no stdout — and stdout is the only channel the consumers
+# read ("if it prints a line, show it"). Pinned by inspection because nothing
+# reachable through this script can make the banner abort any more; that is the
+# property, and the guard is what preserves it.
+grep -q 'staleness_banner .*||' "${ROOT_DIR}/scripts/ask-staleness.sh" \
+  || fail "ask-staleness.sh no longer guards the banner call; a failed check would print nothing"
+
 echo "PASS: ask-staleness"

--- a/tests/ask-staleness.sh
+++ b/tests/ask-staleness.sh
@@ -70,6 +70,20 @@ esac
 printf '# Librarian\n\nlast_scan: %s\n' "$(now_epoch)" > "$D/Librarian.md"
 [ -z "$(drun)" ] || fail "warned on a vault the owner is scanning fine: $(drun)"
 
+# The optional config keys are exactly that. /obsidian:setup's template does not
+# write keeper_interval_secs, and an unmatched grep is a failed pipeline under
+# this script's pipefail — so on a default install the check aborted before the
+# banner ever ran, printing nothing, which every consumer reads as healthy.
+MIN="$TMP/minimal.local.md"
+printf -- '---\nvault_path: %s\n---\n' "$D" > "$MIN"
+MINOUT="$(OBSIDIAN_LOCAL_MD="$MIN" bash "${ROOT_DIR}/scripts/ask-staleness.sh")" \
+  || fail "a config with only vault_path aborted the freshness check"
+printf '# Librarian\n\nlast_scan: %s\nscan_status: INCOMPLETE\n' "$(now_epoch)" > "$D/Librarian.md"
+case "$(OBSIDIAN_LOCAL_MD="$MIN" bash "${ROOT_DIR}/scripts/ask-staleness.sh")" in
+  *faulted*) : ;;
+  *) fail "a faulting scan stayed silent on a config without the optional keys" ;;
+esac
+
 # The entrypoint must not let its own failure pass as a clean bill of health:
 # it runs under set -e with staleness_banner as its last command, so an abort
 # there exits 1 with no stdout — and stdout is the only channel the consumers

--- a/tests/ask-staleness.sh
+++ b/tests/ask-staleness.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . "${ROOT_DIR}/scripts/lib/note-hash.sh"
 . "${ROOT_DIR}/scripts/lib/keeper-state.sh"
+. "${ROOT_DIR}/scripts/lib/keeper-lease.sh"
 fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/ask-stale-XXXXXX")"; trap 'rm -rf "$TMP"' EXIT
 export XDG_CACHE_HOME="$TMP/cache"
@@ -47,6 +48,27 @@ case "$(run)" in
   *unreadable*) : ;;
   *) fail "an empty last_attempt did not surface through the entrypoint: $(run)" ;;
 esac
+
+# A deferring host has no local state at all — only the elected owner scans and
+# keeper state never syncs — so /obsidian:ask on that host must speak from the
+# vault's own evidence: the owner's INCOMPLETE digest, and the lease naming who
+# the owner is (#95). This is the entrypoint half; tests/keeper-state.sh covers
+# the branches.
+D="$TMP/deferring"; mkdir -p "$D"
+DCFG="$TMP/deferring.local.md"
+printf -- '---\nvault_path: %s\nkeeper_interval_secs: 900\nkeeper_host_priority: ml-1 mbp\n---\n' \
+  "$D" > "$DCFG"
+drun() { OBSIDIAN_LOCAL_MD="$DCFG" bash "${ROOT_DIR}/scripts/ask-staleness.sh"; }
+
+[ -z "$(drun)" ] || fail "warned about a vault the keeper has never run on: $(drun)"
+keeper_claim_write "$D/.vaultkeeper" "ml-1"
+printf '# Librarian\n\nlast_scan: %s\nscan_status: INCOMPLETE\n' "$(now_epoch)" > "$D/Librarian.md"
+case "$(drun)" in
+  *faulted*ml-1*) : ;;
+  *) fail "the owner's faulting scans stayed invisible through the entrypoint: $(drun)" ;;
+esac
+printf '# Librarian\n\nlast_scan: %s\n' "$(now_epoch)" > "$D/Librarian.md"
+[ -z "$(drun)" ] || fail "warned on a vault the owner is scanning fine: $(drun)"
 
 # The entrypoint must not let its own failure pass as a clean bill of health:
 # it runs under set -e with staleness_banner as its last command, so an abort

--- a/tests/codex-plugin.sh
+++ b/tests/codex-plugin.sh
@@ -136,4 +136,23 @@ if env -u OBSIDIAN_LOCAL_MD XDG_CONFIG_HOME="$TMP/no-config" \
 fi
 grep -q 'vault_path unresolved' "$TMP/missing.err" || fail "missing config failure was not truthful"
 
+# The vendored copies are maintained by hand: this PR alone carried six fixes
+# across the boundary. Nothing compared them, and the suite exercises the
+# installed keeper only through shapes that predate those fixes -- so a copy
+# drifting back would have gone unnoticed. Compare the bytes.
+for VENDORED in \
+  scripts/keeper \
+  scripts/lib/note-hash.sh \
+  scripts/lib/resolve-config.sh \
+  scripts/lib/vault-index.sh \
+  scripts/lib/commit-capture-parse.sh
+do
+  SRC="$ROOT_DIR/$VENDORED"
+  DST="$ROOT_DIR/packages/codex/skills/commit-capture/$VENDORED"
+  [ -f "$SRC" ] || fail "vendor parity: $VENDORED is missing from scripts/"
+  [ -f "$DST" ] || fail "vendor parity: $VENDORED is missing from the codex package"
+  cmp -s "$SRC" "$DST" \
+    || fail "vendor parity: packages/codex copy of $VENDORED has drifted from scripts/"
+done
+
 printf 'PASS: installed Codex manual commit-capture package\n'

--- a/tests/dedup-scan.sh
+++ b/tests/dedup-scan.sh
@@ -98,6 +98,27 @@ dedup_same_day "$TMP/t" 2026-06-29 keeper-cli '"0.2"' >/dev/null 2>"$TMP/quoted.
 grep -q 'unusable threshold argument' "$TMP/quoted.err" \
   || fail "a quoted threshold argument was passed through to awk:"$'\n'"$(cat "$TMP/quoted.err")"
 
+# An out-of-range value is unusable in the same way a non-numeric one is: 10
+# would disable the check, 0.4 is looser than the vault asked for, and either
+# way the config is wrong and the user should hear about it.
+OOR="$(OBSIDIAN_DEDUP_JACCARD_THRESHOLD=10 dedup_same_day "$TMP/t" 2026-06-29 keeper-cli 2>"$TMP/oor.err")"
+grep -q 'unusable dedup_jaccard_threshold' "$TMP/oor.err" \
+  || fail "an out-of-range threshold was accepted silently:"$'\n'"$(cat "$TMP/oor.err")"
+
+# The library resolves the vault threshold through its sibling resolve-config.sh.
+# If that file is missing the install is broken, not the config — and staying
+# quiet there means a vault that set 0.0 runs at 0.4, which is exactly the
+# twin-note failure #103 exists to prevent.
+ORPHAN="$TMP/orphan-lib"; mkdir -p "$ORPHAN"
+cp "$ROOT_DIR/scripts/lib/dedup-scan.sh" "$ORPHAN/"
+ORPHAN_ERR="$(HOME="$TMP/nohome" XDG_CONFIG_HOME="$TMP/noconfig" CLAUDE_PLUGIN_ROOT="" \
+  OBSIDIAN_LOCAL_MD="" OBSIDIAN_DEDUP_JACCARD_THRESHOLD="" \
+  bash -c ". '$ORPHAN/dedup-scan.sh'; dedup_same_day '$TMP/t' 2026-06-29 keeper-cli" 2>&1 >/dev/null)"
+case "$ORPHAN_ERR" in
+  *resolve-config.sh*) : ;;
+  *) fail "a missing resolve-config.sh sibling fell back to the default in silence: ${ORPHAN_ERR:-<empty>}" ;;
+esac
+
 # zsh cleanliness
 if command -v zsh >/dev/null 2>&1; then
   zsh -c ". '$ROOT_DIR/scripts/lib/dedup-scan.sh'; tokenize_slug a-2026-bb" >/dev/null 2>"$TMP/zerr" || { cat "$TMP/zerr" >&2; fail "dedup-scan broke under zsh"; }

--- a/tests/dedup-scan.sh
+++ b/tests/dedup-scan.sh
@@ -31,6 +31,17 @@ echo "$hit" | grep -q '2026-06-28' && fail "other-day file wrongly matched"
 dedup_same_day "$TMP/f" 2026-06-29 zzz-no-such-topic 0.4 >/dev/null
 echo "ok: bare no-match dedup_same_day survived set -e" >/dev/null
 
+# The documented endpoints must be reachable. `0.0` means "prompt on any
+# same-day note" — it was unreachable while the best-so-far comparison was
+# folded into the threshold test and seeded at 0.00, so a zero-overlap slug
+# scored 0.00 and lost to the seed.
+mkdir -p "$TMP/zero"
+: > "$TMP/zero/2026-06-29-totally-different-subject.md"
+[ -n "$(dedup_same_day "$TMP/zero" 2026-06-29 unrelated-words-here 0.0)" ] \
+  || fail "dedup_jaccard_threshold 0.0 must prompt on any same-day note"
+[ -z "$(dedup_same_day "$TMP/zero" 2026-06-29 unrelated-words-here 0.4)" ] \
+  || fail "0.0 reachability must not make the default threshold match everything"
+
 # --- the per-vault threshold override actually reaches the scanner (#103) ---
 # `keeper-cli` vs `keeper-gui` scores 0.33: below the 0.4 default, above a
 # vault that lowered the bar. A config override that never arrives is invisible

--- a/tests/dedup-scan.sh
+++ b/tests/dedup-scan.sh
@@ -31,6 +31,45 @@ echo "$hit" | grep -q '2026-06-28' && fail "other-day file wrongly matched"
 dedup_same_day "$TMP/f" 2026-06-29 zzz-no-such-topic 0.4 >/dev/null
 echo "ok: bare no-match dedup_same_day survived set -e" >/dev/null
 
+# --- the per-vault threshold override actually reaches the scanner (#103) ---
+# `keeper-cli` vs `keeper-gui` scores 0.33: below the 0.4 default, above a
+# vault that lowered the bar. A config override that never arrives is invisible
+# in the result, which is how every call site ran at 0.4 while the vault said
+# otherwise.
+mkdir -p "$TMP/t"
+: > "$TMP/t/2026-06-29-keeper-gui.md"
+CFG="$TMP/obsidian.local.md"
+printf -- '---\nvault_path: %s\ndedup_jaccard_threshold: 0.2\n---\n' "$TMP" > "$CFG"
+
+# Scrub the resolver's inputs for this one: the developer running the suite may
+# well have a real config, and the default-path assertion must not read it.
+[ -z "$(HOME="$TMP/nohome" XDG_CONFIG_HOME="$TMP/noconfig" CLAUDE_PLUGIN_ROOT="" \
+        dedup_same_day "$TMP/t" 2026-06-29 keeper-cli)" ] \
+  || fail "with no config the arg-less call must use the 0.4 default"
+
+hit="$(OBSIDIAN_LOCAL_MD="$CFG" dedup_same_day "$TMP/t" 2026-06-29 keeper-cli)"
+echo "$hit" | grep -q '2026-06-29-keeper-gui.md' \
+  || fail "the vault's dedup_jaccard_threshold override never reached the scanner: [$hit]"
+
+# an explicit argument still wins over the config
+[ -z "$(OBSIDIAN_LOCAL_MD="$CFG" dedup_same_day "$TMP/t" 2026-06-29 keeper-cli 0.4)" ] \
+  || fail "an explicit threshold argument must override the config"
+
+# a config value the scanner cannot use warns and falls back, rather than
+# reaching awk — where a non-numeric threshold compares as 0 and matches the
+# first note in the folder.
+printf -- '---\ndedup_jaccard_threshold: high\n---\n' > "$TMP/bad.md"
+BADOUT="$(OBSIDIAN_LOCAL_MD="$TMP/bad.md" dedup_same_day "$TMP/t" 2026-06-29 keeper-cli 2>"$TMP/bad.err")"
+[ -z "$BADOUT" ] || fail "an unusable threshold matched anyway: [$BADOUT]"
+grep -q 'unusable dedup_jaccard_threshold' "$TMP/bad.err" \
+  || fail "an unusable threshold was swallowed:"$'\n'"$(cat "$TMP/bad.err")"
+
+# a vault that raises the bar suppresses a match the default would have made
+: > "$TMP/t/2026-06-29-keeper-cli-design.md"
+printf -- '---\ndedup_jaccard_threshold: 1.0\n---\n' > "$TMP/off.md"
+[ -z "$(OBSIDIAN_LOCAL_MD="$TMP/off.md" dedup_same_day "$TMP/t" 2026-06-29 keeper-cli-plan)" ] \
+  || fail "dedup_jaccard_threshold: 1.0 must disable the check"
+
 # zsh cleanliness
 if command -v zsh >/dev/null 2>&1; then
   zsh -c ". '$ROOT_DIR/scripts/lib/dedup-scan.sh'; tokenize_slug a-2026-bb" >/dev/null 2>"$TMP/zerr" || { cat "$TMP/zerr" >&2; fail "dedup-scan broke under zsh"; }

--- a/tests/dedup-scan.sh
+++ b/tests/dedup-scan.sh
@@ -54,7 +54,10 @@ printf -- '---\nvault_path: %s\ndedup_jaccard_threshold: 0.2\n---\n' "$TMP" > "$
 
 # Scrub the resolver's inputs for this one: the developer running the suite may
 # well have a real config, and the default-path assertion must not read it.
+# OBSIDIAN_LOCAL_MD and the env override are scrubbed too: either one set in
+# the developer's shell answers ahead of every path this case is pinning.
 [ -z "$(HOME="$TMP/nohome" XDG_CONFIG_HOME="$TMP/noconfig" CLAUDE_PLUGIN_ROOT="" \
+        OBSIDIAN_LOCAL_MD="" OBSIDIAN_DEDUP_JACCARD_THRESHOLD="" \
         dedup_same_day "$TMP/t" 2026-06-29 keeper-cli)" ] \
   || fail "with no config the arg-less call must use the 0.4 default"
 
@@ -80,6 +83,20 @@ grep -q 'unusable dedup_jaccard_threshold' "$TMP/bad.err" \
 printf -- '---\ndedup_jaccard_threshold: 1.0\n---\n' > "$TMP/off.md"
 [ -z "$(OBSIDIAN_LOCAL_MD="$TMP/off.md" dedup_same_day "$TMP/t" 2026-06-29 keeper-cli-plan)" ] \
   || fail "dedup_jaccard_threshold: 1.0 must disable the check"
+
+# An explicitly passed threshold is validated too. It bypasses dedup_threshold
+# entirely, and a non-numeric or quoted value compares as 0 inside awk — which
+# matches the first note in the folder rather than nothing.
+ARGBAD="$(dedup_same_day "$TMP/t" 2026-06-29 nothing-alike-at-all "not-a-number" 2>"$TMP/argbad.err")"
+[ -z "$ARGBAD" ] \
+  || fail "a non-numeric threshold argument matched a note: [$ARGBAD]"
+grep -q 'unusable threshold argument' "$TMP/argbad.err" \
+  || fail "a non-numeric threshold argument was swallowed:"$'\n'"$(cat "$TMP/argbad.err")"
+# A quoted float is rejected the same way and falls back to the resolved
+# default, rather than reaching awk as a 0 that matches anything.
+dedup_same_day "$TMP/t" 2026-06-29 keeper-cli '"0.2"' >/dev/null 2>"$TMP/quoted.err"
+grep -q 'unusable threshold argument' "$TMP/quoted.err" \
+  || fail "a quoted threshold argument was passed through to awk:"$'\n'"$(cat "$TMP/quoted.err")"
 
 # zsh cleanliness
 if command -v zsh >/dev/null 2>&1; then

--- a/tests/keeper-cli.sh
+++ b/tests/keeper-cli.sh
@@ -327,10 +327,37 @@ else
   [ "$NODAILY_RC" = "0" ] \
     || fail "insert exited $NODAILY_RC after committing the note; a caller reads that as 'not captured'"
   [ -f "$V/Notes/2026-07-02-no-daily-yet.md" ] || fail "insert did not write the note"
-  grep -qF "$V/Notes/2026-07-02-no-daily-yet.md" "$TMP/nodaily.out" \
-    || fail "insert printed no path for a note it committed"
+  # The vault-relative suffix, not "$V/...": $TMPDIR is a symlink on macOS
+  # (/var -> /private/var) and keeper resolves it, so the absolute forms never
+  # match there and this arm failed on every run.
+  grep -qF "Notes/2026-07-02-no-daily-yet.md" "$TMP/nodaily.out" \
+    || fail "insert printed no path for a note it committed:"$'\n'"$(cat "$TMP/nodaily.out")"
   grep -q 'no session link' "$TMP/nodaily.err" \
     || fail "an uncreatable daily note was silent:"$'\n'"$(cat "$TMP/nodaily.err")"
+fi
+
+# I10b: the INDEX creation write is the third bare write after the note
+# commits. `[ -f "$idx" ] || printf ... > "$idx"` aborts under `set -e` when
+# INDEX.md cannot be created -- an INDEX.md that is a directory is the cheap
+# reproduction, ENOSPC the real one -- so insert exits 1 having written the
+# note, which callers read as "not captured". Same invariant as I10 and I11b.
+if [ "$(id -u)" = "0" ]; then
+  printf 'skip: unwritable-INDEX assertion (running as root)\n' >&2
+else
+  mkdir -p "$V/Blocked"
+  mkdir -p "$V/Blocked/INDEX.md"
+  set +e
+  bash "$KEEPER" insert --vault "$V" --target "Blocked/2026-07-03-blocked-index.md" \
+    --body-file "$TMP/note.md" --title "Blocked Index" \
+    >"$TMP/blockidx.out" 2>"$TMP/blockidx.err"
+  BLOCKIDX_RC=$?
+  set -e
+  [ "$BLOCKIDX_RC" = "0" ] \
+    || fail "the note committed, so insert must still exit 0 with an unusable INDEX; rc=$BLOCKIDX_RC"$'\n'"$(cat "$TMP/blockidx.err")"
+  [ -f "$V/Blocked/2026-07-03-blocked-index.md" ] || fail "insert did not write the note"
+  grep -q 'keeper: warning' "$TMP/blockidx.err" \
+    || fail "an unusable INDEX.md was silent:"$'\n'"$(cat "$TMP/blockidx.err")"
+  rmdir "$V/Blocked/INDEX.md" 2>/dev/null || true
 fi
 
 # 14. zsh portability — both subcommands clean under zsh (insert sources the substrate libs)

--- a/tests/keeper-cli.sh
+++ b/tests/keeper-cli.sh
@@ -310,6 +310,27 @@ else
   STRAY="$(find "$V/Daily" -maxdepth 1 -name '*ktmp*' | wc -l | tr -d ' ')"
   [ "$STRAY" = "0" ] \
     || fail "$STRAY stray temp file(s) left in Daily/ after a failed session link"
+
+  # I11b: the same, for the day that has NO daily note yet — the shape the
+  # fixture above skips, and the one where the unguarded writes lived. Creating
+  # the note, appending the section and swapping are three separate writes;
+  # guarding only the last still aborts the insert after the note committed,
+  # which a caller reads as "not captured" for a capture that happened.
+  chmod 555 "$V/Daily"
+  set +e
+  bash "$KEEPER" insert --vault "$V" --target "Notes/2026-07-02-no-daily-yet.md" \
+    --body-file "$TMP/note.md" --title "No Daily Yet" --session-link-date 2026-07-02 \
+    >"$TMP/nodaily.out" 2>"$TMP/nodaily.err"
+  NODAILY_RC=$?
+  set -e
+  chmod 755 "$V/Daily"
+  [ "$NODAILY_RC" = "0" ] \
+    || fail "insert exited $NODAILY_RC after committing the note; a caller reads that as 'not captured'"
+  [ -f "$V/Notes/2026-07-02-no-daily-yet.md" ] || fail "insert did not write the note"
+  grep -qF "$V/Notes/2026-07-02-no-daily-yet.md" "$TMP/nodaily.out" \
+    || fail "insert printed no path for a note it committed"
+  grep -q 'no session link' "$TMP/nodaily.err" \
+    || fail "an uncreatable daily note was silent:"$'\n'"$(cat "$TMP/nodaily.err")"
 fi
 
 # 14. zsh portability — both subcommands clean under zsh (insert sources the substrate libs)

--- a/tests/keeper-cli.sh
+++ b/tests/keeper-cli.sh
@@ -224,14 +224,20 @@ bash "$KEEPER" insert --vault "$V" --target "Decisions/2026-06-29-dup.md" \
 grep -qxF -- '- [[Decisions/2026-06-29-dup|Other Note]]' "$DLY" \
   || fail "second same-titled note lost its Session Links entry:"$'\n'"$(cat "$DLY")"
 
-# I4b: re-linking the SAME note is still idempotent (dedup is per path, not per title).
-bash "$KEEPER" insert --vault "$V" --target "Decisions/2026-06-29-again.md" \
-  --body-file "$TMP/note.md" --title "Again" --session-link-date 2026-06-29 >/dev/null
-bash "$KEEPER" insert --vault "$V" --target "Decisions/2026-06-29-again.md" \
-  --body-file "$TMP/note.md" --title "Again" --session-link-date 2026-06-29 2>/dev/null \
-  && fail "insert must refuse to overwrite; I4b cannot test dedup this way"
-[ "$(grep -cF -- '[[Decisions/2026-06-29-again' "$DLY")" = "1" ] \
-  || fail "Session Links entry duplicated for one note"
+# I4b: the Session Links dedup is per path. A second insert of the same note
+#      cannot test it — the overwrite guard rejects that before the link step
+#      ever runs, so the assertion passed on the early abort rather than on the
+#      dedup. Seed the link into the daily note instead, which is the state a
+#      Syncthing round-trip or a hand-edit leaves, and let the insert reach the
+#      branch.
+awk '{print} /^## Session Links/ && !d {print "- [[Decisions/2026-06-29-seeded|Seeded]]"; d=1}' \
+  "$DLY" > "$DLY.seed" && mv "$DLY.seed" "$DLY"
+[ "$(grep -cF -- '[[Decisions/2026-06-29-seeded' "$DLY")" = "1" ] \
+  || fail "fixture precondition: the seeded link should appear exactly once"
+bash "$KEEPER" insert --vault "$V" --target "Decisions/2026-06-29-seeded.md" \
+  --body-file "$TMP/note.md" --title "Seeded" --session-link-date 2026-06-29 >/dev/null
+[ "$(grep -cF -- '[[Decisions/2026-06-29-seeded' "$DLY")" = "1" ] \
+  || fail "Session Links entry duplicated for a note the daily note already linked:"$'\n'"$(grep -F 'seeded' "$DLY")"
 
 # I5: malformed --session-link-date rejected
 bash "$KEEPER" insert --vault "$V" --target "Decisions/z.md" --body-file "$TMP/note.md" --session-link-date "2026/06/29" 2>/dev/null && fail "malformed session-link-date must fail"
@@ -275,6 +281,35 @@ else
   [ -f "$V/Locked/2026-06-29-orphan.md" ] || fail "insert did not write the note"
   grep -q 'not linked from' "$TMP/lock.err" \
     || fail "insert reported success on an unlinked note; stderr was:"$'\n'"$(cat "$TMP/lock.err")"
+fi
+
+# I11: a Daily/ note that cannot be replaced leaves no stray temp file behind,
+#      and says so. `> "$daily.ktmp" && mv` left a .ktmp in the user's Daily/
+#      folder on failure — and since the note itself commits first, the obvious
+#      retry then died on "target already exists" rather than re-linking.
+if [ "$(id -u)" = "0" ]; then
+  printf 'skip: unwritable-daily assertion (running as root ignores 0444)\n' >&2
+else
+  # The directory, not the file: rename(2) needs write permission on the
+  # directory, so a 0444 daily note is still replaceable and nothing fails.
+  LOCKDAY="$V/Daily/2026-07-01.md"
+  printf -- '---\ndate: 2026-07-01\n---\n\n## Session Links\n' > "$LOCKDAY"
+  chmod 555 "$V/Daily"
+  set +e
+  bash "$KEEPER" insert --vault "$V" --target "Notes/2026-07-01-locked-daily.md" \
+    --body-file "$TMP/note.md" --title "Locked Daily" --session-link-date 2026-07-01 \
+    >"$TMP/lockday.out" 2>"$TMP/lockday.err"
+  LOCKDAY_RC=$?
+  set -e
+  chmod 755 "$V/Daily"
+  [ "$LOCKDAY_RC" = "0" ] \
+    || fail "the note committed, so insert must still exit 0; rc=$LOCKDAY_RC"
+  [ -f "$V/Notes/2026-07-01-locked-daily.md" ] || fail "insert did not write the note"
+  grep -qE 'could not be linked into Daily|Daily/ is unwritable' "$TMP/lockday.err" \
+    || fail "an unlinkable daily note was silent:"$'\n'"$(cat "$TMP/lockday.err")"
+  STRAY="$(find "$V/Daily" -maxdepth 1 -name '*ktmp*' | wc -l | tr -d ' ')"
+  [ "$STRAY" = "0" ] \
+    || fail "$STRAY stray temp file(s) left in Daily/ after a failed session link"
 fi
 
 # 14. zsh portability — both subcommands clean under zsh (insert sources the substrate libs)

--- a/tests/keeper-cli.sh
+++ b/tests/keeper-cli.sh
@@ -85,6 +85,37 @@ bash "$KEEPER" append --vault "$V" --target "Notes/prose.md" \
 grep -q '^## 12:05 — deadbee' "$V/Notes/prose.md" \
   || fail "a sha mentioned in body prose was read as an existing section, dropping the record"
 
+# 17b. the sha may sit anywhere in the heading. Commit capture writes it at the
+#      START ("## <sha> — msg"), and an end-anchored match never fired for that
+#      shape, so the only guard against a double capture was dead (#101).
+printf 'first capture\n' > "$TMP/lead.md"
+bash "$KEEPER" append --vault "$V" --target "Notes/lead.md" \
+  --section '## 7ac9556 — repair the two guards (PR #357)' --body-file "$TMP/lead.md" >/dev/null
+LEAD_BEFORE="$(cat "$V/Notes/lead.md")"
+bash "$KEEPER" append --vault "$V" --target "Notes/lead.md" \
+  --section '## 7ac9556 — repair the two guards (PR #357)' --body-file "$TMP/dup.md" \
+  --skip-if-hash 7ac9556 >/dev/null 2>&1
+[ "$(cat "$V/Notes/lead.md")" = "$LEAD_BEFORE" ] \
+  || fail "a sha at the start of the heading was not seen, so the commit was captured twice"
+
+# 17c. the sha is compared case-insensitively — the validator accepts [0-9a-fA-F],
+#      so a caller passing an uppercase sha must still hit its own section.
+bash "$KEEPER" append --vault "$V" --target "Notes/lead.md" \
+  --section '## 7AC9556 — same commit, uppercase' --body-file "$TMP/dup.md" \
+  --skip-if-hash 7AC9556 >/dev/null 2>&1
+[ "$(cat "$V/Notes/lead.md")" = "$LEAD_BEFORE" ] \
+  || fail "an uppercase --skip-if-hash missed the lowercase section it names"
+
+# 17d. the boundary is real: a heading naming a LONGER sha that merely starts
+#      with this one is a different commit and must not suppress it.
+printf 'longer sha section\n' > "$TMP/long.md"
+bash "$KEEPER" append --vault "$V" --target "Notes/boundary.md" \
+  --section '## abc12345 — a different commit' --body-file "$TMP/long.md" >/dev/null
+bash "$KEEPER" append --vault "$V" --target "Notes/boundary.md" \
+  --section '## abc1234 — the commit we mean' --body-file "$TMP/b.md" --skip-if-hash abc1234 >/dev/null
+grep -q '^## abc1234 — the commit we mean' "$V/Notes/boundary.md" \
+  || fail "a heading for a longer sha with the same prefix suppressed a distinct commit"
+
 # 18. a malformed --skip-if-hash fails loudly. Silently treating an unusable
 #     value as "no guard" turns a typo into a duplicate note, which is the
 #     failure this flag exists to prevent.
@@ -187,6 +218,35 @@ grep -qxF -- '- [[Notes/plain]]' "$V/Notes/INDEX.md" || fail "default title (no 
 # I8: insert path-traversal guard
 bash "$KEEPER" insert --vault "$V" --target "../evil.md" --body-file "$TMP/note.md" 2>/dev/null && fail "insert path traversal must fail"
 [ -f "$TMP/evil.md" ] && fail "insert traversal wrote outside the vault"
+
+# I9: a healthy insert raises no link warning — the warning below must mean
+#     something when it appears.
+bash "$KEEPER" insert --vault "$V" --target "Notes/quiet.md" \
+  --body-file "$TMP/note.md" >/dev/null 2>"$TMP/quiet.err"
+grep -q 'keeper: warning' "$TMP/quiet.err" \
+  && fail "insert warned about a link it did write:"$'\n'"$(cat "$TMP/quiet.err")"
+
+# I10: when the INDEX link cannot be written, insert says so. The note is
+#      committed before the link step, so swallowing the failure with `|| true`
+#      let the CLI print the path and exit 0 on a note nothing links to (#104).
+if [ "$(id -u)" = "0" ]; then
+  printf 'skip: unlinkable-INDEX assertion (running as root ignores 0444)\n' >&2
+else
+  mkdir -p "$V/Locked"
+  printf '# Locked Index\n' > "$V/Locked/INDEX.md"
+  chmod 444 "$V/Locked/INDEX.md"
+  set +e
+  bash "$KEEPER" insert --vault "$V" --target "Locked/2026-06-29-orphan.md" \
+    --body-file "$TMP/note.md" >"$TMP/lock.out" 2>"$TMP/lock.err"
+  LOCK_RC=$?
+  set -e
+  chmod 644 "$V/Locked/INDEX.md"
+  [ "$LOCK_RC" = "0" ] \
+    || fail "the note itself committed, so insert must still exit 0; rc=$LOCK_RC"
+  [ -f "$V/Locked/2026-06-29-orphan.md" ] || fail "insert did not write the note"
+  grep -q 'not linked from' "$TMP/lock.err" \
+    || fail "insert reported success on an unlinked note; stderr was:"$'\n'"$(cat "$TMP/lock.err")"
+fi
 
 # 14. zsh portability — both subcommands clean under zsh (insert sources the substrate libs)
 if command -v zsh >/dev/null 2>&1; then

--- a/tests/keeper-cli.sh
+++ b/tests/keeper-cli.sh
@@ -46,6 +46,35 @@ grep -qE '^## [0-9]{2}:[0-9]{2} — entry' "$V/Notes/y.md" || fail "default sect
 printf 'stdin body\n' | bash "$KEEPER" append --vault "$V" --target "Notes/s.md" --section '## s — t' >/dev/null
 grep -q '^stdin body' "$V/Notes/s.md" || fail "stdin body not appended"
 
+# 6b. a bare --section title is written as a heading, not a paragraph. Plain
+#     text is invisible to Obsidian's outline, and — because the --skip-if-hash
+#     gate reads headings — a section written flat cannot be found by the sha
+#     dedup either, so the same commit captures twice (#100).
+printf 'flat body\n' > "$TMP/flat.md"
+bash "$KEEPER" append --vault "$V" --target "Notes/flat.md" \
+  --section 'Some title 1234abc' --body-file "$TMP/flat.md" >/dev/null
+grep -qxF -- '## Some title 1234abc' "$V/Notes/flat.md" \
+  || fail "a bare --section title was not promoted to a heading:"$'\n'"$(cat "$V/Notes/flat.md")"
+FLAT_BEFORE="$(cat "$V/Notes/flat.md")"
+bash "$KEEPER" append --vault "$V" --target "Notes/flat.md" \
+  --section 'Some title 1234abc' --body-file "$TMP/flat.md" --skip-if-hash 1234abc >/dev/null 2>&1
+[ "$(cat "$V/Notes/flat.md")" = "$FLAT_BEFORE" ] \
+  || fail "a section written from a bare title was not seen by the sha gate"
+
+# 6c. a --section that already carries its own hashes keeps the level it chose;
+#     keeper must not double-prefix it.
+bash "$KEEPER" append --vault "$V" --target "Notes/level.md" \
+  --section '#### deep section' --body-file "$TMP/b.md" >/dev/null
+grep -qxF -- '#### deep section' "$V/Notes/level.md" \
+  || fail "an explicit heading level was rewritten:"$'\n'"$(cat "$V/Notes/level.md")"
+
+# 6d. a whitespace-only --section falls back to the default heading rather than
+#     emitting an empty one.
+bash "$KEEPER" append --vault "$V" --target "Notes/blank.md" --section '   ' \
+  --body-file "$TMP/b.md" >/dev/null
+grep -qE '^## [0-9]{2}:[0-9]{2} — entry' "$V/Notes/blank.md" \
+  || fail "a blank --section did not fall back to the default heading:"$'\n'"$(cat "$V/Notes/blank.md")"
+
 # --- --skip-if-hash: the append is idempotent per commit sha ---
 #
 # The capture gate this replaces lived in a host-local state dir while the vault

--- a/tests/keeper-state.sh
+++ b/tests/keeper-state.sh
@@ -150,4 +150,72 @@ else
   chmod 755 "$(keeper_cache_dir "$VAULT")"
 fi
 
+# --- a deferring host speaks from the vault's evidence (#95) -----------------
+#
+# Keeper state is per-host and never synced, and only the elected owner scans,
+# so a deferring host has neither a scan nor an attempt — and stayed silent
+# whether the owner was healthy or had faulted on every tick since install. On
+# a two-host vault that host is usually where /obsidian:ask is run.
+. "${ROOT_DIR}/scripts/lib/keeper-lease.sh"
+DEF="$TMP/deferring"; mkdir -p "$DEF"
+[ -z "$(keeper_last_scan "$DEF")" ] && [ -z "$(keeper_last_attempt "$DEF")" ] \
+  || fail "fixture precondition: the deferring host must have no local state"
+
+# A vault no host has ever claimed is not a fault: the keeper has never run
+# anywhere, and this host has nothing to report.
+[ -z "$(staleness_banner "$DEF" 900)" ] \
+  || fail "warned about a vault the keeper has never run on: $(staleness_banner "$DEF" 900)"
+
+# With a live claim and no digest at all, no host has ever completed a scan.
+keeper_claim_write "$DEF/.vaultkeeper" "ml-1"
+NODIGEST="$(staleness_banner "$DEF" 900 "ml-1,mbp")"
+case "$NODIGEST" in
+  *"no host has produced"*) : ;;
+  *) fail "a claimed vault with no digest reported nothing: ${NODIGEST:-<empty>}" ;;
+esac
+case "$NODIGEST" in
+  *"ml-1"*) : ;;
+  *) fail "the vault-sourced banner did not name the elected owner: $NODIGEST" ;;
+esac
+
+# The owner stamps scan_status: INCOMPLETE into Librarian.md on every faulted
+# tick. That is the signal the deferring host was blind to.
+printf '# Librarian\n\nlast_scan: %s\nscan_status: INCOMPLETE\n' "$(now_epoch)" > "$DEF/Librarian.md"
+FAULTING="$(staleness_banner "$DEF" 900 "ml-1,mbp")"
+case "$FAULTING" in
+  *faulted*ml-1*) : ;;
+  *) fail "the owner's faulting scans were invisible to the deferring host: ${FAULTING:-<empty>}" ;;
+esac
+
+# A healthy owner must stay quiet here — a banner that always fires carries no
+# information, which is the failure mode the obvious hoist-the-attempt fix has.
+printf '# Librarian\n\nlast_scan: %s\n' "$(now_epoch)" > "$DEF/Librarian.md"
+[ -z "$(staleness_banner "$DEF" 900 "ml-1,mbp")" ] \
+  || fail "warned on a vault the owner is scanning fine: $(staleness_banner "$DEF" 900 "ml-1,mbp")"
+
+# A digest nobody refreshes is what a dead owner leaves: it never gets to stamp
+# INCOMPLETE. Same 2x grace the local branch allows.
+printf '# Librarian\n\nlast_scan: 1000\n' > "$DEF/Librarian.md"
+STALE_DIGEST="$(staleness_banner "$DEF" 900 "ml-1,mbp")"
+case "$STALE_DIGEST" in
+  *"last maintained"*) : ;;
+  *) fail "a digest no host has refreshed reported nothing: ${STALE_DIGEST:-<empty>}" ;;
+esac
+
+# An unparseable digest is a state to report, not one to fall silent on — and
+# the arithmetic on it must not abort the caller.
+printf '# Librarian\n\nlast_scan: not-a-number\n' > "$DEF/Librarian.md"
+BADDIGEST="$(staleness_banner "$DEF" 900 "ml-1,mbp")" \
+  || fail "an unreadable digest aborted staleness_banner"
+case "$BADDIGEST" in
+  *unreadable*) : ;;
+  *) fail "an unreadable digest produced no warning: ${BADDIGEST:-<empty>}" ;;
+esac
+
+# This host's own state still wins when it has any: the vault fallback is for
+# hosts with nothing local to speak from, not a second opinion over one.
+keeper_record_scan "$DEF"
+[ -z "$(staleness_banner "$DEF" 900 "ml-1,mbp")" ] \
+  || fail "a host with a fresh local scan was overruled by the vault digest"
+
 echo "PASS: keeper-state"

--- a/tests/keeper-state.sh
+++ b/tests/keeper-state.sh
@@ -87,4 +87,67 @@ case "$BADA" in
   *) fail "an unreadable last_attempt produced no distinct warning: ${BADA:-<empty>}" ;;
 esac
 
+# --- degraded state files: empty is not absent, and absent is not healthy (#94) ---
+#
+# `>` truncates on open and can then fail on write, so a zero-byte state file is
+# exactly what ENOSPC leaves behind — the disk shape the #49 fd/disk gate was
+# written for. Reading it through `cat` alone made it indistinguishable from a
+# file that was never written.
+
+# keeper_read_ts tells the three states apart, which is what the banner branches on.
+RT="$TMP/rt"; mkdir -p "$RT"
+RC=0; keeper_read_ts "$RT/absent" >/dev/null || RC=$?
+[ "$RC" = "1" ] || fail "a missing state file must read as absent (rc 1), got rc $RC"
+: > "$RT/empty"
+RC=0; keeper_read_ts "$RT/empty" >/dev/null || RC=$?
+[ "$RC" = "2" ] || fail "a zero-byte state file must read as unparseable (rc 2), got rc $RC"
+printf 'abc\n' > "$RT/junk"
+RC=0; keeper_read_ts "$RT/junk" >/dev/null || RC=$?
+[ "$RC" = "2" ] || fail "a non-numeric state file must read as unparseable (rc 2), got rc $RC"
+printf '1712345678\n' > "$RT/good"
+[ "$(keeper_read_ts "$RT/good")" = "1712345678" ] || fail "a valid timestamp did not read back"
+
+# An empty last_scan alongside a valid attempt used to print "never completed a
+# scan" on a host that had just completed one — loud, and wrong.
+keeper_record_attempt "$VAULT"
+: > "$(keeper_last_scan_file "$VAULT")"
+EMPTY_SCAN="$(staleness_banner "$VAULT" 900)" \
+  || fail "an empty last_scan aborted staleness_banner"
+case "$EMPTY_SCAN" in
+  *unreadable*) : ;;
+  *never*) fail "an empty last_scan was reported as a host that never scanned: $EMPTY_SCAN" ;;
+  *) fail "an empty last_scan produced no distinct warning: ${EMPTY_SCAN:-<empty>}" ;;
+esac
+
+# The mirror case: an empty last_attempt with no last_scan used to take the
+# never-attempted branch and stay silent on a host that has attempted and never
+# completed — back in the silence #52 removed.
+rm -f "$(keeper_last_scan_file "$VAULT")"
+: > "$(keeper_last_attempt_file "$VAULT")"
+EMPTY_ATT="$(staleness_banner "$VAULT" 900)" \
+  || fail "an empty last_attempt aborted staleness_banner"
+case "$EMPTY_ATT" in
+  *unreadable*) : ;;
+  *) fail "an empty last_attempt read as 'nothing has tried here': ${EMPTY_ATT:-<empty>}" ;;
+esac
+
+# Recording stages and swaps, so a state file is never observed half-written and
+# no temp file is left in the cache dir.
+rm -f "$(keeper_last_attempt_file "$VAULT")"
+keeper_record_scan "$VAULT" || fail "keeper_record_scan failed"
+[ -n "$(keeper_last_scan "$VAULT")" ] || fail "record_scan wrote no timestamp"
+STRAY="$(find "$(keeper_cache_dir "$VAULT")" -maxdepth 1 -name '.ts-*' | wc -l | tr -d ' ')"
+[ "$STRAY" = "0" ] || fail "record_scan left $STRAY staged temp file(s) behind"
+
+# A cache dir that cannot be written reports the failure rather than claiming a
+# scan the tick could not account for (vaultkeeper-tick.sh branches on this rc).
+if [ "$(id -u)" = "0" ]; then
+  printf 'skip: unwritable-cache-dir assertion (running as root ignores 0555)\n' >&2
+else
+  chmod 555 "$(keeper_cache_dir "$VAULT")"
+  keeper_record_attempt "$VAULT" 2>/dev/null \
+    && { chmod 755 "$(keeper_cache_dir "$VAULT")"; fail "recording into an unwritable cache dir reported success"; }
+  chmod 755 "$(keeper_cache_dir "$VAULT")"
+fi
+
 echo "PASS: keeper-state"

--- a/tests/note-hash.sh
+++ b/tests/note-hash.sh
@@ -38,6 +38,37 @@ case "$MT" in
   ''|*[!0-9]*) fail "file_mtime returned a non-epoch: [$MT]" ;;
 esac
 
+# The real proof, on any host: stub `stat` so the BSD spelling behaves the way
+# GNU stat does — `-f` SUCCEEDS and answers with filesystem stats. On a BSD host
+# both assertions above pass with the old implementation too, since native
+# `stat -f %m` returns a clean epoch there; only this case fails unless
+# file_mtime validates the answer and falls through to `-c %Y`.
+STUB="$TMP/stubbin"; mkdir -p "$STUB"
+cat > "$STUB/stat" <<'STUBEOF'
+#!/usr/bin/env bash
+# GNU stat reads -f as "report the filesystem": exit 0, non-numeric output.
+case "$1" in
+  -f) printf '  File: "%s"
+    ID: 0        Namelen: 255     Type: ext2/ext3
+' "${3:-x}"; exit 0 ;;
+  -c) [ "$2" = "%Y" ] && { printf '1712345678
+'; exit 0; } ;;
+esac
+exit 1
+STUBEOF
+chmod +x "$STUB/stat"
+STUBBED="$(PATH="$STUB:$PATH" bash -c ". '$ROOT_DIR/scripts/lib/note-hash.sh'; file_mtime '$TMP/a.md'")"   || fail "file_mtime failed when only the GNU spelling answers"
+[ "$STUBBED" = "1712345678" ]   || fail "file_mtime trusted the exit status of a stat -f that answers with filesystem stats: [$STUBBED]"
+
+# Neither spelling answering is a hard failure, not a fabricated epoch.
+cat > "$STUB/stat" <<'STUBEOF'
+#!/usr/bin/env bash
+exit 1
+STUBEOF
+chmod +x "$STUB/stat"
+PATH="$STUB:$PATH" bash -c ". '$ROOT_DIR/scripts/lib/note-hash.sh'; file_mtime '$TMP/a.md'" >/dev/null 2>&1   && fail "file_mtime succeeded when no stat spelling answered"
+rm -rf "$STUB"
+
 # A path no stat spelling can answer must fail loudly, not echo something the
 # caller will do arithmetic on.
 file_mtime "$TMP/definitely-not-here.md" >/dev/null 2>&1 \

--- a/tests/note-hash.sh
+++ b/tests/note-hash.sh
@@ -29,4 +29,18 @@ note_hash_valid "" && fail "should reject empty"
 M="$(file_mtime "$TMP/a.md")"; [[ "$M" =~ ^[0-9]+$ ]] || fail "file_mtime not integer: $M"
 N="$(now_epoch)"; [[ "$N" =~ ^[0-9]+$ ]] || fail "now_epoch not integer: $N"
 
+# The two spellings cannot be told apart by exit status: GNU stat reads `-f` as
+# a filesystem query and SUCCEEDS on it, returning a block of filesystem stats.
+# Trusting that answer gave every caller a non-numeric mtime — vault_index_plan
+# then errored per file and silently hashed every note it walked.
+MT="$(file_mtime "$TMP/a.md")"
+case "$MT" in
+  ''|*[!0-9]*) fail "file_mtime returned a non-epoch: [$MT]" ;;
+esac
+
+# A path no stat spelling can answer must fail loudly, not echo something the
+# caller will do arithmetic on.
+file_mtime "$TMP/definitely-not-here.md" >/dev/null 2>&1 \
+  && fail "file_mtime succeeded on a missing file"
+
 echo "PASS: note-hash"

--- a/tests/resolve-config.sh
+++ b/tests/resolve-config.sh
@@ -75,4 +75,28 @@ GOT=$(env XDG_CONFIG_HOME="$XDG" bash "$RESOLVER" --stable)
 [ "$GOT" = "$STABLE" ] || fail "case6 (--stable): got '$GOT' want '$STABLE'"
 PASS_COUNT=$((PASS_COUNT + 1))
 
-printf '%d/6 cases passed\n' "$PASS_COUNT"
+# ----- Case 7: obsidian_config_value reads frontmatter scalars -----
+# The reader dedup_same_day and ask-staleness both go through. It is bounded to
+# the frontmatter block (a config's prose can open a line with `vault_path:` in
+# an example) and strips YAML quotes, so a quoted number reads as the number.
+. "$RESOLVER"
+CV="$XDG/cfgvalue.md"
+mkdir -p "$(dirname "$CV")"
+printf -- '---\nvault_path: /vaults/main\ndedup_jaccard_threshold: "0.2"\nspaced:   0.5   \n---\n\nProse below the frontmatter:\nvault_path: /decoy\n' > "$CV"
+export OBSIDIAN_LOCAL_MD="$CV"
+[ "$(obsidian_config_value vault_path)" = "/vaults/main" ] \
+  || fail "case7: prose below the frontmatter answered ahead of it: '$(obsidian_config_value vault_path)'"
+[ "$(obsidian_config_value dedup_jaccard_threshold)" = "0.2" ] \
+  || fail "case7: a quoted scalar kept its quotes: '$(obsidian_config_value dedup_jaccard_threshold)'"
+[ "$(obsidian_config_value spaced)" = "0.5" ] \
+  || fail "case7: surrounding whitespace was not trimmed: '$(obsidian_config_value spaced)'"
+set +e; obsidian_config_value definitely_absent >/dev/null; RC=$?; set -e
+[ "$RC" -eq 1 ] || fail "case7: an absent key must return 1, got $RC"
+# A config with no frontmatter at all still reads, rather than going silent.
+printf 'vault_path: /nofm\n' > "$CV"
+[ "$(obsidian_config_value vault_path)" = "/nofm" ] \
+  || fail "case7: a config without frontmatter markers read as empty"
+unset OBSIDIAN_LOCAL_MD
+PASS_COUNT=$((PASS_COUNT + 1))
+
+printf '%d/7 cases passed\n' "$PASS_COUNT"

--- a/tests/resolve-config.sh
+++ b/tests/resolve-config.sh
@@ -82,7 +82,7 @@ PASS_COUNT=$((PASS_COUNT + 1))
 . "$RESOLVER"
 CV="$XDG/cfgvalue.md"
 mkdir -p "$(dirname "$CV")"
-printf -- '---\nvault_path: /vaults/main\ndedup_jaccard_threshold: "0.2"\nspaced:   0.5   \n---\n\nProse below the frontmatter:\nvault_path: /decoy\n' > "$CV"
+printf -- '---\nvault_path: /vaults/main\ndedup_jaccard_threshold: "0.2"\nspaced:   0.5   \ncommented: /vaults/commented  # where the notes live\nhashy: /vaults/#inbox\nquoted_comment: "0.3"  # tuned down\n---\n\nProse below the frontmatter:\nvault_path: /decoy\nprose_only_key: /also-decoy\n' > "$CV"
 export OBSIDIAN_LOCAL_MD="$CV"
 [ "$(obsidian_config_value vault_path)" = "/vaults/main" ] \
   || fail "case7: prose below the frontmatter answered ahead of it: '$(obsidian_config_value vault_path)'"
@@ -92,6 +92,20 @@ export OBSIDIAN_LOCAL_MD="$CV"
   || fail "case7: surrounding whitespace was not trimmed: '$(obsidian_config_value spaced)'"
 set +e; obsidian_config_value definitely_absent >/dev/null; RC=$?; set -e
 [ "$RC" -eq 1 ] || fail "case7: an absent key must return 1, got $RC"
+# The decoy above sits BELOW the real key, so awk's first-match exit wins on
+# file order alone and would pass with no frontmatter bound at all. A key that
+# appears ONLY in the prose body is what actually pins the bound.
+set +e; obsidian_config_value prose_only_key >/dev/null; RC=$?; set -e
+[ "$RC" -eq 1 ] \
+  || fail "case7: a key present only below the frontmatter resolved: '$(obsidian_config_value prose_only_key)'"
+# YAML noise the hand-rolled readers each stripped differently: a trailing
+# comment, and a `#` that is part of the value rather than a comment.
+[ "$(obsidian_config_value commented)" = "/vaults/commented" ] \
+  || fail "case7: a trailing comment was not stripped: '$(obsidian_config_value commented)'"
+[ "$(obsidian_config_value hashy)" = "/vaults/#inbox" ] \
+  || fail "case7: a '#' inside the value was treated as a comment: '$(obsidian_config_value hashy)'"
+[ "$(obsidian_config_value quoted_comment)" = "0.3" ] \
+  || fail "case7: a quoted scalar with a trailing comment: '$(obsidian_config_value quoted_comment)'"
 # A config with no frontmatter at all still reads, rather than going silent.
 printf 'vault_path: /nofm\n' > "$CV"
 [ "$(obsidian_config_value vault_path)" = "/nofm" ] \

--- a/tests/sole-brain-save-conversation.sh
+++ b/tests/sole-brain-save-conversation.sh
@@ -35,13 +35,23 @@ echo "$FP" | grep -q 'scripts/keeper" insert' || fail "fast path missing keeper 
 [ "$(echo "$FP" | grep -n 'kspayload_validate' | head -1 | cut -d: -f1)" -lt \
   "$(echo "$FP" | grep -n 'scripts/keeper" insert' | head -1 | cut -d: -f1)" ] \
   || fail "gate ordering: kspayload_validate must precede keeper insert"
-# config sourcing must be real assignments inside the fast-path block, not
-# comments or bare variable references: $VAULT and the dedup threshold both
-# have to derive from $CONFIG
-echo "$FP" | grep -qE '^VAULT=.*vault_path.*"\$CONFIG"' \
-  || fail "fast path must assign VAULT from \$CONFIG vault_path"
-echo "$FP" | grep -qE '^THRESHOLD=.*dedup_jaccard_threshold.*"\$CONFIG"' \
-  || fail "fast path must read dedup_jaccard_threshold from \$CONFIG"
+# Config sourcing must be a real assignment inside the fast-path block, not a
+# comment or a bare variable reference: $VAULT has to come from the config, and
+# it now comes through obsidian_config_value — the one reader that bounds
+# itself to the frontmatter and strips YAML quotes, rather than a grep/sed of
+# $CONFIG open-coded here.
+echo "$FP" | grep -qE '^VAULT="\$\(obsidian_config_value vault_path\)"' \
+  || fail "fast path must assign VAULT via obsidian_config_value vault_path"
+echo "$FP" | grep -q 'resolve-config.sh"$' \
+  || fail "fast path must source resolve-config.sh to get obsidian_config_value"
+# The threshold is the scanner's to resolve (#103). Re-parsing it here is what
+# let the two disagree, so the fast path must NOT hand-roll it.
+echo "$FP" | grep -qE '^THRESHOLD=' \
+  && fail "fast path re-parses the threshold; dedup_same_day resolves it now"
+echo "$FP" | grep -qE 'dedup_same_day "[^"]*" "\$\(date \+%Y-%m-%d\)" "<slug>"$' \
+  || fail "fast path must call dedup_same_day without a threshold argument"
+echo "$FP" | grep -q '<vault_path>/' \
+  && fail "fast path left an unexpanded <vault_path> placeholder in a real command"
 echo "$FP" | grep -q -- '--vault "\$VAULT"' \
   || fail "keeper insert must consume the sourced \$VAULT"
 echo "PASS: sole-brain-save-conversation"


### PR DESCRIPTION
All six open issues, worked easiest to hardest, plus the gaps three review rounds turned up. Every ticket is a silent failure — something that fails in a direction nobody hears — so each fix has coverage that fails without it.

## #101 — `--skip-if-hash` could never match the heading commit-capture writes

The gate anchored the sha to the **end** of a heading, but every commit capture writes it at the start (`## 7ac9556 — msg`), so the only guard against a double capture never fired. It now matches the sha anywhere in a heading, with hex-class boundaries (BSD grep/awk carry no `\b`) and a case-folded compare, since the validator accepts `[0-9a-fA-F]`. Heading-only is preserved — a context bullet naming another commit's sha must not suppress that commit's own record.

The match runs in `awk` rather than `grep -E '^#' | grep -q`: `-q`'s early exit SIGPIPEs the upstream grep, which `set -o pipefail` then reports as a failed match.

## #104 — `keeper insert` swallowed an INDEX-link failure via `|| true`

The note is written before the link step, so a failed link still printed the path and exited 0: the caller relayed success for a note nothing linked. `insert` now verifies the link after the apply and warns on stderr naming the note and the INDEX. Checking `vault_index_apply`'s rc alone would miss the common shape — a coverage defect is only reported on its stderr and still returns 0. Exit status stays 0, because the note itself did commit.

## #100 — `keeper append` wrote `--section` as plain text

A bare title landed as a paragraph: content intact, but absent from Obsidian's outline — and invisible to the heading-shaped `--skip-if-hash` gate above, so the same commit could capture twice. A bare value is now promoted to a level-2 heading; a value that already carries its own `#` prefix is kept verbatim so the caller picks the level; a whitespace-only value falls back to the default heading rather than emitting an empty one.

## #103 — the `dedup_jaccard_threshold` override reached no call site

The full save-conversation procedure interpolated a shell variable nothing ever set, and the librarian passed no threshold at all, so both ran at the library's 0.4 while the vault said otherwise. Resolved in the scanner instead of at each call site, since that is what the call sites kept failing to do: `dedup_same_day` reads the setting when given no threshold argument, via a new `obsidian_config_value` reader in `resolve-config.sh`. An explicit argument still wins — and is validated the same way, so a malformed one cannot reach `awk`, where a non-numeric threshold compares as 0 and matches the first note in the folder.

## #94 — epoch state files were read unvalidated

A zero-byte file — what ENOSPC leaves, since `>` truncates on open and can then fail on write — read as absent: an empty `last_attempt` made the banner take the never-attempted branch and stay quiet on a host that has attempted and never completed, and the mirror case printed "index has never completed a scan" on a host that just completed one.

One validated reader now serves both, separating the three states the banner has to distinguish rather than collapsing them onto emptiness: rc 0 with the value, rc 1 for no file, rc 2 for a file holding no timestamp. `staleness_banner` gets its third branch for that last state. Writes stage into the target's own directory and swap, so a failed write leaves the previous timestamp rather than a zero-byte file — and the `mv` is a rename, not a cross-filesystem copy. `ask-staleness.sh` no longer swallows its own failure, and no longer aborts before reaching it.

## #95 — a deferring host had no signal that the owner's scans are faulting

Not fixed by hoisting `keeper_record_attempt` above the ownership gate: that makes a deferring host claim an attempt it never made and warn forever about a vault the owner is scanning fine, which `tests/vaultkeeper-tick.sh` pins. The evidence is already in the vault and the banner ignored it. Where the host has no local state at all, it now reads what is synced — `Librarian.md`, which the owner stamps `scan_status: INCOMPLETE` into on every faulted tick, and the lease dir, which names the owner.

Four states, three of them a line: no claim by any host means the keeper has never run anywhere and stays quiet; a claim with no digest means no host has completed a scan; `INCOMPLETE` means the owner is faulting; and a digest nobody has refreshed past the same 2× grace the local branch allows is what a dead owner leaves, since it never gets to stamp `INCOMPLETE`. A healthy digest stays silent, and a host with local state is unaffected. The owner is named through `keeper_elect` rather than a second implementation of election.

## One bug found outside the tickets

`file_mtime` probed the two `stat` spellings by exit status: try BSD `-f %m`, fall back if it produced nothing. GNU `stat` reads `-f` as "report the filesystem" and **succeeds**, so on Linux every caller got a block of filesystem stats back as an mtime — `vault_index_plan` compared it with `-gt`, errored once per file, and silently hashed every note it walked, which is the entire cost the mtime gate exists to avoid. It now validates the answer instead of trusting the status.

## What review changed

**Round 1** — two of the six fixes did not reach a user as first written. The Codex package carries byte-identical copies of `scripts/keeper` and the libs it sources and was not re-vendored, so Codex users kept #100 and #101. And `ask-staleness.sh` aborted before it ever reached the banner: its config reads were one unmatched grep away from a failed pipeline under `pipefail`, and `/obsidian:setup`'s template never writes `keeper_interval_secs`, so on a default install the script exited 1 with no stdout — which every consumer reads as a healthy index. Also: save-conversation's steps 3 and 6 still gated on the literal `0.4`; `dedup_same_day`'s best-so-far seed made the documented `0.0` endpoint unreachable; `insert` ran a redundant recursive `dup_leaves` sweep.

**Round 2** (`f60521e`) — the Daily session link left a stray `.ktmp` on failure, and since the note commits first, the retry then died on "target already exists". `obsidian_config_value` scanned past the frontmatter and kept YAML quotes. The fast path hand-rolled config parsing and passed an unexpanded `<vault_path>`. And two tests were passing for the wrong reason: `tests/note-hash.sh` pinned the host's own `stat`, so on macOS it would have passed with the broken `file_mtime`; `tests/keeper-cli.sh` I4b was asserting on the overwrite guard's early abort rather than the dedup it claimed to cover.

**Round 3** (`7cd0afb`) — the round-2 hardening stopped three lines short. With `Daily/` unwritable and no daily note for that date, the `mkdir`, the note write and the `## Session Links` append were still bare, so `insert` exited 1 *after* committing the note, silently — and a caller reads non-zero as "not captured". The round-2 test pre-created the daily note, which is the one fixture shape that skips those lines. Also in this round:

- `ask-staleness.sh`'s `cfg_val` re-introduced the parsing defects `obsidian_config_value` exists to remove, one line below that function. A quoted `vault_path` kept its quotes, so `keeper_vault_health` found no lease dir and took its "stay quiet" branch — #95 undone for exactly the config shape a careful user writes. `session-save.sh` had the same read on the autosave path.
- That reader now strips a trailing ` # comment` as well as quotes, which is what made adopting it safe: `agents/vault-organizer.md` already stripped comments, so routing readers through a function that didn't would have regressed it. The strip requires whitespace before the `#` (so `/notes/#inbox` survives) and is skipped inside quoted scalars.
- `dedup_threshold` fell back to `0.4` in silence when its sibling `resolve-config.sh` was missing, while the unusable-value path beside it warns loudly. It now names the missing file, in the wording `allowlist-validate.sh` and `vault-scan.sh` use.
- `vaultkeeper-tick.sh` called `keeper_record_scan` bare while `keeper-state.sh` documented it as checked. Guarded, so the comment is true.
- save-conversation's `VAULT=` was unguarded: an empty vault scans `/<target-folder>`, `find`'s `2>/dev/null` makes that "no output", and the next line says no output means proceed — a config fault becomes "no duplicate found".
- Case 7's decoy sat *below* the real key, so awk's first-match exit won on file order and the frontmatter bound was never exercised — deleting the bound left it 7/7. A key present only in the prose body now pins it.

## Test notes

Suites are green here except eight that are red on `master` too, for reasons of this container rather than the code: assertions that need a non-root user (0444/0555 mean nothing to root), an `ulimit -n 64` fd-exhaustion probe, a missing `crontab` and a missing `codex` CLI, and the two `commit-capture` suites, which resolve no config of their own and depend on the developer's `~/.config/claude-obsidian/obsidian.local.md`. `note-hash` and `vault-index-plan` were in that red set and are now green, because their cause was the real bug above.

Four assertions skip under root with a printed reason; each was verified by running the suite as `nobody`, where it fails without its fix. Every round-3 fix was reproduced before the change and mutation-tested after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsJcJR3RiUYjiVq8aUMS2S