### PR TITLE
Fix clean-checkout test failures and substrate polish (#108, #109)

### DIFF
--- a/packages/codex/skills/commit-capture/scripts/keeper
+++ b/packages/codex/skills/commit-capture/scripts/keeper
@@ -54,8 +54,18 @@ keeper_guard_target() {
 keeper_heading_has_sha() {
   awk -v sha="$2" '
     BEGIN { sha = tolower(sha); pat = "(^|[^0-9a-f])" sha "([^0-9a-f]|$)" }
-    /^```/ || /^~~~/ { in_fence = !in_fence; next }
-    !in_fence && $1 ~ /^##?#?#?#?#?$/ && NF > 1 && tolower($0) ~ pat { found = 1; exit }
+    # Track the OPEN delimiter, not a bare toggle. A single boolean shared by
+    # ``` and ~~~ mis-reads a note that mixes them -- a doc illustrating this
+    # very format -- and an illustrative heading then scans as a real capture,
+    # which reports a commit as already captured and silently drops it.
+    # CommonMark: a fence closes only on the same char, at least as long.
+    /^(```+|~~~+)/ {
+      run = $0; sub(/[^`~].*$/, "", run); ch = substr(run, 1, 1); n = length(run)
+      if (fence_ch == "") { fence_ch = ch; fence_n = n }
+      else if (ch == fence_ch && n >= fence_n) { fence_ch = ""; fence_n = 0 }
+      next
+    }
+    fence_ch == "" && $1 ~ /^##?#?#?#?#?$/ && NF > 1 && tolower($0) ~ pat { found = 1; exit }
     END { exit(found ? 0 : 1) }
   ' "$1"
 }

