### PR TITLE
codex-plugin: drop the duplicate vendor-parity loop, document the real one

### DIFF
--- a/tests/codex-plugin.sh
+++ b/tests/codex-plugin.sh
@@ -39,6 +39,14 @@ entry = marketplace["plugins"][0]
 assert entry["name"] == "obsidian"
 assert entry["source"] == {"source": "local", "path": "./packages/codex"}
 
+# Vendor parity. The copies under packages/codex are maintained by hand — this
+# branch alone carried seven fixes across that boundary — and the installed
+# keeper is otherwise exercised only through shapes that predate them, so a
+# copy drifting back would go unnoticed without this.
+#
+# It lives HERE, above the `command -v codex` gate below, on purpose: drift is
+# most likely on a machine that has no codex CLI, and a parity check placed
+# after that gate never runs in exactly the environment it is meant to protect.
 for relative in (
     "commit-meta.sh",
     "keeper",
@@ -135,24 +143,5 @@ if env -u OBSIDIAN_LOCAL_MD XDG_CONFIG_HOME="$TMP/no-config" \
   fail "commit-meta succeeded without a configured vault"
 fi
 grep -q 'vault_path unresolved' "$TMP/missing.err" || fail "missing config failure was not truthful"
-
-# The vendored copies are maintained by hand: this PR alone carried six fixes
-# across the boundary. Nothing compared them, and the suite exercises the
-# installed keeper only through shapes that predate those fixes -- so a copy
-# drifting back would have gone unnoticed. Compare the bytes.
-for VENDORED in \
-  scripts/keeper \
-  scripts/lib/note-hash.sh \
-  scripts/lib/resolve-config.sh \
-  scripts/lib/vault-index.sh \
-  scripts/lib/commit-capture-parse.sh
-do
-  SRC="$ROOT_DIR/$VENDORED"
-  DST="$ROOT_DIR/packages/codex/skills/commit-capture/$VENDORED"
-  [ -f "$SRC" ] || fail "vendor parity: $VENDORED is missing from scripts/"
-  [ -f "$DST" ] || fail "vendor parity: $VENDORED is missing from the codex package"
-  cmp -s "$SRC" "$DST" \
-    || fail "vendor parity: packages/codex copy of $VENDORED has drifted from scripts/"
-done
 
 printf 'PASS: installed Codex manual commit-capture package\n'


### PR DESCRIPTION
Follow-up to #105. This was pushed to that branch a couple of minutes after it merged, so it missed the squash — opening it separately rather than reusing a merged PR.

`tests/codex-plugin.sh` currently ends with a byte-parity loop over five vendored files. The intent is right, but the placement defeats it: the block sits **below** the `command -v codex` gate at `:55`, and `fail` exits, so the loop never runs on a machine without the codex CLI — which is exactly the machine where a hand-maintained copy drifts unnoticed.

It is also redundant. The python contract at `:42-52` already compares bytes for all **six** vendored files — a superset, it includes `commit-meta.sh` — and it runs above the gate.

Demonstrated on this branch with no codex CLI installed, drifting `packages/codex/.../scripts/keeper` by one line:

```
AssertionError: keeper
FAIL: Codex package contract failed
```

That is the existing check firing, unaided.

So the loop is removed, and the check that does the work now says what it pins and why it has to stay above the gate. That gap is the substantive part of this change: the coverage has now been read as absent twice — once in a review of #105, once when the duplicate was written — which suggests what was missing was the comment, not the check.

No production code touched; `tests/codex-plugin.sh` only. Suite state is unchanged: the same eight suites fail here as on `master`, all for container reasons (root ignoring 0444/0555, an `ulimit -n` probe, missing `crontab` and `codex` CLIs, and the two `commit-capture` suites depending on a developer's `~/.config/claude-obsidian/obsidian.local.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsJcJR3RiUYjiVq8aUMS2S

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsJcJR3RiUYjiVq8aUMS2S)_