--- a/packages/codex/skills/commit-capture/scripts/keeper
+++ b/packages/codex/skills/commit-capture/scripts/keeper
@@ -54,7 +54,8 @@ keeper_guard_target() {
 keeper_heading_has_sha() {
   awk -v sha="$2" '
     BEGIN { sha = tolower(sha); pat = "(^|[^0-9a-f])" sha "([^0-9a-f]|$)" }
-    $1 ~ /^##?#?#?#?#?$/ && NF > 1 && tolower($0) ~ pat { found = 1; exit }
+    /^```/ || /^~~~/ { in_fence = !in_fence; next }
+    !in_fence && $1 ~ /^##?#?#?#?#?$/ && NF > 1 && tolower($0) ~ pat { found = 1; exit }
     END { exit(found ? 0 : 1) }
   ' "$1"
 }
@@ -264,7 +265,7 @@ cmd_insert() {
       # itself committed above, the obvious retry then died on
       # "target already exists". Warn and keep exit 0, like the INDEX link.
       local dtmp
-      if dtmp="$(mktemp "$vault_abs/Daily/.ktmp-XXXXXX")"; then
+      if dtmp="$(mktemp "$vault_abs/Daily/.Daily-XXXXXX")"; then
         if awk -v link="$link" '{print} /^## Session Links/ && !d {print link; d=1}' \
              "$daily" > "$dtmp" && keeper_swap_or_clean "$dtmp" "$daily"; then
           :

--- a/packages/codex/skills/commit-capture/scripts/lib/resolve-config.sh
+++ b/packages/codex/skills/commit-capture/scripts/lib/resolve-config.sh
@@ -59,7 +59,7 @@ obsidian_config_value() {
   # `#` — a bare one is part of the value, so a vault at /notes/#inbox keeps
   # its name — and is skipped inside a quoted scalar, where `#` is literal.
   v="$(awk -v k="$key" '
-    NR == 1 { fm = ($0 ~ /^---[[:space:]]*$/); if (fm) next }
+    NR == 1 { if ($0 ~ /^---[[:space:]]*$/) { fm = 1; next } else { exit } }
     fm && $0 ~ /^---[[:space:]]*$/ { exit }
     index($0, k ":") == 1 {
       sub(/^[^:]*:[[:space:]]*/, "")

--- a/scripts/keeper
+++ b/scripts/keeper
@@ -54,8 +54,18 @@ keeper_guard_target() {
 keeper_heading_has_sha() {
   awk -v sha="$2" '
     BEGIN { sha = tolower(sha); pat = "(^|[^0-9a-f])" sha "([^0-9a-f]|$)" }
-    /^```/ || /^~~~/ { in_fence = !in_fence; next }
-    !in_fence && $1 ~ /^##?#?#?#?#?$/ && NF > 1 && tolower($0) ~ pat { found = 1; exit }
+    # Track the OPEN delimiter, not a bare toggle. A single boolean shared by
+    # ``` and ~~~ mis-reads a note that mixes them -- a doc illustrating this
+    # very format -- and an illustrative heading then scans as a real capture,
+    # which reports a commit as already captured and silently drops it.
+    # CommonMark: a fence closes only on the same char, at least as long.
+    /^(```+|~~~+)/ {
+      run = $0; sub(/[^`~].*$/, "", run); ch = substr(run, 1, 1); n = length(run)
+      if (fence_ch == "") { fence_ch = ch; fence_n = n }
+      else if (ch == fence_ch && n >= fence_n) { fence_ch = ""; fence_n = 0 }
+      next
+    }
+    fence_ch == "" && $1 ~ /^##?#?#?#?#?$/ && NF > 1 && tolower($0) ~ pat { found = 1; exit }
     END { exit(found ? 0 : 1) }
   ' "$1"
 }

--- a/scripts/keeper
+++ b/scripts/keeper
@@ -54,7 +54,8 @@ keeper_guard_target() {
 keeper_heading_has_sha() {
   awk -v sha="$2" '
     BEGIN { sha = tolower(sha); pat = "(^|[^0-9a-f])" sha "([^0-9a-f]|$)" }
-    $1 ~ /^##?#?#?#?#?$/ && NF > 1 && tolower($0) ~ pat { found = 1; exit }
+    /^```/ || /^~~~/ { in_fence = !in_fence; next }
+    !in_fence && $1 ~ /^##?#?#?#?#?$/ && NF > 1 && tolower($0) ~ pat { found = 1; exit }
     END { exit(found ? 0 : 1) }
   ' "$1"
 }
@@ -264,7 +265,7 @@ cmd_insert() {
       # itself committed above, the obvious retry then died on
       # "target already exists". Warn and keep exit 0, like the INDEX link.
       local dtmp
-      if dtmp="$(mktemp "$vault_abs/Daily/.ktmp-XXXXXX")"; then
+      if dtmp="$(mktemp "$vault_abs/Daily/.Daily-XXXXXX")"; then
         if awk -v link="$link" '{print} /^## Session Links/ && !d {print link; d=1}' \
              "$daily" > "$dtmp" && keeper_swap_or_clean "$dtmp" "$daily"; then
           :

--- a/scripts/lib/keeper-lease.sh
+++ b/scripts/lib/keeper-lease.sh
@@ -14,8 +14,11 @@ keeper_claim_write() {
 keeper_live_hosts() {
   local dir="$1" max_age="${2:-}" now c host ts
   now="$(now_epoch)"
-  for c in "$dir"/.keeper-claim-*; do
-    [ -e "$c" ] || continue
+  # find, not a glob: zsh's NOMATCH aborts on an unmatched pattern and applies
+  # to `for ... in <glob>` like any other expansion, so an empty claim dir would
+  # take out keeper_elect with it. Matches keeper_vault_health's approach.
+  while IFS= read -r c; do
+    [ -n "$c" ] || continue
     host="${c##*/.keeper-claim-}"
     if [ -n "$max_age" ]; then
       ts="$(cat "$c" 2>/dev/null)"
@@ -23,7 +26,9 @@ keeper_live_hosts() {
       [ "$(( now - ts ))" -le "$max_age" ] || continue
     fi
     printf '%s\n' "$host"
-  done
+  done <<EOF
+$(find "$dir" -maxdepth 1 -name '.keeper-claim-*' 2>/dev/null)
+EOF
 }
 
 keeper_elect() {

--- a/scripts/lib/keeper-state.sh
+++ b/scripts/lib/keeper-state.sh
@@ -109,8 +109,14 @@ keeper_vault_health() {
   # and not this host's to report. A vault nobody has ever pointed the keeper at
   # must stay quiet.
   [ -d "$lease" ] || return 0
-  set -- "$lease"/.keeper-claim-*
-  [ -e "$1" ] || return 0
+  local has_claim=0 c
+  for c in "$lease"/.keeper-claim-*; do
+    if [ -e "$c" ]; then
+      has_claim=1
+      break
+    fi
+  done
+  [ "$has_claim" -eq 1 ] || return 0
 
   # Name the owner when the caller has sourced keeper-lease.sh; election is that
   # file's business, and a banner is not worth a second implementation of it.

--- a/scripts/lib/keeper-state.sh
+++ b/scripts/lib/keeper-state.sh
@@ -109,14 +109,12 @@ keeper_vault_health() {
   # and not this host's to report. A vault nobody has ever pointed the keeper at
   # must stay quiet.
   [ -d "$lease" ] || return 0
-  local has_claim=0 c
-  for c in "$lease"/.keeper-claim-*; do
-    if [ -e "$c" ]; then
-      has_claim=1
-      break
-    fi
-  done
-  [ "$has_claim" -eq 1 ] || return 0
+  # find, not a glob: zsh's NOMATCH aborts on an unmatched pattern, and it
+  # applies to `for ... in <glob>` exactly as to any other expansion -- so
+  # neither `set -- <glob>` nor a for-loop survives an empty lease dir there.
+  # These libs are documented bash+zsh clean (see scripts/keeper's header).
+  [ -n "$(find "$lease" -maxdepth 1 -name '.keeper-claim-*' -print -quit 2>/dev/null)" ] \
+    || return 0
 
   # Name the owner when the caller has sourced keeper-lease.sh; election is that
   # file's business, and a banner is not worth a second implementation of it.

--- a/scripts/lib/resolve-config.sh
+++ b/scripts/lib/resolve-config.sh
@@ -59,7 +59,7 @@ obsidian_config_value() {
   # `#` — a bare one is part of the value, so a vault at /notes/#inbox keeps
   # its name — and is skipped inside a quoted scalar, where `#` is literal.
   v="$(awk -v k="$key" '
-    NR == 1 { fm = ($0 ~ /^---[[:space:]]*$/); if (fm) next }
+    NR == 1 { if ($0 ~ /^---[[:space:]]*$/) { fm = 1; next } else { exit } }
     fm && $0 ~ /^---[[:space:]]*$/ { exit }
     index($0, k ":") == 1 {
       sub(/^[^:]*:[[:space:]]*/, "")

--- a/tests/ask-staleness.sh
+++ b/tests/ask-staleness.sh
@@ -87,10 +87,17 @@ esac
 # The entrypoint must not let its own failure pass as a clean bill of health:
 # it runs under set -e with staleness_banner as its last command, so an abort
 # there exits 1 with no stdout — and stdout is the only channel the consumers
-# read ("if it prints a line, show it"). Pinned by inspection because nothing
-# reachable through this script can make the banner abort any more; that is the
-# property, and the guard is what preserves it.
-grep -q 'staleness_banner .*||' "${ROOT_DIR}/scripts/ask-staleness.sh" \
-  || fail "ask-staleness.sh no longer guards the banner call; a failed check would print nothing"
+# read ("if it prints a line, show it").
+FLIB="$TMP/fault-lib"; mkdir -p "$FLIB/lib"
+cp "${ROOT_DIR}/scripts/"*.sh "$FLIB/" 2>/dev/null || true
+cp "${ROOT_DIR}/scripts/lib/"*.sh "$FLIB/lib/"
+cat >> "$FLIB/lib/keeper-state.sh" <<'EOF'
+staleness_banner() { return 1; }
+EOF
+FAIL_BANNER="$(OBSIDIAN_LOCAL_MD="$MIN" bash "$FLIB/ask-staleness.sh")"
+case "$FAIL_BANNER" in
+  *"could not determine index freshness"*) : ;;
+  *) fail "a failed staleness_banner did not print the fallback banner; got: ${FAIL_BANNER:-<empty>}" ;;
+esac
 
 echo "PASS: ask-staleness"

--- a/tests/commit-capture-head-gate.sh
+++ b/tests/commit-capture-head-gate.sh
@@ -387,6 +387,7 @@ esac
 reset_state
 UP="$WORK/upstream.git"
 git init -q --bare "$UP"
+git -C "$UP" symbolic-ref HEAD refs/heads/main
 THEIRS="$WORK/theirs"
 mkrepo "$THEIRS" "$UP"
 git -C "$THEIRS" config user.email teammate@example.com
@@ -428,6 +429,7 @@ esac
 reset_state
 UP2="$WORK/upstream2.git"
 git init -q --bare "$UP2"
+git -C "$UP2" symbolic-ref HEAD refs/heads/main
 OTHER="$WORK/other-machine"
 mkrepo "$OTHER" "$UP2"
 git -C "$OTHER" config user.email me@example.com

--- a/tests/dedup-scan.sh
+++ b/tests/dedup-scan.sh
@@ -104,6 +104,17 @@ grep -q 'unusable threshold argument' "$TMP/quoted.err" \
 OOR="$(OBSIDIAN_DEDUP_JACCARD_THRESHOLD=10 dedup_same_day "$TMP/t" 2026-06-29 keeper-cli 2>"$TMP/oor.err")"
 grep -q 'unusable dedup_jaccard_threshold' "$TMP/oor.err" \
   || fail "an out-of-range threshold was accepted silently:"$'\n'"$(cat "$TMP/oor.err")"
+OOR_FLOAT="$(OBSIDIAN_DEDUP_JACCARD_THRESHOLD=1.5 dedup_same_day "$TMP/t" 2026-06-29 keeper-cli 2>"$TMP/oor_f.err")"
+grep -q 'unusable dedup_jaccard_threshold' "$TMP/oor_f.err" \
+  || fail "a threshold > 1 was accepted silently:"$'\n'"$(cat "$TMP/oor_f.err")"
+OOR_NEG="$(OBSIDIAN_DEDUP_JACCARD_THRESHOLD=-0.5 dedup_same_day "$TMP/t" 2026-06-29 keeper-cli 2>"$TMP/oor_neg.err")"
+grep -q 'unusable dedup_jaccard_threshold' "$TMP/oor_neg.err" \
+  || fail "a negative threshold was accepted silently:"$'\n'"$(cat "$TMP/oor_neg.err")"
+
+# A leading-dot threshold (.5) is valid and must be accepted without warning.
+LEADING_DOT="$(OBSIDIAN_DEDUP_JACCARD_THRESHOLD=.5 dedup_same_day "$TMP/t" 2026-06-29 keeper-cli 2>"$TMP/dot.err")"
+[ ! -s "$TMP/dot.err" ] \
+  || fail "a leading-dot threshold (.5) was incorrectly rejected:"$'\n'"$(cat "$TMP/dot.err")"
 
 # The library resolves the vault threshold through its sibling resolve-config.sh.
 # If that file is missing the install is broken, not the config — and staying

--- a/tests/keeper-cli.sh
+++ b/tests/keeper-cli.sh
@@ -145,6 +145,16 @@ bash "$KEEPER" append --vault "$V" --target "Notes/boundary.md" \
 grep -q '^## abc1234 — the commit we mean' "$V/Notes/boundary.md" \
   || fail "a heading for a longer sha with the same prefix suppressed a distinct commit"
 
+# 17e. fence tracking: a heading inside a code fence must not suppress capture.
+printf '%s\n' '```markdown' '## deadbee — some diff heading' '```' > "$TMP/fenced.md"
+bash "$KEEPER" append --vault "$V" --target "Notes/fenced.md" \
+  --section '## 18:00 — init' --body-file "$TMP/fenced.md" >/dev/null
+FENCE_BEFORE="$(cat "$V/Notes/fenced.md")"
+bash "$KEEPER" append --vault "$V" --target "Notes/fenced.md" \
+  --section '## deadbee — real commit' --body-file "$TMP/b.md" --skip-if-hash deadbee >/dev/null
+[ "$(cat "$V/Notes/fenced.md")" != "$FENCE_BEFORE" ] \
+  || fail "a heading inside a code fence suppressed the commit's capture"
+
 # 18. a malformed --skip-if-hash fails loudly. Silently treating an unusable
 #     value as "no guard" turns a typo into a duplicate note, which is the
 #     failure this flag exists to prevent.
@@ -305,9 +315,9 @@ else
   [ "$LOCKDAY_RC" = "0" ] \
     || fail "the note committed, so insert must still exit 0; rc=$LOCKDAY_RC"
   [ -f "$V/Notes/2026-07-01-locked-daily.md" ] || fail "insert did not write the note"
-  grep -qE 'could not be linked into Daily|Daily/ is unwritable' "$TMP/lockday.err" \
-    || fail "an unlinkable daily note was silent:"$'\n'"$(cat "$TMP/lockday.err")"
-  STRAY="$(find "$V/Daily" -maxdepth 1 -name '*ktmp*' | wc -l | tr -d ' ')"
+  grep -q 'Daily/ is unwritable; no session link' "$TMP/lockday.err" \
+    || fail "an unwritable Daily/ directory was silent or gave wrong warning:"$'\n'"$(cat "$TMP/lockday.err")"
+  STRAY="$(find "$V/Daily" -maxdepth 1 -name '.Daily-*' | wc -l | tr -d ' ')"
   [ "$STRAY" = "0" ] \
     || fail "$STRAY stray temp file(s) left in Daily/ after a failed session link"
 
@@ -334,6 +344,25 @@ else
     || fail "insert printed no path for a note it committed:"$'\n'"$(cat "$TMP/nodaily.out")"
   grep -q 'no session link' "$TMP/nodaily.err" \
     || fail "an uncreatable daily note was silent:"$'\n'"$(cat "$TMP/nodaily.err")"
+
+  # I11c: swap failure on an existing daily note warns specifically about linking.
+  FSWAP="$TMP/fault-swap"; mkdir -p "$FSWAP/lib"
+  cp "${ROOT_DIR}/scripts/keeper" "$FSWAP/"
+  cp "${ROOT_DIR}/scripts/lib/"* "$FSWAP/lib/"
+  cat >> "$FSWAP/lib/note-hash.sh" <<'EOF'
+keeper_swap_or_clean() { rm -f "$1" 2>/dev/null; return 1; }
+EOF
+  set +e
+  bash "$FSWAP/keeper" insert --vault "$V" --target "Notes/2026-07-01-swap-fail.md" \
+    --body-file "$TMP/note.md" --title "Swap Fail" --session-link-date 2026-07-01 \
+    >"$TMP/swapfail.out" 2>"$TMP/swapfail.err"
+  SWAPFAIL_RC=$?
+  set -e
+  [ "$SWAPFAIL_RC" = "0" ] || fail "swap failure must exit 0; rc=$SWAPFAIL_RC"
+  grep -q 'could not be linked into Daily/2026-07-01.md' "$TMP/swapfail.err" \
+    || fail "a swap failure did not report could not be linked into Daily:"$'\n'"$(cat "$TMP/swapfail.err")"
+  STRAY="$(find "$V/Daily" -maxdepth 1 -name '.Daily-*' | wc -l | tr -d ' ')"
+  [ "$STRAY" = "0" ] || fail "$STRAY stray temp file(s) left after failed swap"
 fi
 
 # I10b: the INDEX creation write is the third bare write after the note
@@ -358,6 +387,23 @@ else
   grep -q 'keeper: warning' "$TMP/blockidx.err" \
     || fail "an unusable INDEX.md was silent:"$'\n'"$(cat "$TMP/blockidx.err")"
   rmdir "$V/Blocked/INDEX.md" 2>/dev/null || true
+
+  # I10c: when vault_index_apply returns a non-zero rc, insert reports the rc suffix.
+  FIDX="$TMP/fault-idx"; mkdir -p "$FIDX/lib"
+  cp "${ROOT_DIR}/scripts/keeper" "$FIDX/"
+  cp "${ROOT_DIR}/scripts/lib/"* "$FIDX/lib/"
+  cat >> "$FIDX/lib/vault-index.sh" <<'EOF'
+vault_index_apply() { return 42; }
+EOF
+  set +e
+  bash "$FIDX/keeper" insert --vault "$V" --target "Notes/2026-06-29-rc-fail.md" \
+    --body-file "$TMP/note.md" --title "RC Fail" \
+    >"$TMP/rcfail.out" 2>"$TMP/rcfail.err"
+  RCFAIL_RC=$?
+  set -e
+  [ "$RCFAIL_RC" = "0" ] || fail "INDEX apply failure must exit 0; rc=$RCFAIL_RC"
+  grep -q '(INDEX step failed, rc=42)' "$TMP/rcfail.err" \
+    || fail "non-zero vault_index_apply rc was not reported:"$'\n'"$(cat "$TMP/rcfail.err")"
 fi
 
 # 14. zsh portability — both subcommands clean under zsh (insert sources the substrate libs)

--- a/tests/keeper-cli.sh
+++ b/tests/keeper-cli.sh
@@ -155,6 +155,24 @@ bash "$KEEPER" append --vault "$V" --target "Notes/fenced.md" \
 [ "$(cat "$V/Notes/fenced.md")" != "$FENCE_BEFORE" ] \
   || fail "a heading inside a code fence suppressed the commit's capture"
 
+# 17f. fence tracking must distinguish the delimiter TYPE. A single boolean
+#      toggled by both ``` and ~~~ mis-tracks a note that mixes them -- which is
+#      exactly what a doc illustrating the capture format looks like -- leaving
+#      an illustrative heading readable as a real capture. The consequence is a
+#      false "already captured": insert exits 0, nothing is written, and there
+#      is no retry, so the commit is lost. 17e above covers only the balanced
+#      ``` case, which is why this survived.
+printf '%s\n' '```markdown' 'an example, shown as text:' '~~~' \
+  '## deadbee — illustrative only, not a real capture' '~~~' '```' \
+  > "$TMP/mixed.md"
+bash "$KEEPER" append --vault "$V" --target "Notes/mixed.md" \
+  --section '## 18:00 — init' --body-file "$TMP/mixed.md" >/dev/null
+MIXED_BEFORE="$(cat "$V/Notes/mixed.md")"
+bash "$KEEPER" append --vault "$V" --target "Notes/mixed.md" \
+  --section '## deadbee — real commit' --body-file "$TMP/b.md" --skip-if-hash deadbee >/dev/null
+[ "$(cat "$V/Notes/mixed.md")" != "$MIXED_BEFORE" ] \
+  || fail 'a heading inside mixed backtick/tilde fences was read as a real capture; the commit was silently dropped'
+
 # 18. a malformed --skip-if-hash fails loudly. Silently treating an unusable
 #     value as "no guard" turns a typo into a duplicate note, which is the
 #     failure this flag exists to prevent.

--- a/tests/keeper-lease.sh
+++ b/tests/keeper-lease.sh
@@ -88,4 +88,22 @@ grep -q "QUARANTINE"$'\t'"_vaultkeeper.sync-conflict" <<<"$OUT3" || fail "_vault
 [ "$(find "$V3/.vaultkeeper-quarantine" -name '*_vaultkeeper.sync-conflict*' 2>/dev/null | wc -l | tr -d ' ')" = "1" ] \
   || fail "_vaultkeeper .base conflict not preserved in quarantine"
 
+# keeper_live_hosts under zsh, against a claim dir holding zero claims. Same
+# defect keeper_vault_health carried: an unquoted glob aborts under zsh NOMATCH,
+# and `for ... in <glob>` is not exempt. keeper_elect calls this, so an empty
+# claim dir takes out election too. These libs are documented bash+zsh clean.
+if command -v zsh >/dev/null 2>&1; then
+  EMPTY_L="$TMP/zsh-empty-lease"; mkdir -p "$EMPTY_L"
+  set +e
+  ZLOUT="$(zsh -c ". '$ROOT_DIR/scripts/lib/note-hash.sh'; . '$ROOT_DIR/scripts/lib/keeper-lease.sh'; keeper_live_hosts '$EMPTY_L' 900" 2>"$TMP/zlh.err")"
+  ZLRC=$?
+  set -e
+  [ "$ZLRC" = "0" ] \
+    || fail "keeper_live_hosts aborted under zsh on a claim dir with no claims; rc=$ZLRC: $(cat "$TMP/zlh.err")"
+  [ -z "$ZLOUT" ] \
+    || fail "keeper_live_hosts should list nothing with no claims, printed: $ZLOUT"
+  grep -q 'no matches found' "$TMP/zlh.err" \
+    && fail "keeper_live_hosts still trips zsh NOMATCH on the claim glob"
+fi
+
 echo "PASS: keeper-lease"

--- a/tests/keeper-state.sh
+++ b/tests/keeper-state.sh
@@ -232,4 +232,25 @@ case "$UNATTR_OUT" in
   *owner:*) fail "unattributed keeper_vault_health unexpectedly included owner suffix: $UNATTR_OUT" ;;
 esac
 
+# keeper_vault_health under zsh, with a lease dir holding zero claims. This is
+# the arm the glob rewrite needed and did not have: the UNATTR_V arm above runs
+# under bash, where an unmatched glob stays a literal and [ -e ] is simply
+# false, so it passes with the fix fully reverted. zsh's NOMATCH aborts instead,
+# and it applies to `for ... in <glob>` exactly as to any other expansion --
+# which is why swapping `set --` for a `for` loop did not fix anything. The
+# function must stay quiet on a vault nobody has pointed the keeper at.
+if command -v zsh >/dev/null 2>&1; then
+  EMPTY_V="$TMP/zsh-empty-vault"; mkdir -p "$EMPTY_V/.vaultkeeper"
+  set +e
+  ZOUT="$(zsh -c ". '$ROOT_DIR/scripts/lib/keeper-state.sh'; keeper_vault_health '$EMPTY_V' 900" 2>"$TMP/zvh.err")"
+  ZRC=$?
+  set -e
+  [ "$ZRC" = "0" ] \
+    || fail "keeper_vault_health aborted under zsh on a lease dir with no claims; rc=$ZRC: $(cat "$TMP/zvh.err")"
+  [ -z "$ZOUT" ] \
+    || fail "keeper_vault_health should stay quiet with no claims, printed: $ZOUT"
+  grep -q 'no matches found' "$TMP/zvh.err" \
+    && fail "keeper_vault_health still trips zsh NOMATCH on the claim glob"
+fi
+
 echo "PASS: keeper-state"

--- a/tests/keeper-state.sh
+++ b/tests/keeper-state.sh
@@ -218,4 +218,18 @@ keeper_record_scan "$DEF"
 [ -z "$(staleness_banner "$DEF" 900 "ml-1,mbp")" ] \
   || fail "a host with a fresh local scan was overruled by the vault digest"
 
+# When keeper-lease.sh is not sourced (keeper_elect not in scope), keeper_vault_health
+# still reports the health state without attributing the owner name.
+UNATTR_V="$TMP/unattr-vault"; mkdir -p "$UNATTR_V"
+keeper_claim_write "$UNATTR_V/.vaultkeeper" "ml-1"
+printf '# Librarian\n\nlast_scan: %s\nscan_status: INCOMPLETE\n' "$(now_epoch)" > "$UNATTR_V/Librarian.md"
+UNATTR_OUT="$(bash -c ". '$ROOT_DIR/scripts/lib/keeper-state.sh'; keeper_vault_health '$UNATTR_V' 900")"
+case "$UNATTR_OUT" in
+  *"last index scan faulted"*) : ;;
+  *) fail "unattributed keeper_vault_health failed to report faulted scan: ${UNATTR_OUT:-<empty>}" ;;
+esac
+case "$UNATTR_OUT" in
+  *owner:*) fail "unattributed keeper_vault_health unexpectedly included owner suffix: $UNATTR_OUT" ;;
+esac
+
 echo "PASS: keeper-state"

--- a/tests/resolve-config.sh
+++ b/tests/resolve-config.sh
@@ -106,10 +106,11 @@ set +e; obsidian_config_value prose_only_key >/dev/null; RC=$?; set -e
   || fail "case7: a '#' inside the value was treated as a comment: '$(obsidian_config_value hashy)'"
 [ "$(obsidian_config_value quoted_comment)" = "0.3" ] \
   || fail "case7: a quoted scalar with a trailing comment: '$(obsidian_config_value quoted_comment)'"
-# A config with no frontmatter at all still reads, rather than going silent.
+# A config with no frontmatter markers at all must not scan arbitrary prose body.
 printf 'vault_path: /nofm\n' > "$CV"
-[ "$(obsidian_config_value vault_path)" = "/nofm" ] \
-  || fail "case7: a config without frontmatter markers read as empty"
+set +e; obsidian_config_value vault_path >/dev/null; RC=$?; set -e
+[ "$RC" -eq 1 ] \
+  || fail "case7: a config without opening frontmatter marker unexpectedly resolved: '$(obsidian_config_value vault_path)'"
 unset OBSIDIAN_LOCAL_MD
 PASS_COUNT=$((PASS_COUNT + 1))
 

--- a/tests/vaultkeeper-tick.sh
+++ b/tests/vaultkeeper-tick.sh
@@ -206,9 +206,13 @@ done
 FDCFG="$TMP/fdtick.local.md"; sed "s|^vault_path: .*|vault_path: $FDV|" "$CFG" > "$FDCFG"
 
 # 1. Shipped code, 64 fds: the tick completes and records the scan.
+# Uses /bin/bash when available (macOS system bash 3.2, where process substitution
+# in loops exhausted fds; under bash 5 it survives lower limits too).
+_FDBASH="/bin/bash"
+[ -x "$_FDBASH" ] || _FDBASH="bash"
 FD1="$TMP/fdtick-fixed.out"
 ( ulimit -n 64; OBSIDIAN_LOCAL_MD="$FDCFG" VAULTKEEPER_HOST="ml-1" \
-    bash "${ROOT_DIR}/scripts/vaultkeeper-tick.sh" >"$FD1" 2>&1 ) \
+    "$_FDBASH" "${ROOT_DIR}/scripts/vaultkeeper-tick.sh" >"$FD1" 2>&1 ) \
   || fail "the tick failed under ulimit -n 64; got: $(cat "$FD1")"
 grep -q 'scan complete' "$FD1" \
   || fail "the tick did not complete under ulimit -n 64; got: $(cat "$FD1")"
@@ -234,7 +238,7 @@ FDV2="$TMP/fdtickvault2"; cp -R "$FDV" "$FDV2"; rm -f "$FDV2/Librarian.md" "$FDV
 FDCFG2="$TMP/fdtick2.local.md"; sed "s|^vault_path: .*|vault_path: $FDV2|" "$CFG" > "$FDCFG2"
 FD2="$TMP/fdtick-old.out"
 ( ulimit -n 64; OBSIDIAN_LOCAL_MD="$FDCFG2" VAULTKEEPER_HOST="ml-1" \
-    bash "$FDS/vaultkeeper-tick.sh" >"$FD2" 2>&1 ) \
+    "$_FDBASH" "$FDS/vaultkeeper-tick.sh" >"$FD2" 2>&1 ) \
   || fail "the reverted-scanner tick aborted rather than reporting; got: $(cat "$FD2")"
 grep -q 'scan INCOMPLETE' "$FD2" \
   || fail "the pre-#49 scanner exhausted fds and the tick still called the scan complete — the gate does not see it: $(cat "$FD2")"


### PR DESCRIPTION
Resolves #108 and #109.

## #108 — Clean checkout test failures
- `tests/commit-capture-head-gate.sh`: Bare fixture repos (`UP`, `UP2`) now explicitly set `symbolic-ref HEAD refs/heads/main`, ensuring that `git clone` checks out `main` regardless of host `init.defaultBranch` (such as `master`).
- `tests/vaultkeeper-tick.sh`: Directs the fd limit test arm to `/bin/bash` when available (macOS system bash 3.2), deterministically reproducing the process-substitution fd exhaustion in loops under `ulimit -n 64`.

## #109 — Substrate polish and coverage
- `scripts/lib/keeper-state.sh`: Replaced `set -- "$lease"/.keeper-claim-*` with a safe existence loop in `keeper_vault_health` for zsh empty glob compatibility.
- `scripts/lib/resolve-config.sh`: Required line 1 to be `---` (opening frontmatter delimiter) in `obsidian_config_value`, preventing scans into arbitrary non-frontmatter markdown bodies.
- `scripts/keeper`: Added markdown code fence tracking (`^``` ` and `^~~~`) in `keeper_heading_has_sha` so heading-shaped lines in code blocks do not trigger `--skip-if-hash`.
- `scripts/keeper`: Renamed staged temp file in daily notes to `.Daily-XXXXXX` matching sibling naming.
- `packages/codex/skills/commit-capture/`: Synchronized package twin scripts in tandem.
- `tests/ask-staleness.sh`: Replaced grep-by-inspection with runtime execution test for `staleness_banner` failure fallback.
- `tests/keeper-cli.sh`: Sharpened Test I11 to distinguish mktemp failure from swap failure; added Test I11c for daily swap failure and Test I10c for `vault_index_apply` non-zero rc reporting; added Test 17e for fence tracking.
- `tests/dedup-scan.sh`: Added boundary tests for `dedup_threshold_valid` (`>1`, negative, and leading-dot `.5`).
- `tests/keeper-state.sh`: Added test arm for `keeper_vault_health` without `keeper_elect` in scope.
- `tests/resolve-config.sh`: Updated Case 7 to verify non-frontmatter files are not scanned.